### PR TITLE
CI: Explicitly pull base image for the current platform

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -49,10 +49,8 @@ jobs:
 
       - name: Build image
         run: |
-          podman image pull rust:1.92.0-alpine3.23
+          podman image pull rust:1.92.0-alpine3.23 --platform ${{ matrix.platform }}
           podman image inspect rust:1.92.0-alpine3.23 | grep Architecture
-          podman image pull rust:1.92.0-alpine3.20 --platform ${{ matrix.platform }}
-          podman image inspect rust:1.92.0-alpine3.20 | grep Architecture
           podman build \
             --platform ${{ matrix.platform }} \
             --build-arg BUILD_TIMESTAMP="${{ steps.commit.outputs.timestamp }}" \


### PR DESCRIPTION
Apparently, podman defaults to x86 even when running on ARM. https://github.com/brawer/diffed-places/issues/27