### PR TITLE
Implement a matcher for branded shops

### DIFF
--- a/src/diff_places.rs
+++ b/src/diff_places.rs
@@ -1,10 +1,10 @@
-use crate::places::{Place, PlaceIndex};
+use crate::places::{Place, PlaceIndex, create_matcher};
 use crate::s2_util::MergedCellRanges;
-use crate::{MatchMask, make_progress_bar, match_distance};
+use crate::{make_progress_bar, match_distance};
 use anyhow::Result;
 use indicatif::MultiProgress;
 use rayon::prelude::*;
-use s2::{cap::Cap, cell::Cell, cellid::CellID, point::Point, region::RegionCoverer};
+use s2::{cap::Cap, cell::Cell, cellid::CellID, region::RegionCoverer};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -37,6 +37,7 @@ pub fn diff_places(
 
     let num_atp_features = AtomicU64::new(0);
     let num_candidates = AtomicU64::new(0);
+    let num_matches = AtomicU64::new(0);
 
     for group in atp_places.scan_row_groups() {
         // Each group is processed by the Rayon thread pool in parallel,
@@ -70,12 +71,15 @@ pub fn diff_places(
                     }
                 }
                 if let Some(best_candidate) = best_candidate
-                    && false
+                    && best_score > 0.0
                 {
-                    println!(
-                        "score={} place={:?} best_candidate={:?}",
-                        best_score, place, best_candidate
-                    );
+                    num_matches.fetch_add(1, Ordering::Relaxed);
+                    if false {
+                        println!(
+                            "score={} place={:?} best_candidate={:?}",
+                            best_score, place, best_candidate
+                        );
+                    }
                 }
             };
             Ok::<(), anyhow::Error>(())
@@ -85,9 +89,10 @@ pub fn diff_places(
     let cache_stats = osm_places.cache_stats();
     progress_bar.finish();
     println!(
-        "  features: {} candidates: {}",
+        "  features: {} candidates: {} matches: {}",
         num_atp_features.load(Ordering::SeqCst),
-        num_candidates.load(Ordering::SeqCst)
+        num_candidates.load(Ordering::SeqCst),
+        num_matches.load(Ordering::SeqCst)
     );
     println!(
         "  cache hits: {} misses: {} hit rate: {:.1}%",
@@ -97,50 +102,4 @@ pub fn diff_places(
     );
 
     Ok(out_path)
-}
-
-// TODO: Figure out how to best model matchers for different types, such as trees vs shops.
-fn distance(pt: &Point, place: &Place) -> f64 {
-    let pt2 = Point(CellID(place.s2_cell_id).raw_point().normalize());
-    pt.distance(&pt2).rad() * 6_371_000.0
-}
-
-fn distance_score(pt: &Point, place: &Place, max_meters: f64) -> f64 {
-    let dist = distance(pt, place);
-    if dist <= max_meters {
-        (max_meters - dist) / max_meters
-    } else {
-        0.0
-    }
-}
-
-/// Trait for objects that can score a `Place`.
-pub trait Matcher {
-    /// Returns a score between 0.0 and 1.0 indicating how well the place matches.
-    fn score(&self, place: &Place) -> f64;
-}
-
-pub fn create_matcher(place: &Place) -> Option<Box<dyn Matcher + '_>> {
-    if place.mask.intersects(&MatchMask::SHOP) {
-        Some(Box::new(ShopMatcher::new(place)))
-    } else {
-        None
-    }
-}
-
-pub struct ShopMatcher {
-    center: Point,
-}
-
-impl ShopMatcher {
-    fn new(place: &Place) -> ShopMatcher {
-        let center = Cell::from(CellID(place.s2_cell_id)).center();
-        ShopMatcher { center }
-    }
-}
-
-impl Matcher for ShopMatcher {
-    fn score(&self, p: &Place) -> f64 {
-        distance_score(&self.center, p, 2000.0)
-    }
 }

--- a/src/places/matcher.rs
+++ b/src/places/matcher.rs
@@ -1,0 +1,194 @@
+use crate::{MatchMask, places::Place};
+use s2::{cell::Cell, cellid::CellID, point::Point};
+
+/// Trait for objects that can score a `Place`.
+pub trait Matcher {
+    /// Returns a score between 0.0 and 1.0 indicating how well the place matches.
+    fn score(&self, place: &Place) -> f64;
+}
+
+pub fn create_matcher(place: &Place) -> Option<Box<dyn Matcher + '_>> {
+    if let Some(matcher) = ShopMatcher::for_place(place) {
+        Some(Box::new(matcher))
+    } else {
+        None
+    }
+}
+
+fn distance(pt: &Point, place: &Place) -> f64 {
+    let pt2 = Point(CellID(place.s2_cell_id).raw_point().normalize());
+    pt.distance(&pt2).rad() * 6_371_000.0
+}
+
+fn distance_score(pt: &Point, place: &Place, max_meters: f64) -> f64 {
+    let dist = distance(pt, place);
+    if dist <= max_meters {
+        (max_meters - dist) / max_meters
+    } else {
+        0.0
+    }
+}
+
+fn parse_wikidata_id(s: &str) -> Option<u64> {
+    let trimmed = s.trim();
+    let digits = trimmed
+        .strip_prefix('Q')
+        .or_else(|| trimmed.strip_prefix('q'))?;
+    digits.parse::<u64>().ok()
+}
+
+struct ShopMatcher {
+    center: Point,
+    brand_wikidata: u64,
+}
+
+impl ShopMatcher {
+    // TODO: For now, we only match based on brand:wikidata.
+    // We should also look at names, by computing the token sort ratio,
+    // but we should do this in a way that works for CJK. So we need
+    // a decent segmenter that works for CJK languages. Maybe Lindera?
+    fn for_place(place: &Place) -> Option<ShopMatcher> {
+        if !place.mask.intersects(&MatchMask::SHOP) {
+            return None;
+        }
+        let mut brand_wikidata: Option<u64> = None;
+        for (k, v) in place.tags.iter() {
+            if k.as_str() == "brand:wikidata" {
+                brand_wikidata = parse_wikidata_id(v);
+                break;
+            }
+        }
+
+        if let Some(brand_wikidata) = brand_wikidata {
+            let center = Cell::from(CellID(place.s2_cell_id)).center();
+            Some(ShopMatcher {
+                center,
+                brand_wikidata,
+            })
+        } else {
+            None
+        }
+    }
+}
+
+impl Matcher for ShopMatcher {
+    fn score(&self, candidate: &Place) -> f64 {
+        let mut candidate_brand_wikidata: Option<u64> = None;
+        for (k, v) in candidate.tags.iter() {
+            if k.as_str() == "brand:wikidata" {
+                candidate_brand_wikidata = parse_wikidata_id(v);
+                break;
+            }
+        }
+
+        let distance_score = distance_score(&self.center, candidate, 400.0);
+        if Some(self.brand_wikidata) == candidate_brand_wikidata {
+            distance_score
+        } else {
+            0.0
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::LazyLock;
+
+    static CH_CLOTHES_ATP: LazyLock<Place> = LazyLock::new(|| Place {
+        s2_cell_id: 5159637664633565895,
+        osm_id: 0,
+        source: String::from("atp/newyorker"),
+        mask: MatchMask::SHOP,
+        tags: tags(&[
+            ("addr:city", "Rapperswil"),
+            ("addr:country", "CH"),
+            ("addr:full", "Zürcherstrasse 4, 8640 Rapperswil"),
+            ("addr:postcode", "8640"),
+            ("brand", "New Yorker"),
+            ("brand:wikidata", "Q706421"),
+            ("name", "NEW YORKER | EKZ Sonnenhof"),
+            ("opening_hours", "Mo-Fr 09:00-20:00; Sa 08:00-18:00"),
+            ("phone", "+41 55 210 63 10"),
+            ("ref", "5b3cb3fac00458481b4375e1"),
+            ("shop", "clothes"),
+        ]),
+    });
+
+    static CH_CLOTHES_OSM: LazyLock<Place> = LazyLock::new(|| Place {
+        s2_cell_id: 5159637664662121729,
+        osm_id: 10761965859,
+        source: String::from("osm"),
+        mask: MatchMask(1),
+        tags: tags(&[
+            ("branch", "Rapperswil Sonnenhof"),
+            ("brand", "New Yorker"),
+            ("brand:wikidata", "Q706421"),
+            ("level", "0"),
+            ("name", "New Yorker"),
+            ("opening_hours", "Mo-Fr 09:00-20:00; Sa 08:00-18:00"),
+            ("shop", "clothes"),
+            ("website", "https://www.newyorker.de/ch/"),
+        ]),
+    });
+
+    static CH_KIOSK_ATP: LazyLock<Place> = LazyLock::new(|| Place {
+        s2_cell_id: 5159637400739491865,
+        osm_id: 0,
+        source: String::from("atp/valora"),
+        mask: MatchMask::SHOP,
+        tags: tags(&[
+            ("addr:city", "Rapperswil"),
+            ("addr:country", "CH"),
+            ("addr:postcode", "8640"),
+            ("addr:street_address", "Unterführung Bahnhof 1"),
+            ("brand", "k kiosk"),
+            ("brand:wikidata", "Q60381703"),
+            ("name", "kkiosk Rapperswil BHF"),
+            ("opening_hours", "Mo-Fr 05:30-20:00; Sa-Su 07:00-20:00"),
+            ("ref", "730"),
+            ("shop", "newsagent"),
+        ]),
+    });
+
+    static CH_KIOSK_OSM: LazyLock<Place> = LazyLock::new(|| Place {
+        s2_cell_id: 5159637400743919515,
+        osm_id: 6028968648,
+        source: String::from("osm"),
+        mask: MatchMask::SHOP,
+        tags: tags(&[
+            ("brand", "k kiosk"),
+            ("brand:wikidata", "Q60381703"),
+            ("brand:wikipedia", "it:K Kiosk"),
+            ("cash_withdrawal", "yes"),
+            ("cash_withdrawal:fee", "no"),
+            ("cash_withdrawal:operator", "sonect"),
+            ("cash_withdrawal:purchase_required", "no"),
+            ("cash_withdrawal:type", "checkout"),
+            ("level", "-1"),
+            ("name", "k kiosk"),
+            (
+                "opening_hours",
+                "Mo-Fr 05:45-19:00; Sa 08:00-18:00; Su 09:00-18:00",
+            ),
+            ("shop", "kiosk"),
+            ("wheelchair", "yes"),
+        ]),
+    });
+
+    fn tags(t: &[(&str, &str)]) -> Vec<(String, String)> {
+        t.iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn test_shop_matcher() {
+        let ch_clothes_matcher = create_matcher(&CH_CLOTHES_ATP).expect("should create matcher");
+        let ch_kiosk_matcher = create_matcher(&CH_KIOSK_ATP).expect("should create matcher");
+        assert!(ch_clothes_matcher.score(&CH_CLOTHES_OSM) > 0.5);
+        assert!(ch_clothes_matcher.score(&CH_KIOSK_OSM) == 0.0);
+        assert!(ch_kiosk_matcher.score(&CH_CLOTHES_OSM) == 0.0);
+        assert!(ch_kiosk_matcher.score(&CH_KIOSK_OSM) > 0.5);
+    }
+}

--- a/src/places/mod.rs
+++ b/src/places/mod.rs
@@ -3,10 +3,12 @@ use deepsize::DeepSizeOf;
 use geo::Coord;
 use serde::{Deserialize, Serialize};
 
+mod matcher;
 mod place_index;
 mod writer;
-pub use place_index::PlaceIndex;
 
+pub use matcher::create_matcher;
+pub use place_index::PlaceIndex;
 pub use writer::ParquetWriter;
 
 #[derive(Debug, DeepSizeOf, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]


### PR DESCRIPTION
With current ATP and OSM data, it takes 42 seconds on a MacBook Air 2026 with 10 Apple M5 CPU cores to find the best match for 1714107 shops in AllThePlaces, computing scores for 79383683 candidates in OpenStreetMap, resulting in 693400 matches.