### PR TITLE
CI: Do not specify compression for containers

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -56,8 +56,6 @@ jobs:
             --build-arg BUILD_TIMESTAMP="${TIMESTAMP}" \
             --build-arg VCS_REF="${{ github.sha }}" \
             --build-arg VCS_URL="${{ github.server_url }}/${{ github.repository }}" \
-            --compression-format=zstd \
-            --compression-level=20 \
             --file ./Containerfile \
             --platform ${{ matrix.platform }} \
             --squash \


### PR DESCRIPTION
Apparently, the version of podman on GitHub runners is too old to pass this option.