### PR TITLE
Construct look-up table of OSM nodes in coverage area

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -35,8 +35,8 @@ enum Commands {
         #[arg(long, value_name = "coverage")]
         coverage: PathBuf,
 
-        #[arg(short, long, value_name = "openstreetmap.parquet")]
-        output: PathBuf,
+        #[arg(short, long, value_name = "workdir")]
+        workdir: PathBuf,
     },
 }
 
@@ -48,8 +48,8 @@ fn main() -> Result<()> {
         Some(Commands::ImportOsm {
             osm,
             coverage,
-            output,
-        }) => import_osm(osm, coverage, output),
+            workdir,
+        }) => import_osm(osm, coverage, workdir),
         None => Err(anyhow!("no subcommand given")),
     }
 }


### PR DESCRIPTION
On a 2018 MacBook Pro with 6 Intel CPUs, it takes 93.9 seconds and 159.4 MB peak memory to identify and sort the 14347539 nodes in the 2026-01-19 OpenStreetMap planet dump that are located within the coverage area of the 2026-01-03 AllThePlaces dump. The resulting `covered-nodes` file is 114.8 MB in size.