### PR TITLE
Remove versioning strategy for cargo in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,6 @@ version: 2
 updates:
   - package-ecosystem: "cargo"
     directory: "/"
-    versioning-strategy: "increase"
     schedule:
       interval: "daily"
   - package-ecosystem: "docker"


### PR DESCRIPTION
GitHub’s documentation seems to be out of date. Current Dependabot fails with this error message:

```
The property '#/updates/0/versioning-strategy' value "increase" did not match one of the following values: lockfile-only, auto
```