### PR TITLE
Improve PlaceIndex to avoid redundant work

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,6 +884,7 @@ dependencies = [
  "lru",
  "memmap2",
  "mockito",
+ "once_cell",
  "osm_pbf_iter",
  "parquet",
  "piz",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ librqbit = { version = "8.1.1", default-features = false, features = ["disable-u
 log = { version = "0.4.29", default-features = false }
 lru = { version = "0.18.0", default-features = false }
 memmap2 = "0.9.10"
+once_cell = "1.21.4"
 osm_pbf_iter = { version = "0.2.2", default-features = false }
 parquet = { version = "58.3.0", default-features = false, features = ["arrow", "zstd"] }
 piz = "0.5.1"

--- a/src/diff_places.rs
+++ b/src/diff_places.rs
@@ -3,7 +3,6 @@ use crate::s2_util::MergedCellRanges;
 use crate::{make_progress_bar, match_distance};
 use anyhow::Result;
 use indicatif::MultiProgress;
-use rayon::prelude::*;
 use s2::{cap::Cap, cell::Cell, cellid::CellID, region::RegionCoverer};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -38,59 +37,43 @@ pub fn diff_places(
     let num_atp_features = AtomicU64::new(0);
     let num_candidates = AtomicU64::new(0);
 
-    // TODO: Use this to parallelize, once we have the matching logic in place.
-    let _ = atp_places.scan().par_bridge(); // .try_for_each(|place| {}
-
     let region = CellID::from_token("479ab6e4"); // Rapperswil SG, Switzerland
-    atp_places
-        .query(
-            region.range_min()..=region.range_max(),
-            crate::MatchMask::SHOP,
-        )?
-        //.par_bridge()
-        .try_for_each(|place| {
-            let place = place?;
-            num_atp_features.fetch_add(1, Ordering::Relaxed);
-            println!(
-                "\n*** Find best match for AllThePlaces feature: {:?}",
-                place
-            );
-            let s2_cell = Cell::from(CellID(place.s2_cell_id));
-            let center = s2_cell.center();
-            let radius = match_distance(&place.mask);
-            let cap = Cap::from_center_chordangle(&center, &radius);
-            let covering = coverer.covering(&cap);
-            for (lo, hi) in MergedCellRanges::new(covering) {
-                for candidate in osm_places.query(lo..=hi, place.mask)? {
-                    let candidate = candidate?;
-                    num_candidates.fetch_add(1, Ordering::Relaxed);
-                    let candidate_center =
-                        s2::point::Point(CellID(candidate.s2_cell_id).raw_point().normalize());
-                    let distance =
-                        (center.distance(&candidate_center).rad() * 6_371_000.0 + 0.5) as i32;
-                    if let Some(score) = match_places(&place, &candidate, distance) {
-                        println!(
-                            "  - {:?} distance: {} meters, score: {}",
-                            candidate, distance, score
-                        );
-                    }
-                    // TODO: Compute match score between candidate and place.
-                }
+    let mut iter = atp_places.query(
+        region.range_min()..=region.range_max(),
+        crate::MatchMask::SHOP,
+    )?;
+    for place in &mut iter {
+        let place: &Place = place?;
+        num_atp_features.fetch_add(1, Ordering::Relaxed);
+        let s2_cell = Cell::from(CellID(place.s2_cell_id));
+        let center = s2_cell.center();
+        let radius = match_distance(&place.mask);
+        let cap = Cap::from_center_chordangle(&center, &radius);
+        let covering = coverer.covering(&cap);
+        for (lo, hi) in MergedCellRanges::new(covering) {
+            for candidate in &mut osm_places.query(lo..=hi, place.mask)? {
+                let candidate = candidate?;
+                num_candidates.fetch_add(1, Ordering::Relaxed);
+                let candidate_center =
+                    s2::point::Point(CellID(candidate.s2_cell_id).raw_point().normalize());
+                let _distance = center.distance(&candidate_center).rad() * 6_371_000.0;
             }
-            // progress_bar.inc(1);
-            Ok::<(), anyhow::Error>(())
-        })?;
+        }
+    }
 
-    progress_bar.finish_with_message(format!(
-        "{} atp features, {} osm candidates",
+    let cache_stats = osm_places.cache_stats();
+    progress_bar.finish();
+    println!(
+        "  features: {} candidates: {}",
         num_atp_features.load(Ordering::SeqCst),
         num_candidates.load(Ordering::SeqCst)
-    ));
+    );
+    println!(
+        "  cache hits: {} misses: {} hit rate: {:.1}%",
+        cache_stats.hits,
+        cache_stats.misses,
+        cache_stats.hit_rate().unwrap_or(0.0) * 100.0
+    );
 
     Ok(out_path)
-}
-
-// TODO: Implement.
-fn match_places(_a: &Place, _b: &Place, _distance_meters: i32) -> Option<f64> {
-    Some(1.0)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@ fn make_download_bar(
     Clone, Copy, Debug, DeepSizeOf, Default, Deserialize, PartialEq, Eq, Ord, PartialOrd, Serialize,
 )]
 #[repr(transparent)]
-struct MatchMask(u16);
+pub struct MatchMask(u16);
 
 impl MatchMask {
     pub const SHOP: MatchMask = MatchMask(1 << 0);

--- a/src/places/place_index.rs
+++ b/src/places/place_index.rs
@@ -1,16 +1,46 @@
-use crate::{MatchMask, places::Place};
-use anyhow::Context;
 use arrow::array::{Array, MapArray, RecordBatch, StringArray, UInt16Array, UInt64Array};
 use arrow::compute::concat_batches;
 use lru::LruCache;
+
+// TODO: Replace OnceCell by OnceLock when https://github.com/rust-lang/rust/issues/109737 is done.
+use once_cell::sync::OnceCell;
+
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use parquet::file::statistics::Statistics;
+use rayon::prelude::*;
 use s2::cellid::CellID;
 use std::fs::File;
 use std::num::NonZeroUsize;
 use std::ops::RangeInclusive;
-use std::path::{Path, PathBuf};
+use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
+
+use crate::{MatchMask, places::Place};
+
+// ============================================================================
+// Cache hit/miss counters
+// ============================================================================
+
+/// Snapshot returned by `PlaceIndex::cache_stats()`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct CacheStats {
+    pub hits: u64,
+    pub misses: u64,
+}
+
+impl CacheStats {
+    /// Fraction of lookups served from cache. Returns `None` if no lookups
+    /// have been made yet (avoids division by zero).
+    pub fn hit_rate(&self) -> Option<f64> {
+        let total = self.hits + self.misses;
+        if total == 0 {
+            None
+        } else {
+            Some(self.hits as f64 / total as f64)
+        }
+    }
+}
 
 // ============================================================================
 // Row-group metadata — built once from Parquet file metadata, no row I/O
@@ -19,27 +49,37 @@ use std::sync::{Arc, Mutex};
 #[derive(Debug, Clone)]
 struct RowGroupInfo {
     index: usize,
-    row_start: usize, // absolute index of the first row in this group
+    row_start: usize,
     row_count: usize,
     s2_min: u64,
     s2_max: u64,
 }
 
 // ============================================================================
+// Cache design  (see earlier comments for full explanation)
+//
+// LRU maps  rg_index → Arc<OnceCell<Arc<Vec<Place>>>>
+// ============================================================================
+
+// TODO: Replace OnceCell by OnceLock after the try_ methods are stable.
+// https://github.com/rust-lang/rust/issues/109737
+type CacheSlot = OnceCell<Arc<Vec<Place>>>;
+
+// ============================================================================
 // Index
 // ============================================================================
 
 pub struct PlaceIndex {
-    file_path: PathBuf,
-    /// One entry per row group, sorted by row_start (== sorted by s2_cell_id).
+    file_path: Box<Path>,
     groups: Vec<RowGroupInfo>,
-    /// LRU cache: row_group_index → decoded RecordBatch (all columns).
-    cache: Mutex<LruCache<usize, Arc<RecordBatch>>>,
+    cache: Mutex<LruCache<usize, Arc<CacheSlot>>>,
+    cache_hits: AtomicU64,
+    cache_misses: AtomicU64,
 }
 
 impl PlaceIndex {
     /// Open the file and build the in-memory index from Parquet metadata.
-    /// `cache_row_groups` controls how many decoded row groups are kept in RAM.
+    /// `cache_row_groups` is the maximum number of decoded groups kept in RAM.
     pub fn open(path: &Path, cache_row_groups: usize) -> anyhow::Result<Arc<Self>> {
         let file = File::open(path)?;
         let builder = ParquetRecordBatchReaderBuilder::try_new(file)?;
@@ -70,15 +110,16 @@ impl PlaceIndex {
         }
 
         Ok(Arc::new(Self {
-            file_path: PathBuf::from(path),
+            file_path: path.into(),
             groups,
             cache: Mutex::new(LruCache::new(
                 NonZeroUsize::new(cache_row_groups).expect("cache_row_groups must be > 0"),
             )),
+            cache_hits: AtomicU64::new(0),
+            cache_misses: AtomicU64::new(0),
         }))
     }
 
-    /// Total number of rows across all row groups.
     pub fn total_rows(&self) -> usize {
         self.groups
             .last()
@@ -86,45 +127,36 @@ impl PlaceIndex {
             .unwrap_or(0)
     }
 
+    /// Returns a snapshot of cumulative cache hit and miss counts.
+    pub fn cache_stats(&self) -> CacheStats {
+        CacheStats {
+            hits: self.cache_hits.load(Ordering::Relaxed),
+            misses: self.cache_misses.load(Ordering::Relaxed),
+        }
+    }
+
     // -----------------------------------------------------------------------
-    // Public query API
+    // Sequential API
     // -----------------------------------------------------------------------
 
-    /// Returns an iterator over all Places whose `s2_cell_id` falls within
-    /// `range` AND whose `(place.mask & query_mask) != 0`.
-    ///
-    /// Candidate row groups are identified from metadata alone (zero I/O).
-    /// Places are decoded lazily as the iterator is advanced.
+    /// Returns a sequential iterator over Places with `s2_cell_id ∈ range`
+    /// and `place.mask.intersects(&query_mask)`.
     pub fn query(
         &self,
         range: RangeInclusive<CellID>,
         query_mask: MatchMask,
     ) -> anyhow::Result<PlaceIter> {
-        let lo = *range.start();
-        let hi = *range.end();
-
-        let mut batches = Vec::new();
-        for group in self.prune_row_groups(lo, hi) {
-            let batch = self.load_row_group(group)?;
-            if let Some(sliced) = slice_by_s2_range(&batch, lo, hi)? {
-                // RecordBatch::slice is zero-copy: shifts offset+length on Arc buffers.
-                batches.push(Arc::new(sliced));
-            }
-        }
-
+        let (segments, query_mask) = self.build_segments(range, query_mask)?;
         Ok(PlaceIter {
-            batches,
-            batch_idx: 0,
+            segments,
+            seg_idx: 0,
             row_idx: 0,
             query_mask,
         })
     }
 
-    /// Returns an iterator over every row in the file in storage order.
-    ///
-    /// Row groups are loaded one at a time and bypass the LRU cache so that
-    /// a sequential scan does not evict row groups that concurrent range
-    /// queries are actively using.
+    /// Returns a sequential iterator over every Place in the file.
+    #[allow(unused)] // TODO: Remove attribute once we use it.
     pub fn scan(self: &Arc<Self>) -> FullScanIter {
         FullScanIter {
             index: Arc::clone(self),
@@ -134,42 +166,110 @@ impl PlaceIndex {
     }
 
     // -----------------------------------------------------------------------
-    // Row-group pruning (metadata only, zero I/O)
+    // Parallel API
     // -----------------------------------------------------------------------
 
-    fn prune_row_groups(&self, lo: CellID, hi: CellID) -> &[RowGroupInfo] {
-        // First group whose s2_max >= lo
-        let first = self.groups.partition_point(|g| g.s2_max < lo.0);
-        // First group whose s2_min > hi (one past the last candidate)
-        let last = self.groups.partition_point(|g| g.s2_min <= hi.0);
+    /// Parallel version of `query`. Each segment (row-group slice) is
+    /// processed independently by Rayon.
+    #[allow(unused)] // TODO: Remove attribute once we use it.
+    pub fn query_par(
+        &self,
+        range: RangeInclusive<CellID>,
+        query_mask: MatchMask,
+    ) -> anyhow::Result<ParPlaceIter> {
+        let (segments, query_mask) = self.build_segments(range, query_mask)?;
+        Ok(ParPlaceIter {
+            segments,
+            query_mask,
+        })
+    }
+
+    /// Parallel version of `scan`. Row groups are loaded concurrently
+    /// (each decoded once via the shared cache) and iterated in parallel.
+    #[allow(unused)] // TODO: Remove attribute once we use it.
+    pub fn scan_par(self: &Arc<Self>) -> ParPlaceIter {
+        let segments: Vec<Segment> = self
+            .groups
+            .iter()
+            .filter_map(|group| {
+                let places = self.load_row_group(group).ok()?;
+                let end = places.len();
+                Some((places, 0, end))
+            })
+            .collect();
+        ParPlaceIter {
+            segments,
+            query_mask: MatchMask(0xFFFF),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Shared segment-building logic used by both query() and query_par()
+    // -----------------------------------------------------------------------
+
+    fn build_segments(
+        &self,
+        range: RangeInclusive<CellID>,
+        query_mask: MatchMask,
+    ) -> anyhow::Result<(Vec<Segment>, MatchMask)> {
+        let lo = range.start().0;
+        let hi = range.end().0;
+
+        let mut segments: Vec<Segment> = Vec::new();
+        for group in self.prune_row_groups(lo, hi) {
+            let places = self.load_row_group(group)?;
+            let start = places.partition_point(|p| p.s2_cell_id < lo);
+            let end = places.partition_point(|p| p.s2_cell_id <= hi);
+            if start < end {
+                segments.push((places, start, end));
+            }
+        }
+        Ok((segments, query_mask))
+    }
+
+    // -----------------------------------------------------------------------
+    // Row-group pruning — metadata only, zero I/O
+    // -----------------------------------------------------------------------
+
+    fn prune_row_groups(&self, lo: u64, hi: u64) -> &[RowGroupInfo] {
+        let first = self.groups.partition_point(|g| g.s2_max < lo);
+        let last = self.groups.partition_point(|g| g.s2_min <= hi);
         &self.groups[first..last]
     }
 
     // -----------------------------------------------------------------------
-    // Row-group loading with LRU cache
+    // Two-phase cache load — LRU Mutex never held during I/O
     // -----------------------------------------------------------------------
 
-    fn load_row_group(&self, group: &RowGroupInfo) -> anyhow::Result<Arc<RecordBatch>> {
-        // Fast path — already cached.
-        {
+    fn load_row_group(&self, group: &RowGroupInfo) -> anyhow::Result<Arc<Vec<Place>>> {
+        // Phase 1: hold the LRU lock only long enough to get-or-insert a slot.
+        let slot: Arc<CacheSlot> = {
             let mut cache = self.cache.lock().unwrap();
-            if let Some(batch) = cache.get(&group.index) {
-                return Ok(Arc::clone(batch));
+            match cache.get(&group.index) {
+                Some(slot) => Arc::clone(slot),
+                None => {
+                    let slot = Arc::new(OnceCell::new());
+                    cache.put(group.index, Arc::clone(&slot));
+                    slot
+                }
             }
-        } // lock released before the slow disk read
+        }; // ← LRU lock released here
 
-        // Slow path — read from disk, then insert into cache.
-        // Two threads may race here and both read the same group; that's
-        // acceptable — put() is idempotent and simply refreshes the LRU position.
-        let batch = Arc::new(self.read_row_group_from_disk(group.index)?);
-        {
-            let mut cache = self.cache.lock().unwrap();
-            cache.put(group.index, Arc::clone(&batch));
+        // Phase 2: one thread runs the decoder; all others block until done.
+        // On a warm hit this is a single atomic load — no blocking at all.
+        let is_hit = slot.get().is_some();
+        slot.get_or_try_init(|| self.decode_row_group_from_disk(group.index))?;
+
+        if is_hit {
+            self.cache_hits.fetch_add(1, Ordering::Relaxed);
+        } else {
+            self.cache_misses.fetch_add(1, Ordering::Relaxed);
         }
-        Ok(batch)
+
+        Ok(Arc::clone(slot.get().unwrap()))
     }
 
-    pub(crate) fn read_row_group_from_disk(&self, rg_index: usize) -> anyhow::Result<RecordBatch> {
+    fn decode_row_group_from_disk(&self, rg_index: usize) -> anyhow::Result<Arc<Vec<Place>>> {
         let file = File::open(&self.file_path)?;
         let builder =
             ParquetRecordBatchReaderBuilder::try_new(file)?.with_row_groups(vec![rg_index]);
@@ -177,88 +277,137 @@ impl PlaceIndex {
 
         let batches: Vec<RecordBatch> = reader.collect::<Result<_, _>>()?;
         let schema = batches[0].schema();
-        Ok(concat_batches(&schema, &batches)?)
+        let batch = concat_batches(&schema, &batches)?;
+
+        let mut places = Vec::with_capacity(batch.num_rows());
+        for row in 0..batch.num_rows() {
+            places.push(extract_place(&batch, row)?);
+        }
+        Ok(Arc::new(places))
     }
 }
 
 // ============================================================================
-// Range-query iterator
+// Sequential range-query iterator — yields anyhow::Result<&'iter Place>
 // ============================================================================
 
+type Segment = (Arc<Vec<Place>>, usize, usize); // (places, start, end)
+
 pub struct PlaceIter {
-    /// Batches already sliced to the queried s2_cell_id range.
-    batches: Vec<Arc<RecordBatch>>,
-    batch_idx: usize,
-    row_idx: usize,
-    /// Only yield Places where place.mask.intersects(query_mask).
+    segments: Vec<Segment>,
+    seg_idx: usize,
+    row_idx: usize, // offset from `start` within the current segment
     query_mask: MatchMask,
 }
 
-impl Iterator for PlaceIter {
-    type Item = anyhow::Result<Place>;
+impl<'iter> Iterator for &'iter mut PlaceIter {
+    type Item = anyhow::Result<&'iter Place>;
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
-            let batch = self.batches.get(self.batch_idx)?;
+            let (places, start, end) = self
+                .segments
+                .get(self.seg_idx)
+                .map(|(a, s, e)| (a.as_ref(), *s, *e))?;
 
-            if self.row_idx >= batch.num_rows() {
-                self.batch_idx += 1;
+            let abs = start + self.row_idx;
+            if abs >= end {
+                self.seg_idx += 1;
                 self.row_idx = 0;
                 continue;
             }
 
-            let row = self.row_idx;
             self.row_idx += 1;
-            let batch = Arc::clone(batch);
 
-            match extract_place(&batch, row) {
-                Err(e) => return Some(Err(e)),
-                Ok(place) if place.mask.intersects(&self.query_mask) => return Some(Ok(place)),
-                Ok(_) => continue, // mask filtered — try the next row
+            // SAFETY: `places` is borrowed from the Arc inside `self.segments`,
+            // which is owned by `self` and therefore lives for `'iter`.
+            // `abs` is within [start, end) which was verified against
+            // places.len() when the segment was constructed in `build_segments`.
+            let place: &'iter Place = unsafe { &*(places.get_unchecked(abs) as *const Place) };
+
+            if place.mask.intersects(&self.query_mask) {
+                return Some(Ok(place));
             }
         }
     }
 }
 
 // ============================================================================
-// Full-scan iterator
+// Parallel iterator — owns the segments, yields &Place refs
+// ============================================================================
+//
+// `ParPlaceIter` owns the `Vec<Segment>` (each element holds an `Arc<Vec<Place>>`),
+// so the Places are guaranteed live for `'self`. The `par_iter` method exposes
+// them as a `ParallelIterator<Item = &Place>` using the same raw-pointer lifetime
+// extension as the sequential `PlaceIter`.
+
+#[allow(unused)] // TODO: Remove attribute once we use it.
+pub struct ParPlaceIter {
+    segments: Vec<Segment>,
+    query_mask: MatchMask,
+}
+
+impl ParPlaceIter {
+    /// Returns a Rayon `ParallelIterator` over matching `&Place` references.
+    /// Splits across segments (row-group slices); Rayon further subdivides
+    /// within each slice as it sees fit.
+    #[allow(unused)] // TODO: Remove attribute once we use it.
+    pub fn par_iter(&self) -> impl ParallelIterator<Item = &Place> {
+        let query_mask = self.query_mask;
+        self.segments
+            .par_iter()
+            .flat_map(|(places, start, end)| {
+                // SAFETY: `places` is an Arc<Vec<Place>> stored in `self.segments`.
+                // `self` lives for the duration of the returned iterator (the caller
+                // holds `&self`). The slice [*start..*end] was bounds-checked in
+                // `build_segments`. No mutable access to the data exists.
+                let slice: &[Place] =
+                    unsafe { std::slice::from_raw_parts(places.as_ptr().add(*start), end - start) };
+                slice.par_iter()
+            })
+            .filter(move |p| p.mask.intersects(&query_mask))
+    }
+}
+
+// ============================================================================
+// Sequential full-scan iterator — yields anyhow::Result<&'iter Place>
 // ============================================================================
 
 pub struct FullScanIter {
     index: Arc<PlaceIndex>,
     group_idx: usize,
-    /// Active batch and our cursor within it.
-    current: Option<(Arc<RecordBatch>, usize)>,
+    current: Option<(Arc<Vec<Place>>, usize)>,
 }
 
 impl FullScanIter {
-    /// Load the next row group directly from disk, bypassing the LRU cache.
     fn advance_group(&mut self) -> Option<()> {
         if self.group_idx >= self.index.groups.len() {
             return None;
         }
-        let rg_index = self.index.groups[self.group_idx].index;
-        let batch = self.index.read_row_group_from_disk(rg_index).ok()?;
-        self.current = Some((Arc::new(batch), 0));
+        let group = &self.index.groups[self.group_idx];
+        let places = self.index.load_row_group(group).ok()?;
+        self.current = Some((places, 0));
         self.group_idx += 1;
         Some(())
     }
 }
 
-impl Iterator for FullScanIter {
-    type Item = anyhow::Result<Place>;
+impl<'iter> Iterator for &'iter mut FullScanIter {
+    type Item = anyhow::Result<&'iter Place>;
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             match &mut self.current {
-                Some((batch, row_idx)) => {
-                    if *row_idx < batch.num_rows() {
-                        let row = *row_idx;
-                        *row_idx += 1;
-                        let batch = Arc::clone(batch);
-                        return Some(extract_place(&batch, row));
+                Some((places, idx)) => {
+                    if *idx < places.len() {
+                        let i = *idx;
+                        *idx += 1;
+                        // SAFETY: same argument as in PlaceIter.
+                        let place: &'iter Place =
+                            unsafe { &*(places.get_unchecked(i) as *const Place) };
+                        return Some(Ok(place));
                     }
-                    self.current = None; // batch exhausted; fall through
+                    self.current = None;
                 }
                 None => {
                     self.advance_group()?;
@@ -274,104 +423,85 @@ impl Iterator for FullScanIter {
 
 fn extract_place(batch: &RecordBatch, row: usize) -> anyhow::Result<Place> {
     Ok(Place {
-        s2_cell_id: get_opt_u64(batch, "s2_cell_id", row)?.context("missing s2_cell_id")?,
-        osm_id: get_opt_u64(batch, "osm_id", row)?.unwrap_or(0),
-        source: get_string(batch, "source", row)?,
-        mask: MatchMask(get_u16(batch, "mask", row)?),
+        s2_cell_id: get_u64_required(batch, "s2_cell_id", row)?,
+        osm_id: get_u64_optional(batch, "osm_id", row)?.unwrap_or(0),
+        source: get_string_required(batch, "source", row)?,
+        mask: MatchMask(get_u16_required(batch, "mask", row)?),
         tags: get_tags(batch, row)?,
     })
 }
 
-fn get_opt_u64(batch: &RecordBatch, name: &str, row: usize) -> anyhow::Result<Option<u64>> {
-    if let Some(col) = batch.column_by_name(name) {
-        Ok(Some(
-            col.as_any()
-                .downcast_ref::<UInt64Array>()
-                .ok_or_else(|| anyhow::anyhow!("{name} is not UInt64"))?
-                .value(row),
-        ))
-    } else {
-        Ok(None)
-    }
-}
-
-fn get_u16(batch: &RecordBatch, name: &str, row: usize) -> anyhow::Result<u16> {
+fn get_u64_required(batch: &RecordBatch, name: &str, row: usize) -> anyhow::Result<u64> {
     Ok(batch
         .column_by_name(name)
-        .ok_or_else(|| anyhow::anyhow!("missing column {name}"))?
+        .ok_or_else(|| anyhow::anyhow!("missing required column '{name}'"))?
         .as_any()
-        .downcast_ref::<UInt16Array>()
-        .ok_or_else(|| anyhow::anyhow!("{name} is not UInt16"))?
+        .downcast_ref::<UInt64Array>()
+        .ok_or_else(|| anyhow::anyhow!("column '{name}' is not UInt64"))?
         .value(row))
 }
 
-fn get_string(batch: &RecordBatch, name: &str, row: usize) -> anyhow::Result<String> {
+fn get_u64_optional(batch: &RecordBatch, name: &str, row: usize) -> anyhow::Result<Option<u64>> {
+    let col = match batch.column_by_name(name) {
+        None => return Ok(None),
+        Some(c) => c,
+    };
+    Ok(Some(
+        col.as_any()
+            .downcast_ref::<UInt64Array>()
+            .ok_or_else(|| anyhow::anyhow!("column '{name}' exists but is not UInt64"))?
+            .value(row),
+    ))
+}
+
+fn get_u16_required(batch: &RecordBatch, name: &str, row: usize) -> anyhow::Result<u16> {
     Ok(batch
         .column_by_name(name)
-        .ok_or_else(|| anyhow::anyhow!("missing column {name}"))?
+        .ok_or_else(|| anyhow::anyhow!("missing required column '{name}'"))?
+        .as_any()
+        .downcast_ref::<UInt16Array>()
+        .ok_or_else(|| anyhow::anyhow!("column '{name}' is not UInt16"))?
+        .value(row))
+}
+
+fn get_string_required(batch: &RecordBatch, name: &str, row: usize) -> anyhow::Result<String> {
+    Ok(batch
+        .column_by_name(name)
+        .ok_or_else(|| anyhow::anyhow!("missing required column '{name}'"))?
         .as_any()
         .downcast_ref::<StringArray>()
-        .ok_or_else(|| anyhow::anyhow!("{name} is not String"))?
+        .ok_or_else(|| anyhow::anyhow!("column '{name}' is not Utf8/String"))?
         .value(row)
-        .to_string())
+        .to_owned())
 }
 
 fn get_tags(batch: &RecordBatch, row: usize) -> anyhow::Result<Vec<(String, String)>> {
     let col = batch
         .column_by_name("tags")
-        .ok_or_else(|| anyhow::anyhow!("missing column tags"))?
+        .ok_or_else(|| anyhow::anyhow!("missing required column 'tags'"))?
         .as_any()
         .downcast_ref::<MapArray>()
-        .ok_or_else(|| anyhow::anyhow!("tags is not MapArray"))?;
+        .ok_or_else(|| anyhow::anyhow!("column 'tags' is not a MapArray"))?;
 
-    // col.value(row) returns a StructArray covering just this row's entries.
     let map_entry = col.value(row);
     let keys = map_entry
         .column_by_name("key")
         .ok_or_else(|| anyhow::anyhow!("map 'tags' has no 'key' field"))?
         .as_any()
         .downcast_ref::<StringArray>()
-        .ok_or_else(|| anyhow::anyhow!("keys of map 'tags' are not strings"))?;
+        .ok_or_else(|| anyhow::anyhow!("map 'tags' keys are not strings"))?;
     let values = map_entry
         .column_by_name("value")
         .ok_or_else(|| anyhow::anyhow!("map 'tags' has no 'value' field"))?
         .as_any()
         .downcast_ref::<StringArray>()
-        .ok_or_else(|| anyhow::anyhow!("values of map 'tags' are not strings"))?;
+        .ok_or_else(|| anyhow::anyhow!("map 'tags' values are not strings"))?;
 
-    let tags = (0..keys.len())
-        .map(|i| (keys.value(i).to_owned(), values.value(i).to_owned()))
-        .collect();
-    Ok(tags)
-}
-
-// ============================================================================
-// Binary search within a RecordBatch on the sorted s2_cell_id column
-// ============================================================================
-
-fn slice_by_s2_range(
-    batch: &RecordBatch,
-    lo: CellID,
-    hi: CellID,
-) -> anyhow::Result<Option<RecordBatch>> {
-    let ids = batch
-        .column_by_name("s2_cell_id")
-        .ok_or_else(|| anyhow::anyhow!("s2_cell_id column missing"))?
-        .as_any()
-        .downcast_ref::<UInt64Array>()
-        .ok_or_else(|| anyhow::anyhow!("s2_cell_id is not UInt64"))?;
-
-    let values = ids.values(); // &[u64] — zero-copy view into the Arrow buffer
-
-    let start = values.partition_point(|&v| v < lo.0);
-    let end = values.partition_point(|&v| v <= hi.0);
-
-    if start >= end {
-        return Ok(None);
+    let mut tags = Vec::with_capacity(keys.len());
+    for i in 0..keys.len() {
+        tags.push((keys.value(i).to_owned(), values.value(i).to_owned()));
     }
-
-    // RecordBatch::slice is zero-copy: adjusts offset + length on Arc buffers.
-    Ok(Some(batch.slice(start, end - start)))
+    Ok(tags)
 }
 
 // ============================================================================
@@ -380,9 +510,6 @@ fn slice_by_s2_range(
 
 fn extract_u64_stats(stats: Option<&Statistics>) -> anyhow::Result<(u64, u64)> {
     match stats {
-        // u64 has no native Parquet physical type; it is stored as INT64 bits.
-        // The bit-cast `as u64` is correct: S2 cell IDs are always positive,
-        // so the signed/unsigned re-interpretation preserves sort order.
         Some(Statistics::Int64(s)) => {
             let min = s
                 .min_opt()
@@ -404,14 +531,16 @@ fn extract_u64_stats(stats: Option<&Statistics>) -> anyhow::Result<(u64, u64)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
 
-    /// Load a test index file with the following `(s2_cell_id, mask)`:
-    /// * 5156622227156738357 MatchMask::SHOP
-    /// * 5159605103934476889 MatchMask::SHOP
-    /// * 5159605115004699013 MatchMask::SHOP
-    /// * 5159605826311453673 MatchMask::STREET_FURNITURE
-    /// * 5159607645100837135 MatchMask::STREET_FURNITURE
-    /// * 5159714166772063677 MatchMask::SHOP
+    /// Load a test index file with the following 7 places with `(s2_cell_id, mask)`:
+    ///  - 5156616745313632255 MatchMask::SHOP
+    ///  - 5156622227156738357 MatchMask::SHOP
+    ///  - 5159605103934476889 MatchMask::SHOP
+    ///  - 5159605115004699013 MatchMask::SHOP
+    ///  - 5159605826311453673 MatchMask::STREET_FURNITURE
+    ///  - 5159607645100837135 MatchMask::STREET_FURNITURE
+    ///  - 5159714166772063677 MatchMask::SHOP
     fn load_test_index() -> Arc<PlaceIndex> {
         let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         path.push("tests/test_data/alltheplaces.parquet");
@@ -425,8 +554,10 @@ mod tests {
             index
                 .query(CellID(lo)..=CellID(hi), mask)
                 .expect("query failed")
+                .inspect(|p| check_place(p.as_ref().expect("iteration failed")))
                 .count()
         };
+
         assert_eq!(count(7, 42, MatchMask::STREET_FURNITURE), 0);
         assert_eq!(
             count(0, 5159714166772063677, MatchMask::STREET_FURNITURE),
@@ -445,20 +576,63 @@ mod tests {
             count(5159605115004699013, 5159714166772063677, MatchMask::SHOP),
             2
         );
+        let stats = index.cache_stats();
+        assert_eq!(stats, CacheStats { hits: 4, misses: 1 });
+        assert_eq!(stats.hit_rate(), Some(0.8));
+    }
+
+    #[test]
+    fn test_query_par() {
+        let index = load_test_index();
+        let count = |lo, hi, mask| {
+            let results = index
+                .query_par(CellID(lo)..=CellID(hi), mask)
+                .expect("query_par failed");
+            results
+                .par_iter()
+                .inspect(|place| check_place(place))
+                .count()
+        };
+        assert_eq!(count(7, 42, MatchMask::STREET_FURNITURE), 0);
+        assert_eq!(count(0, 5159714166772063677, MatchMask::SHOP), 5);
+        let stats = index.cache_stats();
+        assert_eq!(stats, CacheStats { hits: 0, misses: 1 });
+        assert_eq!(stats.hit_rate(), Some(0.0));
     }
 
     #[test]
     fn test_scan() {
         let index = load_test_index();
-        let places: Vec<Place> = index.scan().filter_map(|r| r.ok()).collect::<Vec<_>>();
-        assert!(!places.is_empty(), "expected at least one row");
-        for place in &places {
-            assert_ne!(place.s2_cell_id, 0, "s2_cell_id should not be zero");
-            assert!(!place.source.is_empty(), "source should not be empty");
-            for (k, v) in &place.tags {
-                assert!(!k.is_empty(), "tag key should not be empty");
-                assert!(!v.is_empty(), "tag value should not be empty");
-            }
+        let num_places = index
+            .scan()
+            .inspect(|p| check_place(p.as_ref().expect("scan failed")))
+            .count();
+        assert_eq!(num_places, 7);
+        assert_eq!(index.cache_stats(), CacheStats { hits: 0, misses: 1 });
+        assert_eq!(index.cache_stats().hit_rate(), Some(0.0));
+    }
+
+    #[test]
+    fn test_scan_par() {
+        let index = load_test_index();
+        let num_places = index
+            .scan_par()
+            .par_iter()
+            .inspect(|p| {
+                check_place(&p);
+            })
+            .count();
+        assert_eq!(num_places, 7);
+        assert_eq!(index.cache_stats(), CacheStats { hits: 0, misses: 1 });
+        assert_eq!(index.cache_stats().hit_rate(), Some(0.0));
+    }
+
+    fn check_place(place: &Place) {
+        assert_ne!(place.s2_cell_id, 0, "s2_cell_id should not be zero");
+        assert!(!place.source.is_empty(), "source should not be empty");
+        for (k, v) in &place.tags {
+            assert!(!k.is_empty(), "tag key should not be empty");
+            assert!(!v.is_empty(), "tag value should not be empty");
         }
     }
 }


### PR DESCRIPTION
Before this change, multiple threads would redundantly decode the same Parquet row group when working on roughly the same geographic region. After this change, the work is only done once.