### PR TITLE
Optimize size of Parquet row groups

### DIFF
--- a/src/atp/mod.rs
+++ b/src/atp/mod.rs
@@ -54,8 +54,7 @@ fn process_places(
     let mut tmp = PathBuf::from(out);
     tmp.add_extension("tmp");
     let mut writer = ParquetWriter::try_new(
-        /* batch size, in records */ 64 * 1024,
-        /* page size, in bytes */ 1024 * 1024,
+        /* batch size, in records */ 4 * 1024,
         /* osm */ false,
         &tmp,
     )?;

--- a/src/osm/assemble.rs
+++ b/src/osm/assemble.rs
@@ -136,8 +136,7 @@ fn write_places(
     tmp.add_extension("tmp");
 
     let mut writer = ParquetWriter::try_new(
-        /* batch size, in records */ 64 * 1024,
-        /* page size, in bytes */ 1024 * 1024,
+        /* batch size, in records */ 4 * 1024,
         /* osm */ true,
         &tmp,
     )?;

--- a/src/places/writer.rs
+++ b/src/places/writer.rs
@@ -25,8 +25,7 @@ pub struct ParquetWriter {
 
 impl ParquetWriter {
     pub fn try_new(
-        batch_size: usize,
-        page_size: usize, // 1 MiB is a good value for production data
+        batch_size: usize, // number of records per row group
         osm: bool,
         out: &Path,
     ) -> Result<ParquetWriter> {
@@ -36,7 +35,7 @@ impl ParquetWriter {
         let props = WriterProperties::builder()
             .set_compression(Compression::ZSTD(ZstdLevel::try_new(15)?))
             .set_statistics_enabled(EnabledStatistics::Page)
-            .set_data_page_size_limit(page_size)
+            .set_max_row_group_row_count(Some(batch_size))
             .build();
         let writer = ArrowWriter::try_new(file, schema.clone(), Some(props))?;
         Ok(ParquetWriter {


### PR DESCRIPTION
Before this change, the desired row group size was not actually getting passed down to the Parquet library, so Parquet’s default settings were used. (We were writing the data in smaller chunks, but Apache’s Parquet library used an internal buffer to construct large row groups). After this change, the row groups in our Parquet files now have the intended size. As a result, the peak RAM usage for matching the full AllThePlaces data to the full OSM planet drops to 0.4 GB, compared ~18 GB before this change, without significant change in runtime. Our LRU cache for nearby OSM features (in `src/places/place_index.rs`) still sees as cache hit rate of 99.8%.

The intermediate Parquet files are still getting resonably compressed despite the smaller row group sizes: After this change, the size of `alltheplaces.parquet` is 188 MB and `osm.parqet` is 1.2 GB.