### PR TITLE
Store `osm_id` as `Option<NonZeroU64>` instead of `u64`

### DIFF
--- a/src/diff_places.rs
+++ b/src/diff_places.rs
@@ -176,7 +176,7 @@ fn write_edits(edits: Receiver<Place>, path: &Path, workdir: &Path) -> Result<u6
         num_edits.fetch_add(1, Ordering::Relaxed);
         std::io::Result::Ok(x)
     }))?;
-    let mut last_osm_id = 0;
+    let mut last_osm_id = None;
     for edit in sorted {
         let edit = edit?;
         // Only emit one single edit per OSM ID.

--- a/src/matchers/mod.rs
+++ b/src/matchers/mod.rs
@@ -386,7 +386,7 @@ impl<'a> Matcher for ShopMatcher<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::LazyLock;
+    use std::{num::NonZeroU64, sync::LazyLock};
 
     #[test]
     fn test_match_distance() {
@@ -400,7 +400,7 @@ mod tests {
 
     static CH_CLOTHES_ATP: LazyLock<Place> = LazyLock::new(|| Place {
         s2_cell_id: 5159637664633565895,
-        osm_id: 0,
+        osm_id: None,
         source: String::from("atp/newyorker"),
         mask: MatchMask::SHOP,
         tags: tags(&[
@@ -420,7 +420,7 @@ mod tests {
 
     static CH_CLOTHES_OSM: LazyLock<Place> = LazyLock::new(|| Place {
         s2_cell_id: 5159637664662121729,
-        osm_id: 10761965859,
+        osm_id: NonZeroU64::new(10761965859),
         source: String::from("osm"),
         mask: MatchMask(1),
         tags: tags(&[
@@ -437,7 +437,7 @@ mod tests {
 
     static CH_KIOSK_ATP: LazyLock<Place> = LazyLock::new(|| Place {
         s2_cell_id: 5159637400739491865,
-        osm_id: 0,
+        osm_id: None,
         source: String::from("atp/valora"),
         mask: MatchMask::SHOP,
         tags: tags(&[
@@ -456,7 +456,7 @@ mod tests {
 
     static CH_KIOSK_OSM: LazyLock<Place> = LazyLock::new(|| Place {
         s2_cell_id: 5159637400743919515,
-        osm_id: 6028968648,
+        osm_id: NonZeroU64::new(6028968648),
         source: String::from("osm"),
         mask: MatchMask::SHOP,
         tags: tags(&[

--- a/src/osm/assemble.rs
+++ b/src/osm/assemble.rs
@@ -5,6 +5,7 @@ use geo::{Centroid, Coord, LineString};
 use indicatif::{MultiProgress, ProgressBar};
 use rayon::prelude::*;
 use std::fs::rename;
+use std::num::NonZeroU64;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc::{Receiver, SyncSender, sync_channel};
@@ -68,7 +69,7 @@ fn assemble_nodes(
                     .map(|c| (c[0].clone(), c[1].clone()))
                     .collect();
                 if let Some(mut place) = Place::new(&coord, source, mask, tags) {
-                    place.osm_id = node.id * 10 + 1;
+                    place.osm_id = NonZeroU64::new(node.id * 10 + 1);
                     out.send(place)?;
                 }
             }
@@ -113,7 +114,7 @@ fn assemble_ways(
                         .collect();
                     let source = String::from("osm");
                     if let Some(mut place) = Place::new(&centroid.0, source, mask, tags) {
-                        place.osm_id = way.id * 10 + 2;
+                        place.osm_id = NonZeroU64::new(way.id * 10 + 2);
                         out.send(place)?;
                     }
                 }
@@ -173,6 +174,7 @@ mod tests {
     use crate::places::Place;
     use anyhow::{Ok, Result};
     use indicatif::{ProgressBar, ProgressDrawTarget};
+    use std::num::NonZeroU64;
     use std::sync::mpsc::sync_channel;
 
     #[test]
@@ -199,7 +201,7 @@ mod tests {
             vec![(String::from("shop"), String::from("supermarket"))],
         )
         .expect("cannot construct wanted Place");
-        want.osm_id = 123451;
+        want.osm_id = NonZeroU64::new(123451);
         assert_eq!(rx.next(), Some(want));
         assert_eq!(rx.next(), None);
         Ok(())
@@ -241,7 +243,7 @@ mod tests {
             vec![(String::from("natural"), String::from("tree_row"))],
         )
         .expect("cannot construct wanted Place");
-        want.osm_id = 32;
+        want.osm_id = NonZeroU64::new(32);
         assert_eq!(rx.next(), Some(want));
         assert_eq!(rx.next(), None);
         Ok(())

--- a/src/places/mod.rs
+++ b/src/places/mod.rs
@@ -2,6 +2,7 @@ use crate::matchers::MatchMask;
 use deepsize::DeepSizeOf;
 use geo::Coord;
 use serde::{Deserialize, Serialize};
+use std::num::NonZeroU64;
 
 mod place_index;
 mod writer;
@@ -12,7 +13,7 @@ pub use writer::ParquetWriter;
 #[derive(Debug, DeepSizeOf, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
 pub struct Place {
     pub s2_cell_id: u64,
-    pub osm_id: u64,
+    pub osm_id: Option<NonZeroU64>,
     pub source: String,
     pub mask: MatchMask,
     pub tags: Vec<(String, String)>,
@@ -33,7 +34,7 @@ impl Place {
         let s2_cell_id = s2::cellid::CellID::from(s2_lat_lng).0;
         Some(Place {
             s2_cell_id,
-            osm_id: 0,
+            osm_id: None,
             source,
             mask,
             tags,
@@ -58,22 +59,20 @@ impl Place {
         let rounded_lat = (lat_lon.lat.deg() * 1e7).round() / 1e7;
         let point = geo::point!(x: rounded_lon, y: rounded_lat);
 
-        let id = if self.osm_id > 0 {
-            Some(geojson::feature::Id::Number(self.osm_id.into()))
-        } else {
-            // TODO: Generate a unique ID from an AtomicU64. Use
-            // counter value * 10, so it does not conflict with OSM
-            // nodes (id * 10 + 1), ways (id * 10 + 2) or relations
-            // (id * 10 + 3). For now, this is not an issue:
-            // Currently, we never emit edit suggestions that aren't
-            // for existing OSM features.  At some point in the
-            // future, we’ll likely want to suggest creating new
-            // features (from AllThePlaces features that don’t match
-            // anything existing in OSM), and then we’ll need to give
-            // them feature IDs that don’t conflict with anything else
-            // in the generated PMTiles file.
-            None
-        };
+        // TODO: Generate a unique ID from an AtomicU64 if osm_id is None.
+        // Use counter value * 10, so it does not conflict with OSM nodes
+        // (id * 10 + 1), ways (id * 10 + 2) or relations (id * 10 + 3).
+        // For now, this is not an issue: Currently, we never
+        // emit edit suggestions that aren't for existing OSM
+        // features.  At some point in the future, we’ll likely want
+        // to suggest creating new features (from AllThePlaces
+        // features that don’t match anything existing in OSM), and
+        // then we’ll need to give them feature IDs that don’t
+        // conflict with anything else in the generated PMTiles file.
+        let id = self
+            .osm_id
+            .map(|osm_id| geojson::feature::Id::Number(osm_id.get().into()));
+
         geojson::Feature {
             bbox: None,
             geometry: Some(geojson::Geometry::from(&point)),
@@ -123,7 +122,7 @@ mod tests {
             ("name:gsw".to_string(), "Zytglogge".to_string()),
         ];
         let mut place = Place::new(&p, source, MatchMask::SHOP, tags.clone()).unwrap();
-        place.osm_id = 7891;
+        place.osm_id = NonZeroU64::new(7891);
         let mut got_geojson = place.to_geojson();
         let (got_lon, got_lat) = point_coords(got_geojson.geometry.as_ref().unwrap());
         assert!((got_lon - p.x).abs() < 1e-6);

--- a/src/places/place_index.rs
+++ b/src/places/place_index.rs
@@ -6,7 +6,7 @@ use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use parquet::file::statistics::Statistics;
 use s2::cellid::CellID;
 use std::fs::File;
-use std::num::NonZeroUsize;
+use std::num::{NonZeroU64, NonZeroUsize};
 use std::ops::RangeInclusive;
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -320,7 +320,7 @@ impl<'iter> Iterator for &'iter mut PlaceIter {
 fn extract_place(batch: &RecordBatch, row: usize) -> anyhow::Result<Place> {
     Ok(Place {
         s2_cell_id: get_u64_required(batch, "s2_cell_id", row)?,
-        osm_id: get_u64_optional(batch, "osm_id", row)?.unwrap_or(0),
+        osm_id: get_u64_optional(batch, "osm_id", row)?.and_then(NonZeroU64::new),
         source: get_string_required(batch, "source", row)?,
         mask: MatchMask(get_u16_required(batch, "mask", row)?),
         tags: get_tags(batch, row)?,

--- a/src/places/writer.rs
+++ b/src/places/writer.rs
@@ -74,9 +74,15 @@ impl ParquetWriter {
             values.push(Arc::new(StringArray::from_iter_values(
                 self.places.iter().map(|_| "osm"),
             )));
-            values.push(Arc::new(UInt64Array::from_iter(
-                self.places.iter().map(|p| p.osm_id),
-            )));
+            values.push(Arc::new(UInt64Array::from_iter(self.places.iter().map(
+                |p| {
+                    if let Some(osm_id) = p.osm_id {
+                        osm_id.get()
+                    } else {
+                        0
+                    }
+                },
+            ))));
         } else {
             values.push(Arc::new(StringArray::from_iter_values(
                 self.places.iter().map(|p| p.source.as_str()),


### PR DESCRIPTION
In Rust, this makes no difference in memory requirements because the Rust compiler guarantees to recognize this pattern.

Perhaps we should use NonZeroI64 for compatibility with OsmChange, but it does not really matter for us (at least not at the moment), and the library we’re using to read OSM PBF files is working with u64, not i64.