### PR TITLE
Retrieve OpenStreetMap features in conflation step

### DIFF
--- a/src/pipeline/conflate/mod.rs
+++ b/src/pipeline/conflate/mod.rs
@@ -134,11 +134,13 @@ fn produce_rows(
             if let Some(row_osm_id) = row.osm_id {
                 let osm_id = row_osm_id.get() / 10;
                 let osm_type = row_osm_id.get() % 10;
-                // TODO: Implement FeatureStore::get_node/get_way, call it.
                 match osm_type {
-                    1 => if let Some(_node) = osm_store.get_nth_node(osm_id) {},
-                    2 => if let Some(_way) = osm_store.get_nth_way(osm_id) {},
-                    // 3 => if let Some(_way) = osm_store.get_relation(osm_id) {},
+                    // TODO: Currently, we only get some result for ways.
+                    // Change the osm.filter step of the pipeline to construct
+                    // feature_index also for nodes and relations.
+                    1 => if let Some(_node) = osm_store.get_node(osm_id) {},
+                    2 => if let Some(_way) = osm_store.get_way(osm_id) {},
+                    3 => if let Some(_relation) = osm_store.get_relation(osm_id) {},
                     _ => {}
                 };
             };

--- a/src/pipeline/osm/filter.rs
+++ b/src/pipeline/osm/filter.rs
@@ -51,6 +51,18 @@ impl<'a> FilteredFeatureStore<'a> {
 }
 
 impl<'a> FeatureStore for FilteredFeatureStore<'a> {
+    fn get_node(&self, id: u64) -> Option<Node> {
+        self.get_nth_node(self.nodes.feature_index(id)?)
+    }
+
+    fn get_way(&self, id: u64) -> Option<Way> {
+        self.get_nth_way(self.ways.feature_index(id)?)
+    }
+
+    fn get_relation(&self, id: u64) -> Option<Relation> {
+        self.get_nth_relation(self.relations.feature_index(id)?)
+    }
+
     fn node_count(&self) -> u64 {
         self.nodes.feature_count() as u64
     }
@@ -850,7 +862,6 @@ pub mod filtered_file {
             Some(&self.feature_data[start..limit])
         }
 
-        #[allow(unused)] // TODO: Remove attribute once we use this in production code.
         pub fn feature_index(&self, id: u64) -> Option<u64> {
             let index = if cfg!(target_endian = "little") {
                 self.feature_index_keys.binary_search(&id)

--- a/src/pipeline/osm/mod.rs
+++ b/src/pipeline/osm/mod.rs
@@ -158,6 +158,10 @@ enum RelationMember {
 /// Abstracts OSM feature retrieval, so the geometry logic is independent of the storage.
 /// Implemented by MockFeatureStore for testing, and FilteredFeatureStore in production.
 pub trait FeatureStore: Send + Sync {
+    fn get_node(&self, id: u64) -> Option<Node>;
+    fn get_way(&self, id: u64) -> Option<Way>;
+    fn get_relation(&self, id: u64) -> Option<Relation>;
+
     fn node_count(&self) -> u64;
     fn way_count(&self) -> u64;
     fn relation_count(&self) -> u64;
@@ -170,10 +174,6 @@ pub trait FeatureStore: Send + Sync {
     // https://github.com/alltheplaces/osm-diffs/issues/187
     #[allow(unused)]
     fn get_nth_relation(&self, n: u64) -> Option<Relation>;
-
-    //fn get_node(&self, id: u64) -> Option<Node>;
-    //fn get_way(&self, id: u64) -> Option<Way>;
-    //fn get_relation(&self, id: u64) -> Option<Relation>;
 }
 
 fn read_blobs<R: Read + Seek + Send>(
@@ -486,6 +486,30 @@ mod tests {
     }
 
     impl FeatureStore for MockFeatureStore {
+        fn get_node(&self, id: u64) -> Option<Node> {
+            if let Some(node) = self.nodes.get(&id) {
+                Some(node.clone())
+            } else {
+                None
+            }
+        }
+
+        fn get_way(&self, id: u64) -> Option<Way> {
+            if let Some(way) = self.ways.get(&id) {
+                Some(way.clone())
+            } else {
+                None
+            }
+        }
+
+        fn get_relation(&self, id: u64) -> Option<Relation> {
+            if let Some(relation) = self.relations.get(&id) {
+                Some(relation.clone())
+            } else {
+                None
+            }
+        }
+
         fn node_count(&self) -> u64 {
             self.nodes.len() as u64
         }


### PR DESCRIPTION
On a 2026 MacBook Air with 10 CPU cores, the conflation step of the pipeline now takes 250 seconds, with 1.4 GB peak memory footprint.

https://github.com/alltheplaces/osm-diffs/issues/315