### PR TITLE
Write conflated output in GeoParquet format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1311,6 +1311,9 @@ name = "geo-traits"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e7c353d12a704ccfab1ba8bfb1a7fe6cb18b665bf89d37f4f7890edcd260206"
+dependencies = [
+ "geo-types",
+]
 
 [[package]]
 name = "geo-types"
@@ -2595,6 +2598,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2640,6 +2665,7 @@ dependencies = [
  "once_cell",
  "osm_pbf_iter",
  "parquet",
+ "parquet-geospatial",
  "piz",
  "predicates",
  "protobuf_iter",
@@ -2655,6 +2681,7 @@ dependencies = [
  "time",
  "tokio",
  "webpki-roots",
+ "wkb",
 ]
 
 [[package]]
@@ -2711,10 +2738,24 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
+ "parquet-geospatial",
  "paste",
  "seq-macro",
  "twox-hash",
  "zstd",
+]
+
+[[package]]
+name = "parquet-geospatial"
+version = "59.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2aabcf721f7e2c68a5528e57c7c1f741b781f07834260e885f34a025ae2164e3"
+dependencies = [
+ "arrow-schema",
+ "geo-traits",
+ "serde",
+ "serde_json",
+ "wkb",
 ]
 
 [[package]]
@@ -2821,6 +2862,15 @@ checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
 dependencies = [
  "predicates-core",
  "termtree",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -4085,6 +4135,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+dependencies = [
+ "indexmap 2.14.0",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4778,10 +4858,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wkb"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a120b336c7ad17749026d50427c23d838ecb50cd64aaea6254b5030152f890a9"
+dependencies = [
+ "byteorder",
+ "geo-traits",
+ "num_enum",
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,8 @@ lru = { version = "0.18.0", default-features = false }
 memmap2 = "0.9.10"
 once_cell = "1.21.4"
 osm_pbf_iter = { version = "0.2.2", default-features = false }
-parquet = { version = "59.0.0", default-features = false, features = ["arrow", "zstd"] }
+parquet = { version = "59.0.0", default-features = false, features = ["arrow", "geospatial", "zstd"] }
+parquet-geospatial = { version = "59.1.0", default-features = false }
 piz = "0.5.1"
 protobuf_iter = { version = "0.1.3", default-features = false }
 rayon = "1.12.0"
@@ -35,11 +36,12 @@ rustls = { version = "0.23.40", default-features = false, features = ["aws_lc_rs
 s2 = "0.1.0"
 s3 = { version = "0.1.36", default-features = false, features = ["blocking", "multipart", "rustls"] }
 serde = "1.0.228"
-serde_json = "1.0.150"
+serde_json = { version = "1.0.150", default-features = false, features = ["std"] }
 tempfile = "3.27.0"
 time = { version = "0.3.53", default-features = false, features = ["formatting", "parsing", "std"] }
 tokio = { version = "1.52.3", default-features = false }
 webpki-roots = "1.0.6"
+wkb = { version = "0.9.2", default-features = false }
 
 [dev-dependencies]
 assert_cmd = "2.2.2"

--- a/src/pipeline/conflate/mod.rs
+++ b/src/pipeline/conflate/mod.rs
@@ -118,13 +118,8 @@ fn produce_rows(
                 }
             }
 
-            // TODO: Once we support relations, always send rows,
-            // even if we could not find a matching feature in OSM.
-            // https://github.com/alltheplaces/osm-diffs/issues/187
-            if conflated.osm.is_some() {
-                let row = ParquetRow::try_from(conflated)?;
-                out.send(row)?;
-            }
+            let row = ParquetRow::try_from(conflated)?;
+            out.send(row)?;
 
             Ok(())
         })?;
@@ -151,7 +146,7 @@ fn write_conflated(
         std::io::Result::Ok(row)
     }))?;
     progress.set_length(row_count.load(Ordering::SeqCst));
-    let mut writer = ParquetWriter::create(out, /* max_rows_per_group */ 100_000)?;
+    let mut writer = ParquetWriter::create(out, /* max_rows_per_group */ 200_000)?;
     for row in sorted {
         writer.write(row?)?;
         progress.inc(1);

--- a/src/pipeline/conflate/writer.rs
+++ b/src/pipeline/conflate/writer.rs
@@ -1,7 +1,9 @@
 use anyhow::{Ok, Result};
 use arrow::array::{
     ArrayRef, RecordBatch, StructArray,
-    builder::{MapBuilder, MapFieldNames, StringBuilder, UInt32Builder, UInt64Builder},
+    builder::{
+        BinaryBuilder, MapBuilder, MapFieldNames, StringBuilder, UInt32Builder, UInt64Builder,
+    },
 };
 use arrow_buffer::builder::NullBufferBuilder;
 use arrow_schema::{DataType, SchemaRef};
@@ -33,6 +35,7 @@ pub struct ParquetWriter {
     atp_present: NullBufferBuilder,
     atp_tags: MapBuilder<StringBuilder, StringBuilder>,
     atp_spiders: StringBuilder,
+    atp_geometries: BinaryBuilder,
 
     osm_present: NullBufferBuilder,
     osm_types: StringBuilder,
@@ -40,6 +43,9 @@ pub struct ParquetWriter {
     osm_tags: MapBuilder<StringBuilder, StringBuilder>,
     osm_changesets: UInt64Builder,
     osm_versions: UInt32Builder,
+    osm_geometries: BinaryBuilder,
+
+    geometries: BinaryBuilder,
 }
 
 /// A single row in the conflated parquet file.
@@ -61,8 +67,11 @@ pub struct ParquetRow {
     osm_changeset: Option<NonZeroU64>,
     osm_version: Option<NonZeroU32>,
     osm_tags: Vec<(String, String)>,
+    osm_shape_wkb: Vec<u8>,
+
     atp_spider: Option<String>,
     atp_tags: Vec<(String, String)>,
+    atp_shape_wkb: Vec<u8>,
 }
 
 impl ParquetWriter {
@@ -73,7 +82,8 @@ impl ParquetWriter {
         let properties = WriterProperties::builder()
             .set_compression(Compression::ZSTD(ZstdLevel::try_new(22)?))
             .set_max_row_group_row_count(Some(max_rows_per_group))
-            .build(); // TODO: metadata
+            .set_bloom_filter_enabled(true)
+            .build();
         let options = ArrowWriterOptions::new().with_properties(properties);
         let file = File::create(&tmp_path)?;
         let writer = ArrowWriter::try_new_with_options(file, schema.clone(), options)?;
@@ -93,6 +103,12 @@ impl ParquetWriter {
                 /* data_capacity */ 16 * 1024,
             ),
 
+            // Most ATP geometries are points, which need 21 bytes in WKB encoding.
+            atp_geometries: BinaryBuilder::with_capacity(
+                /* item_capacity */ max_rows_per_group,
+                /* data_capacity */ max_rows_per_group * 21,
+            ),
+
             osm_present: NullBufferBuilder::new(max_rows_per_group),
             // TODO: Use dictionary instead of string for osm_types?
             osm_types: StringBuilder::with_capacity(
@@ -104,6 +120,18 @@ impl ParquetWriter {
             osm_tags: Self::new_key_value_map_builder(max_rows_per_group),
             osm_changesets: UInt64Builder::with_capacity(max_rows_per_group),
             osm_versions: UInt32Builder::with_capacity(max_rows_per_group),
+
+            // Many OSM geometries are points, which need 21 bytes in WKB encoding.
+            osm_geometries: BinaryBuilder::with_capacity(
+                /* item_capacity */ max_rows_per_group,
+                /* data_capacity */ max_rows_per_group * 21,
+            ),
+
+            // Most geometries are points, which need 21 bytes in WKB encoding.
+            geometries: BinaryBuilder::with_capacity(
+                /* item_capacity */ max_rows_per_group,
+                /* data_capacity */ max_rows_per_group * 21,
+            ),
         })
     }
 
@@ -140,10 +168,12 @@ impl ParquetWriter {
             }
             self.atp_tags.append(true)?;
             self.atp_spiders.append_value(atp_spider);
+            self.atp_geometries.append_value(&row.atp_shape_wkb);
         } else {
             self.atp_present.append_null();
             self.atp_tags.append(false)?;
             self.atp_spiders.append_value("");
+            self.atp_geometries.append_null();
         }
 
         if let Some(osm_id) = row.osm_id {
@@ -155,6 +185,7 @@ impl ParquetWriter {
                 _ => panic!("osm_id {} with unexpected last digit", osm_id.get()),
             });
             self.osm_ids.append_value(osm_id.get() / 10);
+
             for (key, value) in row.osm_tags.iter() {
                 self.osm_tags.keys().append_value(key);
                 self.osm_tags.values().append_value(value);
@@ -165,6 +196,7 @@ impl ParquetWriter {
                 .append_value(row.osm_changeset.expect("osm_changeset").get());
             self.osm_versions
                 .append_value(row.osm_version.expect("osm_version").get());
+            self.osm_geometries.append_value(&row.osm_shape_wkb);
         } else {
             self.osm_present.append_null();
             self.osm_types.append_value("");
@@ -172,7 +204,17 @@ impl ParquetWriter {
             self.osm_tags.append(false)?;
             self.osm_changesets.append_value(0);
             self.osm_versions.append_value(0);
+            self.osm_geometries.append_null();
         }
+
+        if !row.osm_shape_wkb.is_empty() {
+            self.geometries.append_value(&row.osm_shape_wkb);
+        } else if !row.atp_shape_wkb.is_empty() {
+            self.geometries.append_value(&row.atp_shape_wkb);
+        } else {
+            self.geometries.append_null();
+        }
+
         self.rows_in_group += 1;
         Ok(())
     }
@@ -197,6 +239,7 @@ impl ParquetWriter {
             vec![
                 Arc::new(self.atp_tags.finish()) as ArrayRef,
                 Arc::new(self.atp_spiders.finish()) as ArrayRef,
+                Arc::new(self.atp_geometries.finish()) as ArrayRef,
             ],
             self.atp_present.finish(),
         )?;
@@ -214,6 +257,7 @@ impl ParquetWriter {
                 Arc::new(self.osm_tags.finish()) as ArrayRef,
                 Arc::new(self.osm_changesets.finish()) as ArrayRef,
                 Arc::new(self.osm_versions.finish()) as ArrayRef,
+                Arc::new(self.osm_geometries.finish()) as ArrayRef,
             ],
             self.osm_present.finish(),
         )?;
@@ -223,6 +267,7 @@ impl ParquetWriter {
             vec![
                 Arc::new(atp_struct) as ArrayRef,
                 Arc::new(osm_struct) as ArrayRef,
+                Arc::new(self.geometries.finish()) as ArrayRef,
             ],
         )?;
 
@@ -234,6 +279,7 @@ impl ParquetWriter {
 
 impl TryFrom<ConflatedFeature> for ParquetRow {
     type Error = anyhow::Error;
+
     fn try_from(cf: ConflatedFeature) -> Result<Self, Self::Error> {
         let atp = cf.atp;
         let osm = cf.osm;
@@ -249,11 +295,14 @@ impl TryFrom<ConflatedFeature> for ParquetRow {
         };
 
         let atp_spider;
+        let atp_shape_wkb;
         let atp_tags;
         if let Some(atp) = atp {
+            atp_shape_wkb = wkb(&atp.shape());
             atp_spider = Some(atp.source);
             atp_tags = atp.tags;
         } else {
+            atp_shape_wkb = Vec::with_capacity(0);
             atp_spider = None;
             atp_tags = Vec::with_capacity(0);
         };
@@ -261,16 +310,19 @@ impl TryFrom<ConflatedFeature> for ParquetRow {
         let osm_id;
         let osm_changeset;
         let osm_version;
+        let osm_shape_wkb;
         let osm_tags;
         if let Some(osm) = osm {
             osm_id = osm.osm_id;
             osm_changeset = osm.osm_changeset;
             osm_version = osm.osm_version;
+            osm_shape_wkb = wkb(&osm.shape());
             osm_tags = osm.tags;
         } else {
             osm_id = None;
             osm_changeset = None;
             osm_version = None;
+            osm_shape_wkb = Vec::with_capacity(0);
             osm_tags = Vec::with_capacity(0);
         };
 
@@ -278,10 +330,12 @@ impl TryFrom<ConflatedFeature> for ParquetRow {
             s2_cell_id,
             atp_spider,
             atp_tags,
+            atp_shape_wkb,
             osm_id,
             osm_changeset,
             osm_version,
             osm_tags,
+            osm_shape_wkb,
         })
     }
 }
@@ -311,8 +365,19 @@ impl PartialEq for ParquetRow {
 
 impl Eq for ParquetRow {}
 
+fn wkb(shape: &geo::Geometry<f64>) -> Vec<u8> {
+    // Most of our features have point geometry, which uses 21 bytes in WKB encoding.
+    let mut buf = Vec::<u8>::with_capacity(21);
+    let opts = wkb::writer::WriteOptions {
+        endianness: wkb::Endianness::LittleEndian,
+    };
+    wkb::writer::write_geometry(&mut buf, shape, &opts).expect("wkb encoding failed");
+    buf
+}
+
 mod schema {
     use arrow_schema::{DataType, Field, Schema};
+    use parquet_geospatial::{WkbEdges, WkbMetadata, WkbType};
 
     const NOT_NULLABLE: bool = false;
     const NULLABLE: bool = true;
@@ -324,9 +389,11 @@ mod schema {
             vec![
                 new_key_value_field("tags"),
                 Field::new("spider", DataType::Utf8, NOT_NULLABLE),
+                new_geo_field("geometry", NOT_NULLABLE),
             ],
             NULLABLE,
         );
+
         let osm = Field::new_struct(
             "osm",
             vec![
@@ -335,10 +402,13 @@ mod schema {
                 new_key_value_field("tags"),
                 Field::new("changeset", DataType::UInt64, NOT_NULLABLE),
                 Field::new("version", DataType::UInt32, NOT_NULLABLE),
+                new_geo_field("geometry", NOT_NULLABLE),
             ],
             NULLABLE,
         );
-        Schema::new(vec![atp, osm])
+
+        let geometry = new_geo_field("geometry", NOT_NULLABLE);
+        Schema::new(vec![atp, osm, geometry])
     }
 
     fn new_key_value_field(name: &str) -> Field {
@@ -350,5 +420,11 @@ mod schema {
             UNSORTED,
             NOT_NULLABLE,
         )
+    }
+
+    fn new_geo_field(name: &str, nullable: bool) -> Field {
+        let metadata = WkbMetadata::new(Some("EPSG:4326"), Some(WkbEdges::Spherical));
+        Field::new(name, DataType::Binary, nullable)
+            .with_extension_type(WkbType::new(Some(metadata)))
     }
 }

--- a/src/pipeline/geostats.rs
+++ b/src/pipeline/geostats.rs
@@ -1,0 +1,49 @@
+use anyhow::{Ok, Result};
+use parquet::{
+    basic::LogicalType,
+    geospatial::accumulator::{
+        GeoStatsAccumulator, GeoStatsAccumulatorFactory, ParquetGeoStatsAccumulator,
+        VoidGeoStatsAccumulator, init_geo_stats_accumulator_factory,
+    },
+    schema::types::ColumnDescPtr,
+};
+use std::sync::Arc;
+
+// As of Apache Parquet version 59.0, geospatial statistics ony get
+// computed for GEOMETRY fields, whose coordinates are in a projected,
+// rectangular reference system.  For GEOGRAPHY fields, whose
+// coordinates are in a (unprojected) spherical reference system,
+// Parquet computes no GeoStats. Their bounding box computation simply
+// takes the min/max of every x/y; this gives wrong results for shapes
+// that cross the poles or the anti-meridian. As we’re already using
+// the S2 library for spherical geometry, we could relatively easily
+// implement a GeoStats callback that does computation this
+// properly. However, this particular part of the Rust port of S2 is
+// not implemented yet. Therefore, we cheat by invoking the
+// Parquet-supplied GeoStats accumulator also for GEOGRAPHY fields
+// with spherical coordinates. In practice, neither AllThePlaces nor
+// OpenStreetMap contain any gas stations or hotels whose shapes cross
+// the poles, so this is not a major problem for us.
+//
+// Apache Parquet was originally written in Java, and it clearly shows
+// also in its Rust interface. Well, the API of Apache Parquet is
+// what it is; greetings from Java land. For a proposal to remove
+// this global state, which would require an API change to Apache
+// Parquet, see https://github.com/apache/arrow-rs/issues/10312.
+struct CustomGeoStatsAccumulatorFactory {}
+
+impl GeoStatsAccumulatorFactory for CustomGeoStatsAccumulatorFactory {
+    fn new_accumulator(&self, desc: &ColumnDescPtr) -> Box<dyn GeoStatsAccumulator> {
+        match desc.logical_type_ref() {
+            Some(LogicalType::Geography { .. }) => Box::new(ParquetGeoStatsAccumulator::default()),
+            Some(LogicalType::Geometry { .. }) => Box::new(ParquetGeoStatsAccumulator::default()),
+            _ => Box::new(VoidGeoStatsAccumulator::default()),
+        }
+    }
+}
+
+pub fn init() -> Result<()> {
+    let factory = Arc::new(CustomGeoStatsAccumulatorFactory {});
+    init_geo_stats_accumulator_factory(factory)?;
+    Ok(())
+}

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -3,6 +3,7 @@ use std::{path::Path, time::SystemTime};
 
 mod conflate;
 mod edits;
+mod geostats;
 mod tiles;
 mod upload;
 
@@ -11,6 +12,7 @@ pub fn run_pipeline(http_client: &reqwest::Client, workdir: &Path) -> Result<()>
         std::fs::create_dir(workdir)?;
     }
 
+    geostats::init()?;
     let progress = indicatif::MultiProgress::new();
     let atp = tokio::runtime::Builder::new_multi_thread()
         .enable_all()

--- a/src/places/mod.rs
+++ b/src/places/mod.rs
@@ -57,6 +57,14 @@ impl Place {
         }
     }
 
+    pub fn shape(&self) -> geo::Geometry<f64> {
+        let s2_cell_id = s2::cellid::CellID(self.s2_cell_id);
+        let lat_lon = s2::latlng::LatLng::from(s2_cell_id);
+        let rounded_lon = (lat_lon.lng.deg() * 1e7).round() / 1e7;
+        let rounded_lat = (lat_lon.lat.deg() * 1e7).round() / 1e7;
+        geo::Geometry::from(geo::Point::<f64>::new(rounded_lon, rounded_lat))
+    }
+
     pub fn to_geojson(&self) -> geojson::Feature {
         let s2_cell_id = s2::cellid::CellID(self.s2_cell_id);
         let lat_lon = s2::latlng::LatLng::from(s2_cell_id);
@@ -190,5 +198,26 @@ mod tests {
         assert_eq!(a.eq(&a), true);
         assert_eq!(a.cmp(&b), a.s2_cell_id.cmp(&b.s2_cell_id));
         assert_eq!(a.partial_cmp(&b), a.s2_cell_id.partial_cmp(&b.s2_cell_id));
+    }
+
+    #[test]
+    fn test_shape() {
+        let place = Place::new(
+            &Coord {
+                x: 7.4478123,
+                y: 46.9479801,
+            },
+            "test/source".to_string(),
+            MatchMask::SHOP,
+            vec![],
+        )
+        .unwrap();
+        let shape = place.shape();
+        if let geo::Geometry::Point(p) = shape {
+            assert_eq!(p.x(), 7.4478123);
+            assert_eq!(p.y(), 46.9479801);
+        } else {
+            assert!(false, "expected a point, got {:?}", shape);
+        };
     }
 }


### PR DESCRIPTION
The output `conflated.parquet` file is now 149.7 MB in size.

On a 2026 MacBook Air with 10 CPU cores, the conflation step of the pipeline now takes 252 seconds, with 2.226 GB peak memory footprint. The large memory footprint is mostly due to the increased row group size, but it seems still acceptable. If it is a problem, we can reduce the row group size again.

https://github.com/alltheplaces/osm-diffs/issues/315