### PR TITLE
CI: Restrict workflow permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/diffed-places/diffed-places-pipeline/security/code-scanning/1](https://github.com/diffed-places/diffed-places-pipeline/security/code-scanning/1)

In general, to fix this class of issue you add a `permissions:` block to the workflow or to each job to explicitly define the minimal scopes the `GITHUB_TOKEN` should have. For a test/build workflow that only needs to read the repository contents, `contents: read` is usually sufficient.

For this specific workflow, the simplest non‑breaking fix is to add a root‑level `permissions:` block just under the `name:` (or immediately after the `on:` block) that sets `contents: read`. This will apply to all jobs that don’t define their own `permissions:`. None of the steps in the `build` job require write access (they only check out code and run `cargo` commands locally), so this change does not affect existing functionality.

Concretely, in `.github/workflows/test.yml`, insert:

```yaml
permissions:
  contents: read
```

near the top of the file (e.g., after line 2 or after the `on:` block). No additional imports or methods are needed; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
