### PR TITLE
Simplify Parquet schema

### DIFF
--- a/src/import_atp.rs
+++ b/src/import_atp.rs
@@ -102,8 +102,7 @@ fn make_place(geojson: &str) -> Option<Place> {
     };
     let properties = feature.properties?;
 
-    let mut source_id: Option<String> = None;
-    let mut source_url: Option<String> = None;
+    let mut source: Option<String> = None;
 
     // We strip three properties ("nsi_id", "@spider", "@source_uri") from tags,
     // so we do not need to reserve space for them.
@@ -132,12 +131,7 @@ fn make_place(geojson: &str) -> Option<Place> {
 
         if key == "@spider" {
             value.insert_str(0, "atp/");
-            source_id = Some(value);
-            continue;
-        }
-
-        if key == "@source_uri" {
-            source_url = Some(value);
+            source = Some(value);
             continue;
         }
 
@@ -147,7 +141,7 @@ fn make_place(geojson: &str) -> Option<Place> {
 
         tags.push((key, value));
     }
-    Place::new(&point, source_id?, source_url, tags)
+    Place::new(&point, source?, tags)
 }
 
 /// Finds a representative point for a GeoJson feature.
@@ -273,10 +267,7 @@ mod tests {
     #[test]
     fn test_make_place() {
         let place = super::make_place(PLAYGROUND).unwrap();
-        assert_eq!(place.lon_e7, 8_7339982);
-        assert_eq!(place.lat_e7, 47_5039168);
-        assert_eq!(place.source_id, "atp/winterthur_ch");
-        assert_eq!(place.source_url, None);
+        assert_eq!(place.source, "atp/winterthur_ch");
         assert_eq!(
             tags(&place),
             [
@@ -292,14 +283,7 @@ mod tests {
     #[test]
     fn test_make_place_for_line_string() {
         let place = super::make_place(BICYCLE_ROAD).unwrap();
-        assert_eq!(place.lon_e7, 7_4593195);
-        assert_eq!(place.lat_e7, 46_9423753);
-        assert_eq!(place.source_id, "atp/bern_ch");
-        let source_url = place.source_url.clone().unwrap();
-        assert_eq!(
-            source_url,
-            "https://map.bern.ch/ogd/poi_velo/poi_velo_json.zip"
-        );
+        assert_eq!(place.source, "atp/bern_ch");
         assert_eq!(
             tags(&place),
             [("bicycle_road", "yes"), ("highway", "residential"),]

--- a/src/place/mod.rs
+++ b/src/place/mod.rs
@@ -1,63 +1,30 @@
 use deepsize::DeepSizeOf;
 use geo_types::Point;
 use serde::{Deserialize, Serialize};
-use std::cmp::Ordering;
 
 mod writer;
 pub use writer::ParquetWriter;
 
-#[derive(Debug, DeepSizeOf, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, DeepSizeOf, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
 pub struct Place {
     pub s2_cell_id: u64,
-    pub lon_e7: i32,
-    pub lat_e7: i32,
-    pub source_id: String,
-    pub source_url: Option<String>,
+    pub source: String,
     pub tags: Vec<(String, String)>,
 }
 
 impl Place {
-    pub fn new(
-        point: &Point,
-        source_id: String,
-        source_url: Option<String>,
-        tags: Vec<(String, String)>,
-    ) -> Option<Place> {
+    pub fn new(point: &Point, source: String, tags: Vec<(String, String)>) -> Option<Place> {
         let s2_lat_lng = s2::latlng::LatLng::from_degrees(point.y(), point.x());
         if !s2_lat_lng.is_valid() {
             return None;
         }
 
         let s2_cell_id = s2::cellid::CellID::from(s2_lat_lng).0;
-        let lon_e7 = (point.x() * 1e7) as i32;
-        let lat_e7 = (point.y() * 1e7) as i32;
         Some(Place {
             s2_cell_id,
-            lon_e7,
-            lat_e7,
-            source_id,
-            source_url,
+            source,
             tags,
         })
-    }
-}
-
-impl Ord for Place {
-    fn cmp(&self, other: &Self) -> Ordering {
-        // Because s2_cell_id is a projection of the geographic longitude
-        // and latitude at centimeter resolution, we do not need to compare
-        // lng_e7 and lat_e7.
-        self.s2_cell_id
-            .cmp(&other.s2_cell_id)
-            .then(self.source_id.cmp(&other.source_id))
-            .then(self.source_url.cmp(&other.source_url))
-            .then(self.tags.cmp(&other.tags))
-    }
-}
-
-impl PartialOrd for Place {
-    fn partial_cmp(&self, other: &Place) -> Option<Ordering> {
-        Some(self.cmp(other))
     }
 }
 
@@ -69,19 +36,14 @@ mod tests {
     #[test]
     fn test_new() {
         let p = Point::new(7.447_812_3, 46.947_980_1);
-        let source_id = "test/source_id".to_string();
-        let source_url = Some("https://example.org/zytglogge".to_string());
+        let source = "test/source".to_string();
         let tags = vec![
             ("building".to_string(), "tower".to_string()),
             ("name:gsw".to_string(), "Zytglogge".to_string()),
         ];
-        let place = Place::new(&p, source_id, source_url, tags.clone()).unwrap();
-        let place_source_url = place.source_url.unwrap();
+        let place = Place::new(&p, source, tags.clone()).unwrap();
         assert_eq!(place.s2_cell_id, 5156122125915201443);
-        assert_eq!(place.lon_e7, 7_447_812_3);
-        assert_eq!(place.lat_e7, 46_947_980_1);
-        assert_eq!(place.source_id, "test/source_id");
-        assert_eq!(place_source_url, "https://example.org/zytglogge");
+        assert_eq!(place.source, "test/source");
         assert_eq!(place.tags, tags);
     }
 
@@ -89,15 +51,13 @@ mod tests {
     fn test_cmp() {
         let a = Place::new(
             &Point::new(7.4478123, 46.9479801),
-            "test/source_id".to_string(),
-            None,
+            "test/source".to_string(),
             vec![],
         )
         .unwrap();
         let b = Place::new(
             &Point::new(-122.4630042, 37.8045878),
-            "test/source_id".to_string(),
-            None,
+            "test/source".to_string(),
             vec![],
         )
         .unwrap();


### PR DESCRIPTION
We can easily and very efficiently compute `longitude` and `latitude` from S2 cell ids. Actually, we won’t even need to do this: the S2 library has a fast approximation for the distance between two S2Points. For our matching purposes, this approximation is accurate enough.

The `source_url` property does not contain much useful information, so we drop it. For debugging, we can always check out the ATP site. Also, the URLs are often machine-readable files, typically JSON or ZIP files, so the property is not actually suitable to be displayed to human editors in a future web front-end.

For [ATP 2026-01-03](https://alltheplaces-data.openaddresses.io/runs/2026-01-03-13-32-38/output.zip), this change reduces the size of the generated Parquet file from 629.9 MB to 453.7 MB.