### PR TITLE
Write Parquet file with output of conflation step

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2616,6 +2616,8 @@ version = "0.5.0"
 dependencies = [
  "anyhow",
  "arrow",
+ "arrow-buffer",
+ "arrow-schema",
  "assert_cmd",
  "aws-lc-rs",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2024"
 [dependencies]
 anyhow = "1.0.102"
 arrow = { version = "59.0.0", default-features = false }
+arrow-buffer = { version = "59.1.0", default-features = false }
+arrow-schema = { version = "59.1.0", default-features = false }
 aws-lc-rs = { version = "1.17.0", default-features = false }
 clap = { version = "4.6.1", default-features = false, features = ["derive", "std"] }
 deepsize = "0.2.0"

--- a/src/pipeline/conflate/mod.rs
+++ b/src/pipeline/conflate/mod.rs
@@ -147,15 +147,16 @@ fn write_conflated(
             .with_buffer(MemoryLimitedBufferBuilder::new(150_000_000))
             .build()?;
     let sorted = sorter.sort(cf.iter().map(|row| {
-        row_count.fetch_add(1, Ordering::SeqCst);
+        progress.set_length(row_count.fetch_add(1, Ordering::SeqCst));
         std::io::Result::Ok(row)
     }))?;
     progress.set_length(row_count.load(Ordering::SeqCst));
-    let mut writer = ParquetWriter::create(out)?;
+    let mut writer = ParquetWriter::create(out, /* max_rows_per_group */ 100_000)?;
     for row in sorted {
         writer.write(row?)?;
         progress.inc(1);
     }
     writer.close()?;
+    progress.finish();
     Ok(())
 }

--- a/src/pipeline/conflate/writer.rs
+++ b/src/pipeline/conflate/writer.rs
@@ -1,17 +1,44 @@
 use anyhow::{Ok, Result};
+use arrow::array::{
+    ArrayRef, RecordBatch, StructArray,
+    builder::{MapBuilder, MapFieldNames, StringBuilder, UInt32Builder, UInt64Builder},
+};
+use arrow_buffer::builder::NullBufferBuilder;
+use arrow_schema::{DataType, SchemaRef};
 use deepsize::DeepSizeOf;
+use parquet::{
+    arrow::{ArrowWriter, arrow_writer::ArrowWriterOptions},
+    file::properties::WriterProperties,
+};
 use serde::{Deserialize, Serialize};
 use std::{
+    fs::File,
     num::{NonZeroU32, NonZeroU64},
     path::{Path, PathBuf},
+    sync::Arc,
 };
 
 use super::ConflatedFeature;
 
 pub struct ParquetWriter {
-    #[allow(unused)]
     path: PathBuf,
+    tmp_path: PathBuf,
+    schema: SchemaRef,
+    writer: ArrowWriter<File>,
     last_s2_cell_id: u64,
+    rows_in_group: usize,
+    max_rows_per_group: usize,
+
+    atp_present: NullBufferBuilder,
+    atp_tags: MapBuilder<StringBuilder, StringBuilder>,
+    atp_spiders: StringBuilder,
+
+    osm_present: NullBufferBuilder,
+    osm_types: StringBuilder,
+    osm_ids: UInt64Builder,
+    osm_tags: MapBuilder<StringBuilder, StringBuilder>,
+    osm_changesets: UInt64Builder,
+    osm_versions: UInt32Builder,
 }
 
 /// A single row in the conflated parquet file.
@@ -38,21 +65,167 @@ pub struct ParquetRow {
 }
 
 impl ParquetWriter {
-    pub fn create(path: &Path) -> Result<ParquetWriter> {
+    pub fn create(path: &Path, max_rows_per_group: usize) -> Result<ParquetWriter> {
+        let mut tmp_path = PathBuf::from(path);
+        tmp_path.add_extension("tmp");
+        let schema = SchemaRef::new(schema::build_schema());
+        let properties = WriterProperties::builder()
+            .set_max_row_group_row_count(Some(max_rows_per_group))
+            .build(); // TODO: metadata
+        let options = ArrowWriterOptions::new().with_properties(properties);
+        let file = File::create(&tmp_path)?;
+        let writer = ArrowWriter::try_new_with_options(file, schema.clone(), options)?;
         Ok(ParquetWriter {
             path: PathBuf::from(path),
+            tmp_path,
+            schema,
+            writer,
             last_s2_cell_id: 0,
+            rows_in_group: 0,
+            max_rows_per_group,
+
+            atp_present: NullBufferBuilder::new(max_rows_per_group),
+            atp_tags: Self::new_key_value_map_builder(max_rows_per_group),
+            atp_spiders: StringBuilder::with_capacity(
+                /* item_capacity */ max_rows_per_group,
+                /* data_capacity */ 16 * 1024,
+            ),
+
+            osm_present: NullBufferBuilder::new(max_rows_per_group),
+            // TODO: Use dictionary instead of string for osm_types?
+            osm_types: StringBuilder::with_capacity(
+                /* item_capacity */
+                max_rows_per_group,
+                /* data_capacity */ 1024,
+            ),
+            osm_ids: UInt64Builder::with_capacity(max_rows_per_group),
+            osm_tags: Self::new_key_value_map_builder(max_rows_per_group),
+            osm_changesets: UInt64Builder::with_capacity(max_rows_per_group),
+            osm_versions: UInt32Builder::with_capacity(max_rows_per_group),
         })
+    }
+
+    fn new_key_value_map_builder(capacity: usize) -> MapBuilder<StringBuilder, StringBuilder> {
+        MapBuilder::with_capacity(
+            Some(MapFieldNames {
+                entry: String::from("key_value"),
+                key: String::from("key"),
+                value: String::from("value"),
+            }),
+            StringBuilder::with_capacity(
+                /* item_capacity */ capacity, /* data_capacity */ capacity,
+            ),
+            StringBuilder::with_capacity(
+                /* item_capacity */ capacity, /* data_capacity */ capacity,
+            ),
+            capacity,
+        )
     }
 
     pub fn write(&mut self, row: ParquetRow) -> Result<()> {
         let row_s2_cell_id = row.s2_cell_id.get();
         assert!(row_s2_cell_id >= self.last_s2_cell_id);
         self.last_s2_cell_id = row_s2_cell_id;
+        if self.rows_in_group >= self.max_rows_per_group {
+            self.write_row_group()?;
+        }
+
+        if let Some(atp_spider) = row.atp_spider {
+            self.atp_present.append_non_null();
+            for (key, value) in row.atp_tags.iter() {
+                self.atp_tags.keys().append_value(key);
+                self.atp_tags.values().append_value(value);
+            }
+            self.atp_tags.append(true)?;
+            self.atp_spiders.append_value(atp_spider);
+        } else {
+            self.atp_present.append_null();
+            self.atp_tags.append(false)?;
+            self.atp_spiders.append_value("");
+        }
+
+        if let Some(osm_id) = row.osm_id {
+            self.osm_present.append_non_null();
+            self.osm_types.append_value(match osm_id.get() % 10 {
+                1 => "node",
+                2 => "way",
+                3 => "relation",
+                _ => panic!("osm_id {} with unexpected last digit", osm_id.get()),
+            });
+            self.osm_ids.append_value(osm_id.get() / 10);
+            for (key, value) in row.osm_tags.iter() {
+                self.osm_tags.keys().append_value(key);
+                self.osm_tags.values().append_value(value);
+            }
+            self.osm_tags.append(true)?;
+
+            self.osm_changesets
+                .append_value(row.osm_changeset.expect("osm_changeset").get());
+            self.osm_versions
+                .append_value(row.osm_version.expect("osm_version").get());
+        } else {
+            self.osm_present.append_null();
+            self.osm_types.append_value("");
+            self.osm_ids.append_value(0);
+            self.osm_tags.append(false)?;
+            self.osm_changesets.append_value(0);
+            self.osm_versions.append_value(0);
+        }
+        self.rows_in_group += 1;
         Ok(())
     }
 
-    pub fn close(self) -> Result<()> {
+    pub fn close(mut self) -> Result<()> {
+        if self.rows_in_group > 0 {
+            self.write_row_group()?;
+        }
+        self.writer.close()?;
+        std::fs::rename(self.tmp_path, self.path)?;
+        Ok(())
+    }
+
+    fn write_row_group(&mut self) -> Result<()> {
+        let atp_fields = match self.schema.field_with_name("atp")?.data_type() {
+            DataType::Struct(fields) => fields,
+            _ => panic!("field \"atp\" must be DataType::Struct"),
+        };
+
+        let atp_struct = StructArray::try_new(
+            atp_fields.clone(),
+            vec![
+                Arc::new(self.atp_tags.finish()) as ArrayRef,
+                Arc::new(self.atp_spiders.finish()) as ArrayRef,
+            ],
+            self.atp_present.finish(),
+        )?;
+
+        let osm_fields = match self.schema.field_with_name("osm")?.data_type() {
+            DataType::Struct(fields) => fields,
+            _ => panic!("field \"osm\" must be DataType::Struct"),
+        };
+
+        let osm_struct = StructArray::try_new(
+            osm_fields.clone(),
+            vec![
+                Arc::new(self.osm_types.finish()) as ArrayRef,
+                Arc::new(self.osm_ids.finish()) as ArrayRef,
+                Arc::new(self.osm_tags.finish()) as ArrayRef,
+                Arc::new(self.osm_changesets.finish()) as ArrayRef,
+                Arc::new(self.osm_versions.finish()) as ArrayRef,
+            ],
+            self.osm_present.finish(),
+        )?;
+
+        let batch = RecordBatch::try_new(
+            self.schema.clone(),
+            vec![
+                Arc::new(atp_struct) as ArrayRef,
+                Arc::new(osm_struct) as ArrayRef,
+            ],
+        )?;
+
+        self.writer.write(&batch)?;
+        self.rows_in_group = 0;
         Ok(())
     }
 }
@@ -135,3 +308,45 @@ impl PartialEq for ParquetRow {
 }
 
 impl Eq for ParquetRow {}
+
+mod schema {
+    use arrow_schema::{DataType, Field, Schema};
+
+    const NOT_NULLABLE: bool = false;
+    const NULLABLE: bool = true;
+    const UNSORTED: bool = false;
+
+    pub fn build_schema() -> Schema {
+        let atp = Field::new_struct(
+            "atp",
+            vec![
+                new_key_value_field("tags"),
+                Field::new("spider", DataType::Utf8, NOT_NULLABLE),
+            ],
+            NULLABLE,
+        );
+        let osm = Field::new_struct(
+            "osm",
+            vec![
+                Field::new("type", DataType::Utf8, NOT_NULLABLE),
+                Field::new("id", DataType::UInt64, NOT_NULLABLE),
+                new_key_value_field("tags"),
+                Field::new("changeset", DataType::UInt64, NOT_NULLABLE),
+                Field::new("version", DataType::UInt32, NOT_NULLABLE),
+            ],
+            NULLABLE,
+        );
+        Schema::new(vec![atp, osm])
+    }
+
+    fn new_key_value_field(name: &str) -> Field {
+        Field::new_map(
+            name,
+            "key_value",
+            Field::new("key", DataType::Utf8, NOT_NULLABLE),
+            Field::new("value", DataType::Utf8, NULLABLE),
+            UNSORTED,
+            NOT_NULLABLE,
+        )
+    }
+}


### PR DESCRIPTION
Spatial properties (GeoParquet) will be added later.  Currently, we only write non-geoegraphic properties such as `atp.tags`, `atp.spider`, `osm.type` (one of `node`, `way` or `relation`), `osm.id`, `osm.tags`, `osm.changeset`, `osm.version`.

On a 2026 MacBook Air with 10 CPU cores, the conflation step of the pipeline takes 158 seconds, with 846.3 MB peak memory footprint. The output `conflated.parquet` file is 324.6 MB.

https://github.com/alltheplaces/osm-diffs/issues/315