### PR TITLE
CI: Execute unit tests for merge queue

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 name: Tests
 
 on:
+  merge_group:
   push:
     branches: [ "main" ]
   pull_request:


### PR DESCRIPTION
Should not use branch filtering, according to advice from GitHub Copilot. https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue