### PR TITLE
Revert "Vendor id-tagging-schema v7.0.1 (#469)"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "vendor/id-tagging-schema"]
-	path = vendor/id-tagging-schema
-	url = https://github.com/openstreetmap/id-tagging-schema.git


### PR DESCRIPTION
This reverts commit e51010aaa712167d539fb08037162546eb51d293. We ended up not vendoring via git submodules.