### PR TITLE
Build coverage file

### DIFF
--- a/src/coverage.rs
+++ b/src/coverage.rs
@@ -11,8 +11,9 @@ use s2::{
     region::RegionCoverer,
     s1::{Angle, ChordAngle},
 };
-use std::fs::File;
-use std::path::Path;
+use std::fs::{File, remove_file};
+use std::io::{BufReader, BufWriter, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
 use std::sync::mpsc::{Receiver, SyncSender, sync_channel};
 
 /// Computes the spatial coverage of a set of places.
@@ -22,7 +23,7 @@ pub fn build_coverage(places: &Path, output: &Path) -> Result<()> {
     let (tx, rx) = sync_channel(50_000);
     std::thread::scope(|s| {
         let producer = s.spawn(|| read_places(places, tx));
-        let consumer = s.spawn(|| process_coverings(rx, output));
+        let consumer = s.spawn(|| build_spatial_coverage(rx, output));
         producer.join().unwrap().and(consumer.join().unwrap())
     })
 }
@@ -126,23 +127,157 @@ fn meters_to_chord_angle(radius_meters: f64) -> ChordAngle {
 }
 
 /// Builds a spatial coverage file from a stream of s2::CellIDs.
-fn process_coverings(cells: Receiver<CellID>, _out: &Path) -> Result<()> {
-    // let mut writer = bitmaps::Writer::try_new(out)?;
+fn build_spatial_coverage(cells: Receiver<CellID>, out: &Path) -> Result<()> {
+    let mut writer = CoverageWriter::try_new(out)?;
     let sorter: ExternalSorter<CellID, std::io::Error, LimitedBufferBuilder> =
         ExternalSorterBuilder::new()
             .with_tmp_dir(Path::new("./"))
             .with_buffer(LimitedBufferBuilder::new(
-                10_000_000, /* preallocate */ true,
+                1_000_000, /* preallocate */ true,
             ))
             .build()?;
     let sorted = sorter.sort(cells.iter().map(std::io::Result::Ok))?;
     for cur in sorted {
-        let _shifted = cur?.0 >> S2_CELL_ID_SHIFT;
-        // num_cells: 153903929 num_chunks: 421598 num_bitmaps: 384
-        // writer.write(cur?);
+        writer.write(cur?.0 >> S2_CELL_ID_SHIFT)?;
     }
-    // writer.close()?;
+    writer.close()?;
     Ok(())
+}
+
+struct CoverageWriter {
+    writer: BufWriter<File>,
+    run_starts_pos: u64, // offset of run_starts array relative to start of file
+
+    run_lengths_path: PathBuf,
+    run_lengths_writer: BufWriter<File>,
+
+    num_values: u64,
+    num_runs: u64,
+    run_start: Option<u64>,
+    run_length_minus_1: u8,
+}
+
+impl CoverageWriter {
+    const NUM_HEADERS: usize = 2;
+
+    fn try_new(path: &Path) -> Result<CoverageWriter> {
+        let file = File::create(path)?;
+        let mut writer = BufWriter::with_capacity(32768, file);
+
+        // Write file header.
+        writer.write_all(b"diffed-places coverage\0\0")?;
+        writer.write_all(&(Self::NUM_HEADERS as u64).to_le_bytes())?;
+        writer.write_all(&[0; 24 * Self::NUM_HEADERS])?; // leave space for headers
+
+        let run_starts_pos = writer.stream_position()?;
+        let run_lengths_path = path.with_extension("tmp_run_lengths");
+        let run_lengths_file = File::create(&run_lengths_path)?;
+        let run_lengths_writer = BufWriter::with_capacity(32768, run_lengths_file);
+
+        Ok(CoverageWriter {
+            writer,
+            run_starts_pos,
+            run_lengths_path,
+            run_lengths_writer,
+            num_values: 0,
+            num_runs: 0,
+            run_start: None,
+            run_length_minus_1: 0,
+        })
+    }
+
+    fn write(&mut self, value: u64) -> Result<()> {
+        let Some(run_start) = self.run_start else {
+            self.num_values = 1;
+            self.num_runs = 1;
+            self.run_start = Some(value);
+            self.run_length_minus_1 = 0;
+            return Ok(());
+        };
+
+        let run_end: u64 = run_start + (self.run_length_minus_1 as u64);
+        assert!(
+            value >= run_end,
+            "values not written in sort order: {} after {}",
+            value,
+            run_end
+        );
+
+        if value == run_end {
+            // If we write the same value twice, we don’t need to do anything.
+            return Ok(());
+        } else if value == run_end + 1 && self.run_length_minus_1 < 0xff {
+            // Extending the length of the current run, if there’s still
+            // enough space to hold the new length in the available 8 bits.
+            self.run_length_minus_1 += 1;
+            self.num_values += 1;
+            return Ok(());
+        }
+
+        // Start a new run with the current value.
+        self.finish_run()?;
+        self.run_start = Some(value);
+        self.run_length_minus_1 = 0;
+        self.num_values += 1;
+        Ok(())
+    }
+
+    fn close(mut self) -> Result<()> {
+        self.finish_run()?;
+        self.writer.flush()?;
+
+        // Add the run lengths, which are at this point in time in a temporary file,
+        // to end end of the main file.
+        let run_lengths_pos = self.writer.stream_position()?;
+        self.run_lengths_writer.flush()?;
+        self.run_lengths_writer.seek(SeekFrom::Start(0))?;
+
+        let run_lengths_path: &Path = self.run_lengths_path.as_path();
+        let mut reader = BufReader::new(File::open(run_lengths_path)?);
+        std::io::copy(&mut reader, &mut self.writer)?;
+        remove_file(run_lengths_path)?;
+
+        // todo: add runs at end of file
+        self.write_headers(&[
+            ("runstart", self.run_starts_pos, self.num_runs * 8),
+            ("runlengt", run_lengths_pos, self.num_runs),
+        ])?;
+
+        println!(
+            "got num_values={} num_runs={}",
+            self.num_values, self.num_runs
+        );
+        Ok(())
+    }
+
+    fn write_headers(&mut self, headers: &[(&str, u64, u64)]) -> Result<()> {
+        self.writer.seek(SeekFrom::Start(32))?;
+        assert_eq!(headers.len(), Self::NUM_HEADERS);
+        for (id, pos, len) in headers {
+            assert_eq!(
+                id.len(),
+                8,
+                "header id must be 8 chars long but \"{:?}\" is not",
+                id
+            );
+            self.writer.write_all(id.as_bytes())?;
+            self.writer.write_all(&pos.to_le_bytes())?;
+            self.writer.write_all(&len.to_le_bytes())?;
+        }
+        self.writer.flush()?;
+        Ok(())
+    }
+
+    fn finish_run(&mut self) -> Result<()> {
+        let Some(run_start) = self.run_start else {
+            return Ok(());
+        };
+        self.writer.write_all(&run_start.to_le_bytes())?;
+        self.run_lengths_writer
+            .write_all(&[self.run_length_minus_1])?;
+        self.num_runs += 1;
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,8 +30,8 @@ enum Commands {
         #[arg(short, long, value_name = "alltheplaces.parquet")]
         places: PathBuf,
 
-        #[arg(short, long, value_name = "spatial-coverage")]
-        out_spatial_coverage: PathBuf,
+        #[arg(short, long, value_name = "coverage")]
+        output: PathBuf,
     },
 }
 
@@ -41,11 +41,8 @@ fn main() -> Result<()> {
         Some(Commands::ImportAtp { input, output }) => {
             import_atp(input, output)?;
         }
-        Some(Commands::BuildCoverage {
-            places,
-            out_spatial_coverage,
-        }) => {
-            build_coverage(places, out_spatial_coverage)?;
+        Some(Commands::BuildCoverage { places, output }) => {
+            build_coverage(places, output)?;
         }
         None => {
             eprintln!("no subcommand given");


### PR DESCRIPTION
On a 2018 MacBook Pro with 6 Intel CPU cores, it takes 101.5 seconds with a peak memory footprint of 71 MiBytes to compute the spatial coverage of the global All The Places dataset of 2026-01-03. The input is read from a 450.5 MiB file in Parquet format, as produced by the import-atp phase of our pipeline. Note that these numbers are better than before, when we did less work than now. This is due to tuning the sort buffer size.