### PR TITLE
Store numeric feature ids into map tiles

### DIFF
--- a/src/osm/assemble.rs
+++ b/src/osm/assemble.rs
@@ -61,14 +61,14 @@ fn assemble_nodes(
                     x: node.lon_e7 as f64 * 1e-7,
                     y: node.lat_e7 as f64 * 1e-7,
                 };
-                let source = String::from("n");
+                let source = String::from("osm");
                 let tags = node
                     .tags
                     .chunks_exact(2)
                     .map(|c| (c[0].clone(), c[1].clone()))
                     .collect();
                 if let Some(mut place) = Place::new(&coord, source, mask, tags) {
-                    place.osm_id = node.id;
+                    place.osm_id = node.id * 10 + 1;
                     out.send(place)?;
                 }
             }
@@ -111,9 +111,9 @@ fn assemble_ways(
                         .chunks_exact(2)
                         .map(|c| (c[0].clone(), c[1].clone()))
                         .collect();
-                    let source = String::from("w");
+                    let source = String::from("osm");
                     if let Some(mut place) = Place::new(&centroid.0, source, mask, tags) {
-                        place.osm_id = way.id;
+                        place.osm_id = way.id * 10 + 2;
                         out.send(place)?;
                     }
                 }
@@ -195,12 +195,12 @@ mod tests {
 
         let mut want = Place::new(
             &geo::Coord { x: 11.0, y: 12.0 },
-            String::from("n"),
+            String::from("osm"),
             MatchMask::SHOP,
             vec![(String::from("shop"), String::from("supermarket"))],
         )
         .expect("cannot construct wanted Place");
-        want.osm_id = 12345;
+        want.osm_id = 123451;
         assert_eq!(rx.next(), Some(want));
         assert_eq!(rx.next(), None);
         Ok(())
@@ -237,12 +237,12 @@ mod tests {
 
         let mut want = Place::new(
             &geo::Coord { x: 60.0, y: 30.0 }, // centroid
-            String::from("w"),
+            String::from("osm"),
             MatchMask::SHRUBBERY,
             vec![(String::from("natural"), String::from("tree_row"))],
         )
         .expect("cannot construct wanted Place");
-        want.osm_id = 3;
+        want.osm_id = 32;
         assert_eq!(rx.next(), Some(want));
         assert_eq!(rx.next(), None);
         Ok(())

--- a/src/places/mod.rs
+++ b/src/places/mod.rs
@@ -59,11 +59,21 @@ impl Place {
         let rounded_lon = (lat_lon.lng.deg() * 1e7).round() / 1e7;
         let rounded_lat = (lat_lon.lat.deg() * 1e7).round() / 1e7;
         let point = geo::point!(x: rounded_lon, y: rounded_lat);
+
         let id = if self.osm_id > 0 {
-            // TODO: Handle ways and relations.
-            let id_string = format!("node/{}", self.osm_id);
-            Some(geojson::feature::Id::String(id_string))
+            Some(geojson::feature::Id::Number(self.osm_id.into()))
         } else {
+            // TODO: Generate a unique ID from an AtomicU64. Use
+            // counter value * 10, so it does not conflict with OSM
+            // nodes (id * 10 + 1), ways (id * 10 + 2) or relations
+            // (id * 10 + 3). For now, this is not an issue:
+            // Currently, we never emit edit suggestions that aren't
+            // for existing OSM features.  At some point in the
+            // future, we’ll likely want to suggest creating new
+            // features (from AllThePlaces features that don’t match
+            // anything existing in OSM), and then we’ll need to give
+            // them feature IDs that don’t conflict with anything else
+            // in the generated PMTiles file.
             None
         };
         geojson::Feature {
@@ -116,7 +126,7 @@ mod tests {
             ("name:gsw".to_string(), "Zytglogge".to_string()),
         ];
         let mut place = Place::new(&p, source, MatchMask::SHOP, tags.clone()).unwrap();
-        place.osm_id = 789;
+        place.osm_id = 7891;
         let mut got_geojson = place.to_geojson();
         let (got_lon, got_lat) = point_coords(got_geojson.geometry.as_ref().unwrap());
         assert!((got_lon - p.x).abs() < 1e-6);
@@ -124,7 +134,7 @@ mod tests {
         got_geojson.geometry = None;
         let expected_geojson: geojson::Feature = r#"{
             "type": "Feature",
-            "id": "node/789",
+            "id": 7891,
             "properties": { "building": "tower", "name:gsw": "Zytglogge" }
         }"#
         .parse()

--- a/src/places/writer.rs
+++ b/src/places/writer.rs
@@ -1,7 +1,7 @@
 use super::Place;
 use anyhow::{Ok, Result};
 use arrow::{
-    array::{ArrayRef, MapArray, StringArray, StructArray, UInt8Array, UInt16Array, UInt64Array},
+    array::{ArrayRef, MapArray, StringArray, StructArray, UInt16Array, UInt64Array},
     buffer::OffsetBuffer,
     datatypes::{DataType, Field, Schema},
     record_batch::RecordBatch,
@@ -11,7 +11,6 @@ use parquet::{
     basic::{Compression, ZstdLevel},
     file::properties::{EnabledStatistics, WriterProperties},
 };
-use std::collections::HashMap;
 use std::fs::File;
 use std::path::Path;
 use std::sync::Arc;
@@ -76,14 +75,6 @@ impl ParquetWriter {
             values.push(Arc::new(StringArray::from_iter_values(
                 self.places.iter().map(|_| "osm"),
             )));
-            values.push(Arc::new(UInt8Array::from_iter(self.places.iter().map(
-                |p| match p.source.as_ref() {
-                    "n" => 0_u8,
-                    "w" => 1_u8,
-                    "r" => 2_u8,
-                    _ => panic!("source must be \"n\", \"w\" or \"r\""),
-                },
-            ))));
             values.push(Arc::new(UInt64Array::from_iter(
                 self.places.iter().map(|p| p.osm_id),
             )));
@@ -157,13 +148,6 @@ fn make_schema(osm: bool) -> Schema {
         Field::new("source", DataType::Utf8, /* nullable */ false),
     ];
     if osm {
-        let mut osm_type_metadata = HashMap::new();
-        osm_type_metadata.insert("ENUM_VALUES".to_string(), "node,way,relation".to_string());
-        osm_type_metadata.insert("ENUM_TYPE".to_string(), "u8".to_string());
-        fields.push(
-            Field::new("osm_type", DataType::UInt8, /* nullable */ false)
-                .with_metadata(osm_type_metadata),
-        );
         fields.push(Field::new(
             "osm_id",
             DataType::UInt64,


### PR DESCRIPTION
Using same encoding as Planetiler: (osm_id * 10 + 1) for nodes, (osm_id * 10 + 2) for ways, (osm_id * 10 + 3) for relations.