### PR TITLE
Compress `conflated.parquet`

### DIFF
--- a/src/pipeline/conflate/writer.rs
+++ b/src/pipeline/conflate/writer.rs
@@ -8,6 +8,7 @@ use arrow_schema::{DataType, SchemaRef};
 use deepsize::DeepSizeOf;
 use parquet::{
     arrow::{ArrowWriter, arrow_writer::ArrowWriterOptions},
+    basic::{Compression, ZstdLevel},
     file::properties::WriterProperties,
 };
 use serde::{Deserialize, Serialize};
@@ -70,6 +71,7 @@ impl ParquetWriter {
         tmp_path.add_extension("tmp");
         let schema = SchemaRef::new(schema::build_schema());
         let properties = WriterProperties::builder()
+            .set_compression(Compression::ZSTD(ZstdLevel::try_new(22)?))
             .set_max_row_group_row_count(Some(max_rows_per_group))
             .build(); // TODO: metadata
         let options = ArrowWriterOptions::new().with_properties(properties);


### PR DESCRIPTION
The output `conflated.parquet` file is now 55.9 MB in size. This is only 17% of 324.6 MB, which was the size of the output before this change.

On a 2026 MacBook Air with 10 CPU cores, the conflation step of the pipeline now takes 271 seconds (before this change: 158 seconds), with 600.4 MB peak memory footprint (before: 846.3 MB).

https://github.com/alltheplaces/osm-diffs/issues/315