### PR TITLE
CI: Squash container layers

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -55,6 +55,7 @@ jobs:
             --build-arg BUILD_TIMESTAMP="${{ steps.commit.outputs.timestamp }}" \
             --build-arg VCS_REF="${{ github.sha }}" \
             --build-arg VCS_URL="${{ github.server_url }}/${{ github.repository }}" \
+            --squash \
             -f ./Containerfile \
             -t $IMAGE \
             .


### PR DESCRIPTION
We’re not losing any history because we’re based on a scratch container. Nobody cares about the details how we copied our build artifacts from the build stage into the final container image.