### PR TITLE
Include OSM changeset and version in output

### DIFF
--- a/src/matchers/mod.rs
+++ b/src/matchers/mod.rs
@@ -350,6 +350,9 @@ impl<'a> Matcher for ShopMatcher<'a> {
         }
     }
 
+    // TODO: This is not really a Matcher task. Move this elsewhere,
+    // once we figure out what the final output format should be
+    // for the pipeline.
     fn suggest_edit(&self, osm_feature: &Place) -> Option<Place> {
         let osm_tags: HashMap<&str, &str> = osm_feature
             .tags
@@ -376,6 +379,8 @@ impl<'a> Matcher for ShopMatcher<'a> {
         Some(Place {
             s2_cell_id: osm_feature.s2_cell_id,
             osm_id: osm_feature.osm_id,
+            osm_changeset: osm_feature.osm_changeset,
+            osm_version: osm_feature.osm_version,
             source: self.atp_place.source.clone(),
             mask: osm_feature.mask,
             tags: tag_edits,
@@ -386,7 +391,10 @@ impl<'a> Matcher for ShopMatcher<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::{num::NonZeroU64, sync::LazyLock};
+    use std::{
+        num::{NonZeroI32, NonZeroI64, NonZeroU64},
+        sync::LazyLock,
+    };
 
     #[test]
     fn test_match_distance() {
@@ -401,6 +409,8 @@ mod tests {
     static CH_CLOTHES_ATP: LazyLock<Place> = LazyLock::new(|| Place {
         s2_cell_id: 5159637664633565895,
         osm_id: None,
+        osm_changeset: None,
+        osm_version: None,
         source: String::from("atp/newyorker"),
         mask: MatchMask::SHOP,
         tags: tags(&[
@@ -421,6 +431,8 @@ mod tests {
     static CH_CLOTHES_OSM: LazyLock<Place> = LazyLock::new(|| Place {
         s2_cell_id: 5159637664662121729,
         osm_id: NonZeroU64::new(10761965859),
+        osm_changeset: NonZeroI64::new(149971213),
+        osm_version: NonZeroI32::new(4),
         source: String::from("osm"),
         mask: MatchMask(1),
         tags: tags(&[
@@ -438,6 +450,8 @@ mod tests {
     static CH_KIOSK_ATP: LazyLock<Place> = LazyLock::new(|| Place {
         s2_cell_id: 5159637400739491865,
         osm_id: None,
+        osm_changeset: None,
+        osm_version: None,
         source: String::from("atp/valora"),
         mask: MatchMask::SHOP,
         tags: tags(&[
@@ -457,6 +471,8 @@ mod tests {
     static CH_KIOSK_OSM: LazyLock<Place> = LazyLock::new(|| Place {
         s2_cell_id: 5159637400743919515,
         osm_id: NonZeroU64::new(6028968648),
+        osm_changeset: NonZeroI64::new(157167503),
+        osm_version: NonZeroI32::new(6),
         source: String::from("osm"),
         mask: MatchMask::SHOP,
         tags: tags(&[

--- a/src/osm/assemble.rs
+++ b/src/osm/assemble.rs
@@ -70,6 +70,8 @@ fn assemble_nodes(
                     .collect();
                 if let Some(mut place) = Place::new(&coord, source, mask, tags) {
                     place.osm_id = NonZeroU64::new(node.id * 10 + 1);
+                    place.osm_changeset = node.changeset;
+                    place.osm_version = node.version;
                     out.send(place)?;
                 }
             }
@@ -115,6 +117,8 @@ fn assemble_ways(
                     let source = String::from("osm");
                     if let Some(mut place) = Place::new(&centroid.0, source, mask, tags) {
                         place.osm_id = NonZeroU64::new(way.id * 10 + 2);
+                        place.osm_changeset = way.changeset;
+                        place.osm_version = way.version;
                         out.send(place)?;
                     }
                 }
@@ -174,7 +178,7 @@ mod tests {
     use crate::places::Place;
     use anyhow::{Ok, Result};
     use indicatif::{ProgressBar, ProgressDrawTarget};
-    use std::num::NonZeroU64;
+    use std::num::{NonZeroI32, NonZeroI64, NonZeroU64};
     use std::sync::mpsc::sync_channel;
 
     #[test]
@@ -182,6 +186,8 @@ mod tests {
         let store = MockFeatureStore::new(
             vec![Node {
                 id: 12345,
+                changeset: NonZeroI64::new(999),
+                version: NonZeroI32::new(7),
                 tags: vec![String::from("shop"), String::from("supermarket")],
                 lon_e7: 11_000_000_0,
                 lat_e7: 12_000_000_0,
@@ -202,6 +208,8 @@ mod tests {
         )
         .expect("cannot construct wanted Place");
         want.osm_id = NonZeroU64::new(123451);
+        want.osm_changeset = NonZeroI64::new(999);
+        want.osm_version = NonZeroI32::new(7);
         assert_eq!(rx.next(), Some(want));
         assert_eq!(rx.next(), None);
         Ok(())
@@ -213,12 +221,16 @@ mod tests {
             vec![
                 Node {
                     id: 1,
+                    changeset: NonZeroI64::new(1999),
+                    version: NonZeroI32::new(17),
                     tags: vec![],
                     lon_e7: 50_000_000_0,
                     lat_e7: 20_000_000_0,
                 },
                 Node {
                     id: 2,
+                    changeset: NonZeroI64::new(2999),
+                    version: NonZeroI32::new(27),
                     tags: vec![],
                     lon_e7: 70_000_000_0,
                     lat_e7: 40_000_000_0,
@@ -226,6 +238,8 @@ mod tests {
             ],
             vec![Way {
                 id: 3,
+                changeset: NonZeroI64::new(3999),
+                version: NonZeroI32::new(37),
                 nodes: vec![1, 2, 666],
                 tags: vec![String::from("natural"), String::from("tree_row")],
             }],
@@ -244,6 +258,8 @@ mod tests {
         )
         .expect("cannot construct wanted Place");
         want.osm_id = NonZeroU64::new(32);
+        want.osm_changeset = NonZeroI64::new(3999);
+        want.osm_version = NonZeroI32::new(37);
         assert_eq!(rx.next(), Some(want));
         assert_eq!(rx.next(), None);
         Ok(())

--- a/src/osm/filter.rs
+++ b/src/osm/filter.rs
@@ -10,6 +10,7 @@ use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::fs::{File, remove_file, rename};
 use std::io::{BufWriter, Cursor, Read, Seek, Write};
+use std::num::{NonZeroI32, NonZeroI64};
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::sync_channel;
 use std::thread;
@@ -116,6 +117,7 @@ pub fn filter_relations<'a, R: Read + Seek + Send>(
                 let block = PrimitiveBlock::parse(&data);
                 for primitive in block.primitives() {
                     if let Primitive::Relation(rel) = primitive
+                        && let Some(ref info) = rel.info
                         && filter(rel.id, rel.tags(), covered_relations, coverage)
                     {
                         let tags: Vec<String> = rel
@@ -151,6 +153,8 @@ pub fn filter_relations<'a, R: Read + Seek + Send>(
 
                         rel_tx.send(Relation {
                             id: rel.id,
+                            changeset: get_changeset(info),
+                            version: get_version(info),
                             tags,
                             members,
                         })?;
@@ -276,7 +280,9 @@ pub fn filter_ways<'a, R: Read + Seek + Send>(
                 let data = blob.into_data(); // decompress
                 let block = PrimitiveBlock::parse(&data);
                 for primitive in block.primitives() {
-                    if let Primitive::Way(way) = primitive {
+                    if let Primitive::Way(way) = primitive
+                        && let Some(ref info) = way.info
+                    {
                         if filter(way.id, way.tags(), covered_ways, coverage) {
                             let nodes = collect_way_nodes(&way);
                             let tags: Vec<String> = way
@@ -288,6 +294,8 @@ pub fn filter_ways<'a, R: Read + Seek + Send>(
                             }
                             way_tx.send(Way {
                                 id: way.id,
+                                changeset: get_changeset(info),
+                                version: get_version(info),
                                 nodes,
                                 tags,
                             })?;
@@ -303,6 +311,8 @@ pub fn filter_ways<'a, R: Read + Seek + Send>(
                             }
                             way_tx.send(Way {
                                 id: way.id,
+                                changeset: get_changeset(info),
+                                version: get_version(info),
                                 nodes,
                                 tags: Vec::<String>::with_capacity(0),
                             })?;
@@ -440,7 +450,9 @@ pub fn filter_nodes<'a, R: Read + Seek + Send>(
                 let data = blob.into_data(); // decompress
                 let block = PrimitiveBlock::parse(&data);
                 for primitive in block.primitives() {
-                    if let Primitive::Node(node) = primitive {
+                    if let Primitive::Node(node) = primitive
+                        && let Some(ref info) = node.info
+                    {
                         if filter(node.id, node.tags.iter().copied(), covered_nodes, coverage) {
                             let tags: Vec<String> = node
                                 .tags
@@ -450,6 +462,8 @@ pub fn filter_nodes<'a, R: Read + Seek + Send>(
                             if let Some((lon_e7, lat_e7)) = round_coords(node.lon, node.lat) {
                                 node_tx.send(Node {
                                     id: node.id,
+                                    changeset: get_changeset(info),
+                                    version: get_version(info),
                                     tags,
                                     lon_e7,
                                     lat_e7,
@@ -542,6 +556,28 @@ pub fn filter_nodes<'a, R: Read + Seek + Send>(
     ));
 
     Ok(FilteredFile::open(&out_path)?)
+}
+
+fn get_changeset(info: &osm_pbf_iter::info::Info) -> Option<NonZeroI64> {
+    if let Some(changeset) = info.changeset
+        && changeset > 0
+        && changeset <= i64::MAX as u64
+    {
+        NonZeroI64::new(changeset as i64)
+    } else {
+        None
+    }
+}
+
+fn get_version(info: &osm_pbf_iter::info::Info) -> Option<NonZeroI32> {
+    if let Some(version) = info.version
+        && version > 0
+        && version <= i32::MAX as u32
+    {
+        NonZeroI32::new(version as i32)
+    } else {
+        None
+    }
 }
 
 /// Helper for `filter_nodes()`.

--- a/src/osm/mod.rs
+++ b/src/osm/mod.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::io::{Read, Seek, SeekFrom};
+use std::num::{NonZeroI32, NonZeroI64};
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::{SyncSender, sync_channel};
 use std::thread;
@@ -97,7 +98,9 @@ pub fn import_osm(coverage: &Path, progress: &MultiProgress, workdir: &Path) -> 
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 struct Node {
-    id: u64,
+    id: u64, // TODO: NonZeroI64?
+    changeset: Option<NonZeroI64>,
+    version: Option<NonZeroI32>,
     tags: Vec<String>,
     lon_e7: i32,
     lat_e7: i32,
@@ -105,14 +108,18 @@ struct Node {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 struct Way {
-    id: u64,
+    id: u64, // TODO: NonZeroI64?
+    changeset: Option<NonZeroI64>,
+    version: Option<NonZeroI32>,
     nodes: Vec<u64>,
     tags: Vec<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 struct Relation {
-    id: u64,
+    id: u64, // TODO: NonZeroI64?
+    changeset: Option<NonZeroI64>,
+    version: Option<NonZeroI32>,
     tags: Vec<String>,
     members: Vec<RelationMember>,
 }

--- a/src/places/mod.rs
+++ b/src/places/mod.rs
@@ -2,7 +2,7 @@ use crate::matchers::MatchMask;
 use deepsize::DeepSizeOf;
 use geo::Coord;
 use serde::{Deserialize, Serialize};
-use std::num::NonZeroU64;
+use std::num::{NonZeroI32, NonZeroI64, NonZeroU64};
 
 mod place_index;
 mod writer;
@@ -13,7 +13,9 @@ pub use writer::ParquetWriter;
 #[derive(Debug, DeepSizeOf, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
 pub struct Place {
     pub s2_cell_id: u64,
-    pub osm_id: Option<NonZeroU64>,
+    pub osm_id: Option<NonZeroU64>,        // TODO: Option<NonZeroI64>?
+    pub osm_changeset: Option<NonZeroI64>, // TODO: Remove if not needed for MapRoulette.
+    pub osm_version: Option<NonZeroI32>,
     pub source: String,
     pub mask: MatchMask,
     pub tags: Vec<(String, String)>,
@@ -35,6 +37,8 @@ impl Place {
         Some(Place {
             s2_cell_id,
             osm_id: None,
+            osm_changeset: None,
+            osm_version: None,
             source,
             mask,
             tags,
@@ -45,6 +49,8 @@ impl Place {
         Place {
             s2_cell_id: self.s2_cell_id,
             osm_id: self.osm_id,
+            osm_changeset: self.osm_changeset,
+            osm_version: self.osm_version,
             source: self.source.clone(),
             mask: self.mask,
             tags: self.tags.clone(),
@@ -73,16 +79,29 @@ impl Place {
             .osm_id
             .map(|osm_id| geojson::feature::Id::Number(osm_id.get().into()));
 
+        let mut properties: serde_json::Map<String, serde_json::Value> = self
+            .tags
+            .iter()
+            .map(|(k, v)| (k.clone(), serde_json::Value::String(v.clone())))
+            .collect();
+        if let Some(changeset) = self.osm_changeset {
+            properties.insert(
+                String::from("@osm_changeset"),
+                serde_json::Value::from(changeset.get()),
+            );
+        }
+        if let Some(version) = self.osm_version {
+            properties.insert(
+                String::from("@osm_version"),
+                serde_json::Value::from(version.get()),
+            );
+        }
+
         geojson::Feature {
             bbox: None,
             geometry: Some(geojson::Geometry::from(&point)),
             id,
-            properties: Some(
-                self.tags
-                    .iter()
-                    .map(|(k, v)| (k.clone(), serde_json::Value::String(v.clone())))
-                    .collect(),
-            ),
+            properties: Some(properties),
             foreign_members: None,
         }
     }

--- a/src/places/place_index.rs
+++ b/src/places/place_index.rs
@@ -1,4 +1,6 @@
-use arrow::array::{Array, MapArray, RecordBatch, StringArray, UInt16Array, UInt64Array};
+use arrow::array::{
+    Array, Int32Array, Int64Array, MapArray, RecordBatch, StringArray, UInt16Array, UInt64Array,
+};
 use arrow::compute::concat_batches;
 use lru::LruCache;
 use once_cell::sync::OnceCell;
@@ -6,7 +8,7 @@ use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use parquet::file::statistics::Statistics;
 use s2::cellid::CellID;
 use std::fs::File;
-use std::num::{NonZeroU64, NonZeroUsize};
+use std::num::{NonZeroI32, NonZeroI64, NonZeroU64, NonZeroUsize};
 use std::ops::RangeInclusive;
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -321,10 +323,38 @@ fn extract_place(batch: &RecordBatch, row: usize) -> anyhow::Result<Place> {
     Ok(Place {
         s2_cell_id: get_u64_required(batch, "s2_cell_id", row)?,
         osm_id: get_u64_optional(batch, "osm_id", row)?.and_then(NonZeroU64::new),
+        osm_changeset: get_i64_optional(batch, "osm_changeset", row)?.and_then(NonZeroI64::new),
+        osm_version: get_i32_optional(batch, "osm_version", row)?.and_then(NonZeroI32::new),
         source: get_string_required(batch, "source", row)?,
         mask: MatchMask(get_u16_required(batch, "mask", row)?),
         tags: get_tags(batch, row)?,
     })
+}
+
+fn get_i32_optional(batch: &RecordBatch, name: &str, row: usize) -> anyhow::Result<Option<i32>> {
+    let col = match batch.column_by_name(name) {
+        None => return Ok(None),
+        Some(c) => c,
+    };
+    Ok(Some(
+        col.as_any()
+            .downcast_ref::<Int32Array>()
+            .ok_or_else(|| anyhow::anyhow!("column '{name}' exists but is not Int32"))?
+            .value(row),
+    ))
+}
+
+fn get_i64_optional(batch: &RecordBatch, name: &str, row: usize) -> anyhow::Result<Option<i64>> {
+    let col = match batch.column_by_name(name) {
+        None => return Ok(None),
+        Some(c) => c,
+    };
+    Ok(Some(
+        col.as_any()
+            .downcast_ref::<Int64Array>()
+            .ok_or_else(|| anyhow::anyhow!("column '{name}' exists but is not Int64"))?
+            .value(row),
+    ))
 }
 
 fn get_u64_required(batch: &RecordBatch, name: &str, row: usize) -> anyhow::Result<u64> {

--- a/src/places/writer.rs
+++ b/src/places/writer.rs
@@ -1,7 +1,10 @@
 use super::Place;
 use anyhow::{Ok, Result};
 use arrow::{
-    array::{ArrayRef, MapArray, StringArray, StructArray, UInt16Array, UInt64Array},
+    array::{
+        ArrayRef, Int32Array, Int64Array, MapArray, StringArray, StructArray, UInt16Array,
+        UInt64Array,
+    },
     buffer::OffsetBuffer,
     datatypes::{DataType, Field, Schema},
     record_batch::RecordBatch,
@@ -83,6 +86,24 @@ impl ParquetWriter {
                     }
                 },
             ))));
+            values.push(Arc::new(Int64Array::from_iter(self.places.iter().map(
+                |p| {
+                    if let Some(osm_changeset) = p.osm_changeset {
+                        osm_changeset.get()
+                    } else {
+                        0
+                    }
+                },
+            ))));
+            values.push(Arc::new(Int32Array::from_iter(self.places.iter().map(
+                |p| {
+                    if let Some(osm_version) = p.osm_version {
+                        osm_version.get()
+                    } else {
+                        0
+                    }
+                },
+            ))));
         } else {
             values.push(Arc::new(StringArray::from_iter_values(
                 self.places.iter().map(|p| p.source.as_str()),
@@ -156,6 +177,16 @@ fn make_schema(osm: bool) -> Schema {
         fields.push(Field::new(
             "osm_id",
             DataType::UInt64,
+            /* nullable */ false,
+        ));
+        fields.push(Field::new(
+            "osm_changeset",
+            DataType::Int64,
+            /* nullable */ false,
+        ));
+        fields.push(Field::new(
+            "osm_version",
+            DataType::Int32,
             /* nullable */ false,
         ));
     }


### PR DESCRIPTION
We may not actually need the changeset IDs; thanks to @CJ-Malone for noticing! Keeping them around for now, but will remove them again if they turn out to be unnecessary.

See https://pmtiles.io/#url=https%3A%2F%2Fcdn.diffed-places.org%2Fedits.pmtiles&inspectFeatures=true for the PMTiles file after this change.

https://github.com/alltheplaces/osm-diffs/issues/319