### PR TITLE
Revert "CI: Configure Dependabot to track updates to git submodules (…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,10 +8,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-  - package-ecosystem: "gitsubmodule"
-    directory: "/"
-    schedule:
-      interval: "daily"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
…#470)"

This reverts commit 36f4a9791ccc189a2b4e9eff3488a24091cf531b. We ended up not using git submodules.