### PR TITLE
Add skeleton for node indexing

### DIFF
--- a/src/pipeline/osm/index.rs
+++ b/src/pipeline/osm/index.rs
@@ -1,12 +1,15 @@
 use super::{BlobReader, Prunings};
 use crate::{
     make_progress_bar,
+    matchers::MatchMask,
     tables::{StringCounts, StringPool},
 };
 use anyhow::{Ok, Result};
 use ext_sort::{ExternalSorter, ExternalSorterBuilder, buffer::LimitedBufferBuilder};
 use indicatif::MultiProgress;
-use std::{fs::File, path::Path};
+use osm_pbf_iter::{Blob, Primitive, PrimitiveBlock};
+use rayon::prelude::*;
+use std::{fs::File, path::Path, sync::mpsc::sync_channel, thread};
 
 #[allow(unused)]
 pub struct Index<'a> {
@@ -15,12 +18,13 @@ pub struct Index<'a> {
 
 impl<'a> Index<'a> {
     pub fn create(
-        _osm_reader: &mut BlobReader<File>,
+        osm: &mut BlobReader<File>,
         prunings: &Prunings,
         progress: &MultiProgress,
         workdir: &Path,
     ) -> Result<Index<'a>> {
         let strings = index_strings(&prunings.strings, progress, workdir)?;
+        index_nodes(osm, prunings, &strings, progress, workdir)?;
         Ok(Index { strings })
     }
 }
@@ -84,4 +88,70 @@ fn index_strings<'a>(
     iter_result?;
     read_progress.finish();
     Ok(pool)
+}
+
+fn index_nodes(
+    osm: &mut BlobReader<File>,
+    prunings: &Prunings,
+    strings: &StringPool,
+    progress: &MultiProgress,
+    _workdir: &Path,
+) -> Result<()> {
+    let progress_bar = make_progress_bar(
+        progress,
+        "osm.index.nodes  ",
+        osm.count_node_blobs() as u64,
+        "nodes",
+    );
+    thread::scope(|s| {
+        let progress_bar = &progress_bar;
+        let num_workers = usize::from(thread::available_parallelism()?);
+        let (blob_tx, blob_rx) = sync_channel::<Blob>(num_workers);
+        let producer = s.spawn(|| osm.send_node_blobs(blob_tx));
+
+        let keep_nodes = &prunings.keep_nodes;
+        let consumer = s.spawn(move || {
+            blob_rx.into_iter().par_bridge().try_for_each(|blob| {
+                let data = blob.into_data(); // decompress
+                let block = PrimitiveBlock::parse(&data);
+                for primitive in block.primitives() {
+                    if let Primitive::Node(node) = primitive
+                        && keep_nodes.contains(node.id)
+                    {
+                        // Handle geometry.
+                        let s2_lat_lon = s2::latlng::LatLng::from_degrees(node.lat, node.lon);
+                        let _s2_cell_id = s2::cellid::CellID::from(s2_lat_lon);
+
+                        // Handle tags.
+                        let mut mask = MatchMask::default();
+                        for (key, value) in node.tags.iter() {
+                            mask.add_tag(key, value);
+                            let _key_id = strings.lookup(key).unwrap_or_else(|| {
+                                panic!(
+                                    "OpenStreetMap node/{} tag key not in StringPool: \"{}\"",
+                                    node.id, key
+                                )
+                            });
+                            let _value_id = strings.lookup(value).unwrap_or_else(|| {
+                                panic!(
+                                    "OpenStreetMap node/{} tag value not in StringPool: \"{}\"",
+                                    node.id, value
+                                )
+                            });
+                        }
+
+                        // TODO: Encode as proto message. Sort by s2_cell_id.
+                    }
+                }
+                progress_bar.inc(1);
+                Ok(())
+            })
+        });
+
+        consumer.join().expect("panic in consumer")?;
+        producer.join().expect("panic in producer")?;
+        Ok(())
+    })?;
+    progress_bar.finish();
+    Ok(())
 }

--- a/src/pipeline/osm/prune.rs
+++ b/src/pipeline/osm/prune.rs
@@ -21,7 +21,7 @@ use std::{
 pub struct Prunings<'a> {
     coords: CoordsMap<'a>,
     pub strings: StringCounts<'a>,
-    keep_nodes: U64Set,
+    pub keep_nodes: U64Set,
     keep_ways: U64Set,
     keep_relations: U64Set,
     relation_members: U64Set,

--- a/src/tables/string_pool.rs
+++ b/src/tables/string_pool.rs
@@ -213,8 +213,11 @@ impl<'a> StringPool<'a> {
     }
 
     fn hash(s: &str) -> u32 {
-        // TODO: Measure whether the xxhash crate makes any performance difference
-        // when indexing the full OpenStreetMap planet.
+        // We did not explore faster hashers (such as xxhash or ahash)
+        // because StringPool lookup is not a bottleneck. On a 2026 MacBook
+        // Air with 10 Apple M5 CPU cores, looking up every tag of every node
+        // in our conflation pipleline takes 8 seconds; even if another hasher
+        // was twice as fast, the difference would not be noticeable.
         let mut hasher = DefaultHasher::new();
         s.hash(&mut hasher);
         hasher.finish() as u32


### PR DESCRIPTION
On a 2026 MacBook Air with 10 Apple M5 CPU cores, the new step `osm.index.nodes` takes 125 seconds, with 0.57 GB peak memory footprint. No output generated yet.