### PR TITLE
Expose OpenStreetMap FeatureStore to conflate step

### DIFF
--- a/src/pipeline/conflate/mod.rs
+++ b/src/pipeline/conflate/mod.rs
@@ -2,6 +2,7 @@ use super::last_modified;
 use crate::{
     make_progress_bar,
     matchers::{create_matcher, match_distance},
+    pipeline::osm::FeatureStore,
     places::{Place, PlaceIndex},
     s2_util::MergedCellRanges,
 };
@@ -26,6 +27,7 @@ pub fn conflate(
     atp: &Path,
     coverage: &Path,
     osm: &Path,
+    osm_store: &dyn FeatureStore,
     progress: &MultiProgress,
     workdir: &Path,
 ) -> Result<PathBuf> {
@@ -47,8 +49,13 @@ pub fn conflate(
     thread::scope(|s| {
         let (tx, rx) = sync_channel::<ParquetRow>(8192);
         s.spawn(|| {
-            producer_result =
-                produce_rows(atp_index.clone(), osm_index.clone(), producer_progress, tx);
+            producer_result = produce_rows(
+                atp_index.clone(),
+                osm_index.clone(),
+                osm_store,
+                producer_progress,
+                tx,
+            );
         });
         s.spawn(|| {
             writer_result = write_conflated(rx, writer_progress, workdir, &out_path);
@@ -70,6 +77,7 @@ struct ConflatedFeature {
 fn produce_rows(
     atp_index: Arc<PlaceIndex>,
     osm_index: Arc<PlaceIndex>,
+    osm_store: &dyn FeatureStore,
     progress_bar: ProgressBar,
     out: SyncSender<ParquetRow>,
 ) -> Result<()> {
@@ -118,7 +126,22 @@ fn produce_rows(
                 }
             }
 
+            // TODO: Use a custom function instead of try_from, so we
+            // can pass a reference to FeatureStore to extract the
+            // geometry (and any other attributes not needed for
+            // matching).
             let row = ParquetRow::try_from(conflated)?;
+            if let Some(row_osm_id) = row.osm_id {
+                let osm_id = row_osm_id.get() / 10;
+                let osm_type = row_osm_id.get() % 10;
+                // TODO: Implement FeatureStore::get_node/get_way, call it.
+                match osm_type {
+                    1 => if let Some(_node) = osm_store.get_nth_node(osm_id) {},
+                    2 => if let Some(_way) = osm_store.get_nth_way(osm_id) {},
+                    // 3 => if let Some(_way) = osm_store.get_relation(osm_id) {},
+                    _ => {}
+                };
+            };
             out.send(row)?;
 
             Ok(())

--- a/src/pipeline/conflate/writer.rs
+++ b/src/pipeline/conflate/writer.rs
@@ -62,7 +62,7 @@ pub struct ParquetRow {
     /// performance with geographic Parquet files.
     s2_cell_id: NonZeroU64,
 
-    osm_id: Option<NonZeroU64>,
+    pub osm_id: Option<NonZeroU64>,
     osm_changeset: Option<NonZeroU64>,
     osm_version: Option<NonZeroU32>,
     osm_tags: Vec<(String, String)>,

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -20,9 +20,16 @@ pub fn run_pipeline(http_client: &reqwest::Client, workdir: &Path) -> Result<()>
         .build()?
         .block_on(crate::atp::import_atp(http_client, &progress, workdir))?;
     let coverage = crate::coverage::build_coverage(&atp, &progress, workdir)?;
-    let osm = osm::import_osm(&coverage, &progress, workdir)?;
-    let _conflated = conflate::conflate(&atp, &coverage, &osm, &progress, workdir)?;
-    let edits = edits::suggest_edits(&coverage, &atp, &osm, &progress, workdir)?;
+    let (osm_parquet, osm_store) = osm::import_osm(&coverage, &progress, workdir)?;
+    let _conflated = conflate::conflate(
+        &atp,
+        &coverage,
+        &osm_parquet,
+        &*osm_store,
+        &progress,
+        workdir,
+    )?;
+    let edits = edits::suggest_edits(&coverage, &atp, &osm_parquet, &progress, workdir)?;
     let tiles = tiles::render_tiles(&edits, &progress, workdir)?;
     upload::upload_tiles(&tiles, &progress)?;
 

--- a/src/pipeline/osm/filter.rs
+++ b/src/pipeline/osm/filter.rs
@@ -18,22 +18,35 @@ use std::thread;
 use filtered_file::FilteredFile;
 
 pub struct FilteredFeatureStore<'a> {
-    nodes: &'a FilteredFile<'a>,
-    ways: &'a FilteredFile<'a>,
-    relations: &'a FilteredFile<'a>,
+    nodes: FilteredFile<'a>,
+    ways: FilteredFile<'a>,
+    relations: FilteredFile<'a>,
 }
 
 impl<'a> FilteredFeatureStore<'a> {
     pub fn new(
-        nodes: &'a FilteredFile<'a>,
-        ways: &'a FilteredFile<'a>,
-        relations: &'a FilteredFile<'a>,
+        nodes: FilteredFile<'a>,
+        ways: FilteredFile<'a>,
+        relations: FilteredFile<'a>,
     ) -> FilteredFeatureStore<'a> {
         FilteredFeatureStore {
             nodes,
             ways,
             relations,
         }
+    }
+
+    pub fn exists(workdir: &Path) -> bool {
+        workdir.join("osm-filtered-nodes").exists()
+            && workdir.join("osm-filtered-ways").exists()
+            && workdir.join("osm-filtered-relations").exists()
+    }
+
+    pub fn open(workdir: &Path) -> Result<FilteredFeatureStore<'a>> {
+        let nodes = FilteredFile::open(&workdir.join("osm-filtered-nodes"))?;
+        let ways = FilteredFile::open(&workdir.join("osm-filtered-ways"))?;
+        let relations = FilteredFile::open(&workdir.join("osm-filtered-relations"))?;
+        Ok(Self::new(nodes, ways, relations))
     }
 }
 

--- a/src/pipeline/osm/mod.rs
+++ b/src/pipeline/osm/mod.rs
@@ -20,13 +20,19 @@ mod coords;
 mod cover;
 mod fetch;
 mod filter;
+use filter::FilteredFeatureStore;
 
-pub fn import_osm(coverage: &Path, progress: &MultiProgress, workdir: &Path) -> Result<PathBuf> {
+pub fn import_osm(
+    coverage: &Path,
+    progress: &MultiProgress,
+    workdir: &Path,
+) -> Result<(PathBuf, Box<dyn FeatureStore>)> {
     assert!(workdir.exists());
 
     let out_path = workdir.join("osm.parquet");
-    if out_path.exists() {
-        return Ok(out_path);
+    if out_path.exists() && FilteredFeatureStore::exists(workdir) {
+        let store = FilteredFeatureStore::open(workdir)?;
+        return Ok((out_path, Box::new(store)));
     }
 
     let pbf = fetch::fetch_planet(progress, workdir)?;
@@ -90,14 +96,14 @@ pub fn import_osm(coverage: &Path, progress: &MultiProgress, workdir: &Path) -> 
         workdir,
     )?;
 
-    let feature_store = filter::FilteredFeatureStore::new(&nodes, &ways, &relations);
+    let feature_store = filter::FilteredFeatureStore::new(nodes, ways, relations);
     assemble::assemble(&feature_store, progress, workdir, &out_path)?;
 
-    Ok(out_path)
+    Ok((out_path, Box::new(feature_store)))
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-struct Node {
+pub struct Node {
     id: u64,
     changeset: Option<NonZeroU64>,
     version: Option<NonZeroU32>,
@@ -107,7 +113,7 @@ struct Node {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-struct Way {
+pub struct Way {
     id: u64,
     changeset: Option<NonZeroU64>,
     version: Option<NonZeroU32>,
@@ -116,7 +122,7 @@ struct Way {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-struct Relation {
+pub struct Relation {
     id: u64,
     changeset: Option<NonZeroU64>,
     version: Option<NonZeroU32>,
@@ -151,7 +157,7 @@ enum RelationMember {
 
 /// Abstracts OSM feature retrieval, so the geometry logic is independent of the storage.
 /// Implemented by MockFeatureStore for testing, and FilteredFeatureStore in production.
-trait FeatureStore: Send + Sync {
+pub trait FeatureStore: Send + Sync {
     fn node_count(&self) -> u64;
     fn way_count(&self) -> u64;
     fn relation_count(&self) -> u64;


### PR DESCRIPTION
On a 2026 MacBook Air with 10 CPU cores, the conflation step of the pipeline now takes 242 seconds, with 2.0 GB peak memory footprint. No change in output (for the time being), so the file size stays the same.

https://github.com/alltheplaces/osm-diffs/issues/315