### PR TITLE
Refactoring: Don’t leave partially created `U64Tables` around

### DIFF
--- a/src/pipeline/osm/cover.rs
+++ b/src/pipeline/osm/cover.rs
@@ -5,7 +5,6 @@ use indicatif::MultiProgress;
 use osm_pbf_iter::{Blob, Primitive, PrimitiveBlock, RelationMemberType};
 use rayon::prelude::*;
 use std::collections::HashMap;
-use std::fs::rename;
 use std::io::{Read, Seek};
 use std::path::Path;
 use std::sync::mpsc::sync_channel;
@@ -27,9 +26,6 @@ pub fn cover_nodes<R: Read + Seek + Send>(
     if out.exists() {
         return Ok(U64Table::open(&out)?);
     }
-
-    let mut tmp = out.clone();
-    tmp.add_extension("tmp");
 
     let mut num_covered_nodes = 0;
     thread::scope(|s| {
@@ -60,7 +56,7 @@ pub fn cover_nodes<R: Read + Seek + Send>(
         });
 
         let writer = s.spawn(|| {
-            num_covered_nodes = u64_table::create(node_rx, workdir, &tmp)?;
+            num_covered_nodes = u64_table::create(node_rx, workdir, &out)?;
             Ok(())
         });
 
@@ -70,7 +66,6 @@ pub fn cover_nodes<R: Read + Seek + Send>(
         Ok(())
     })?;
 
-    rename(&tmp, &out)?;
     progress_bar.finish_with_message(format!("blobs → {} nodes", num_covered_nodes));
 
     Ok(U64Table::open(&out)?)
@@ -83,8 +78,6 @@ pub fn cover_ways<R: Read + Seek + Send>(
     workdir: &Path,
 ) -> Result<U64Table> {
     let out = workdir.join("covered-ways");
-    let mut tmp = out.clone();
-    tmp.add_extension("tmp");
     if out.exists() {
         return Ok(U64Table::open(&out)?);
     }
@@ -129,7 +122,7 @@ pub fn cover_ways<R: Read + Seek + Send>(
 
         // Thread to sort way ids and write the resulting table to the working directory.
         let writer = s.spawn(|| {
-            num_covered_ways = crate::u64_table::create(way_rx, workdir, &tmp)?;
+            num_covered_ways = crate::u64_table::create(way_rx, workdir, &out)?;
             Ok(())
         });
 
@@ -139,7 +132,6 @@ pub fn cover_ways<R: Read + Seek + Send>(
         Ok(())
     })?;
 
-    rename(&tmp, &out)?;
     progress_bar.finish_with_message(format!("blobs → {} ways", num_covered_ways));
     Ok(U64Table::open(&out)?)
 }
@@ -155,8 +147,6 @@ pub fn cover_relations<R: Read + Seek + Send>(
     workdir: &Path,
 ) -> Result<U64Table> {
     let out = workdir.join("covered-relations");
-    let mut tmp = out.clone();
-    tmp.add_extension("tmp");
     if out.exists() {
         return Ok(U64Table::open(&out)?);
     }
@@ -225,7 +215,7 @@ pub fn cover_relations<R: Read + Seek + Send>(
 
         // Thread to sort way ids and write the resulting table to the working directory.
         let writer = s.spawn(|| {
-            num_relations = crate::u64_table::create(rel_rx, workdir, &tmp)?;
+            num_relations = crate::u64_table::create(rel_rx, workdir, &out)?;
             Ok(())
         });
 
@@ -235,7 +225,6 @@ pub fn cover_relations<R: Read + Seek + Send>(
         Ok(())
     })?;
 
-    rename(&tmp, &out)?;
     progress_bar.finish_with_message(format!("blobs → {} relations", num_relations));
     Ok(U64Table::open(&out)?)
 }

--- a/src/pipeline/osm/prune.rs
+++ b/src/pipeline/osm/prune.rs
@@ -100,16 +100,14 @@ fn prune_relations(
         prune_relations_pass_1(reader, &progress_bar, workdir, &keep_relations_path)?;
 
     // Second pass.
-    let tmp_path = PathBuf::from(workdir).join("osm-prune-relations.tmp");
     let stats = prune_relations_pass_2(
         reader,
         &keep_relations,
         &graph,
         &progress_bar,
         workdir,
-        &tmp_path,
+        &keep_relation_members_path,
     )?;
-    std::fs::rename(&tmp_path, &keep_relation_members_path)?;
 
     progress_bar.finish_with_message(format!(
         "blobs → {} relations (with {} nodes, {} ways, {} relations as members)",
@@ -338,9 +336,9 @@ fn prune_ways(
     workdir: &Path,
 ) -> Result<U64Table> {
     // TODO: Also build a table osm-prune.keep-ways, separate from keep-way-members.
-    let out_path = PathBuf::from(workdir).join("osm-prune.keep-way-members");
-    if out_path.exists() {
-        return U64Table::open(&out_path);
+    let keep_way_members_path = PathBuf::from(workdir).join("osm-prune.keep-way-members");
+    if keep_way_members_path.exists() {
+        return U64Table::open(&keep_way_members_path);
     }
 
     let progress_bar = make_progress_bar(
@@ -349,9 +347,6 @@ fn prune_ways(
         reader.count_way_blobs() as u64,
         "blobs",
     );
-
-    let mut tmp_path = out_path.clone();
-    tmp_path.add_extension("tmp");
 
     let stats = Arc::new(Mutex::new(PruneStats::default()));
     thread::scope(|s| {
@@ -394,20 +389,19 @@ fn prune_ways(
                 Ok(())
             })
         });
-        let pruned_writer = s.spawn(|| u64_table::create(keep_rx, workdir, &tmp_path));
+        let pruned_writer = s.spawn(|| u64_table::create(keep_rx, workdir, &keep_way_members_path));
         pruned_writer.join().expect("panic in pruned_writer")?;
         blob_consumer.join().expect("panic in blob_consumer")?;
         blob_producer.join().expect("panic in blob_producer")?;
         Ok(())
     })?;
     let stats = stats.lock().expect("lock").clone();
-    std::fs::rename(&tmp_path, &out_path)?;
 
     // OSM ways don’t have relation members, so we don’t emit any relations.
     progress_bar.finish_with_message(format!(
-        "blobs → {} nodes, {} ways",
-        stats.node_count, stats.way_count,
+        "blobs → {} ways (with {} nodes as members)",
+        stats.way_count, stats.node_count,
     ));
 
-    U64Table::open(&out_path)
+    U64Table::open(&keep_way_members_path)
 }

--- a/src/u64_table.rs
+++ b/src/u64_table.rs
@@ -120,10 +120,12 @@ mod writer {
     use ext_sort::{ExternalSorter, ExternalSorterBuilder, buffer::LimitedBufferBuilder};
     use std::fs::File;
     use std::io::{BufWriter, Write};
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
     use std::sync::mpsc::Receiver;
 
     pub fn create(stream: Receiver<u64>, workdir: &Path, out: &Path) -> Result<u64> {
+        let mut tmp_out = PathBuf::from(out);
+        tmp_out.add_extension("tmp");
         let sorter: ExternalSorter<u64, std::io::Error, LimitedBufferBuilder> =
             ExternalSorterBuilder::new()
                 .with_tmp_dir(workdir)
@@ -132,7 +134,7 @@ mod writer {
                 ))
                 .build()?;
         let sorted = sorter.sort(stream.into_iter().map(std::io::Result::Ok))?;
-        let file = File::create(out)?;
+        let file = File::create(&tmp_out)?;
         let mut writer = BufWriter::with_capacity(32768, file);
         let mut num_unique_values = 0;
         let mut last: Option<u64> = None;
@@ -152,6 +154,8 @@ mod writer {
         }
 
         writer.flush()?;
+        writer.into_inner()?.sync_all()?;
+        std::fs::rename(&tmp_out, out)?;
         Ok(num_unique_values)
     }
 


### PR DESCRIPTION
Simplify callers who had to handle partially created tables by asking U64Table to create a temporary file, which each caller was renaming to the final file name (in an atomic file system operation) after `U64Table::create` finished.

After this change, this renaming business is handled within U64Table. This simplifies the call sites.