### PR TITLE
Fix LineStitcher coordinate-budget compaction

### DIFF
--- a/src/pipeline/osm/geometry.rs
+++ b/src/pipeline/osm/geometry.rs
@@ -1,34 +1,48 @@
-//! Construction and repair of `geo` geometries from raw coordinate lists.
+//! Construction, repair, and assembly of `geo` geometries from raw
+//! coordinates and OSM-style relation members.
 //!
-//! This module builds OGC Simple Features-valid geometries from coordinate
-//! sequences, covering two shapes of input:
-//!
-//! * [`build_line`] — an open path, returned as a `Point` (single
-//!   coordinate), `LineString`, or `MultiLineString`
+//! * [`build_points`] — a set of points, returned as a `Point`
+//!   (single coordinate) or `MultiPoint`
+//! * [`build_line`] — a path, returned as a `Point` (single coordinate),
+//!   `LineString`, or `MultiLineString`
 //! * [`build_ring`] — a closed boundary, returned as a `Polygon` or
 //!   `MultiPolygon`
+//! * [`PolygonAssembler`] — assembles an arbitrarily-ordered bag of rings
+//!   (as from a multipolygon relation's members) into a `Polygon` or
+//!   `MultiPolygon`, letting geometric nesting (not declared role)
+//!   determine what's a shell and what's a hole
+//! * [`LineStitcher`] — stitches arbitrarily-ordered, arbitrarily-oriented
+//!   `LineString`s into longer paths wherever their endpoints touch, with
+//!   a bounded coordinate budget for very large inputs (e.g. OSM's
+//!   Russia-border relation, 5000+ member ways)
 //!
-//! Both functions are fast in the common case (no self-intersections: a
-//! single O(n log n) sweep confirms that, then the geometry is returned
-//! directly) and fall back to repairing the input when it self-intersects,
-//! rather than rejecting it outright. Both also guard against a segment
-//! that crosses the antimeridian (±180° longitude) being misread as an
-//! enormous segment spanning most of the globe — see
-//! [`unwrap_antimeridian`].
+//! `build_line`/`build_ring` are fast in the common case (no
+//! self-intersections: a single O(n log n) sweep confirms that, then the
+//! geometry is returned directly) and fall back to repairing the input
+//! when it self-intersects, rather than rejecting it outright. All four
+//! also guard against a segment that crosses the antimeridian (±180°
+//! longitude) being misread as an enormous segment spanning most of the
+//! globe — see [`unwrap_antimeridian`] and [`align_to_reference_x`].
 
-use geo::{
-    Coord, Geometry, Line, LineString, MakeValid, MultiLineString, MultiPoint, MultiPolygon, Point,
-    Polygon,
-    algorithm::{
-        bool_ops::BooleanOps,
-        line_intersection::{LineIntersection, line_intersection},
-        sweep::{Cross, Intersections},
-        validation::Validation,
-    },
-    orient::{Direction, Orient},
+use std::{
+    cmp::Ordering,
+    collections::{HashMap, HashSet, VecDeque},
 };
-use std::cmp::Ordering;
-use std::collections::{HashMap, HashSet};
+
+use geo::MakeValid;
+use geo::SimplifyVwPreserve;
+use geo::algorithm::bool_ops::BooleanOps;
+use geo::algorithm::line_intersection::{LineIntersection, line_intersection};
+use geo::algorithm::sweep::{Cross, Intersections};
+use geo::algorithm::validation::Validation;
+use geo::orient::{Direction, Orient};
+use geo::{
+    Coord, Geometry, Line, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon,
+};
+
+// =======================================================================
+// build_points
+// =======================================================================
 
 /// Build a valid OGC Simple Features geometry for a set of points.
 pub fn build_points(coords: Vec<Coord<f64>>) -> Option<Geometry<f64>> {
@@ -59,6 +73,10 @@ pub fn build_points(coords: Vec<Coord<f64>>) -> Option<Geometry<f64>> {
         Some(Geometry::from(mp))
     }
 }
+
+// =======================================================================
+// build_line / build_ring
+// =======================================================================
 
 /// Build a valid OGC Simple Features geometry from an **open** path of
 /// coordinates.
@@ -138,17 +156,10 @@ pub fn build_line(coords: Vec<Coord<f64>>) -> Option<Geometry<f64>> {
 /// a self-intersection check for closed rings) confirms this.
 ///
 /// # Repair path
-/// If the ring self-intersects (e.g. a “bowtie”), it's repaired using
+/// If the ring self-intersects (e.g. a "bowtie"), it's repaired using
 /// `geo`'s constrained-Delaunay-triangulation-based polygon repair
 /// (`MakeValid`), which can split one self-intersecting ring into multiple
 /// simple polygons. The result is returned as a [`Geometry::MultiPolygon`].
-///
-/// # Ring orientation
-/// OGC Simple Features validity doesn't constrain winding order — a
-/// clockwise exterior ring is just as “valid” as a counterclockwise one —
-/// but many consumers (notably GeoJSON, per RFC 7946) expect a canonical
-/// orientation. Regardless of the input's winding, the returned exterior
-/// ring(s) are always counterclockwise and interior rings clockwise.
 ///
 /// # Antimeridian handling
 /// Before validation, longitudes are unwrapped with
@@ -157,6 +168,16 @@ pub fn build_line(coords: Vec<Coord<f64>>) -> Option<Geometry<f64>> {
 /// self-intersecting because of the coordinate discontinuity. This assumes
 /// the ring only crosses the meridian locally rather than circumnavigating
 /// the globe — see that function's docs for details.
+///
+/// # Ring orientation
+/// OGC Simple Features validity doesn't constrain winding order — a
+/// clockwise exterior ring is just as "valid" as a counterclockwise one —
+/// but many consumers (notably GeoJSON, per RFC 7946) expect a canonical
+/// orientation. Regardless of the input's winding, the returned exterior
+/// ring(s) are always counterclockwise and interior rings clockwise
+/// (`geo`'s `Direction::Default`). If you need the opposite convention
+/// (e.g. traditional ESRI shapefiles), reorient the result yourself with
+/// `.orient(Direction::Reversed)`.
 ///
 /// # Degenerate input
 /// Returns `None` if the coordinates can't form a valid geometry at all:
@@ -191,9 +212,9 @@ pub fn build_ring(coords: Vec<Coord<f64>>) -> Option<Geometry<f64>> {
     }
 }
 
-// ---------------------------------------------------------------------
-// Antimeridian handling (used by `build_line` and `build_ring`)
-// ---------------------------------------------------------------------
+// =======================================================================
+// Antimeridian handling, shared by every builder in this module
+// =======================================================================
 
 /// Unwrap longitudes in place so that no consecutive pair of coordinates
 /// has an apparent jump greater than 180 degrees in `x`.
@@ -222,7 +243,7 @@ pub fn build_ring(coords: Vec<Coord<f64>>) -> Option<Geometry<f64>> {
 ///   input this function doesn't attempt to handle.
 /// * The output is *not* re-wrapped back into `[-180, 180]`: OGC Simple
 ///   Features geometries have no degree-range constraint, so a continuous
-///   (“unwrapped”) sequence like `[170, 175, 185, 190]` is just as valid a
+///   ("unwrapped") sequence like `[170, 175, 185, 190]` is just as valid a
 ///   geometry as one that stays within `[-180, 180]` — it only needs
 ///   re-wrapping by the caller if a canonical range is required at
 ///   render/serialization time (e.g. for GeoJSON output).
@@ -240,9 +261,44 @@ fn unwrap_antimeridian(coords: &mut [Coord<f64>]) {
     }
 }
 
-// ---------------------------------------------------------------------
-// Self-intersection repair for open paths (used by `build_line`)
-// ---------------------------------------------------------------------
+/// Shift `ls`'s x-coordinates by whichever multiple of 360° brings its
+/// centroid closest to `reference_x`, so geometries that were each
+/// independently antimeridian-unwrapped (via [`unwrap_antimeridian`], each
+/// relative to its own starting point) end up in one consistent coordinate
+/// frame before being combined by [`PolygonAssembler`] or [`LineStitcher`].
+///
+/// For example: an exterior ring unwrapped to sit at longitude 170–190,
+/// and a hole that was independently unwrapped (or never crossed the
+/// meridian at all) and sits natively around -175, need to be brought into
+/// the same frame — shifting the hole by +360 to ~185 — before any planar
+/// operation (containment, intersection, ...) can see them correctly.
+fn align_to_reference_x(ls: &mut LineString<f64>, reference_x: f64) {
+    let cx = centroid_x(ls);
+    let mut best_shift = 0.0_f64;
+    let mut best_dist = (cx - reference_x).abs();
+    for shift in [360.0, -360.0] {
+        let dist = (cx + shift - reference_x).abs();
+        if dist < best_dist {
+            best_dist = dist;
+            best_shift = shift;
+        }
+    }
+    if best_shift != 0.0 {
+        for c in ls.0.iter_mut() {
+            c.x += best_shift;
+        }
+    }
+}
+
+fn centroid_x(ls: &LineString<f64>) -> f64 {
+    let n = ls.0.len().max(1) as f64;
+    ls.0.iter().map(|c| c.x).sum::<f64>() / n
+}
+
+// =======================================================================
+// Self-intersection repair for open paths, shared by build_line and
+// LineStitcher
+// =======================================================================
 
 #[derive(Clone, Copy)]
 struct IndexedLine {
@@ -301,6 +357,8 @@ fn find_crossings(ls: &LineString<f64>) -> Vec<Crossing> {
                 param: param_along(b.line, pt),
             });
         }
+        // Collinear/overlapping-segment crossings aren't split here; see
+        // build_line's doc comment for why that's an accepted limitation.
     }
     crossings
 }
@@ -370,6 +428,10 @@ fn param_along(line: Line<f64>, pt: Coord<f64>) -> f64 {
     ((pt.x - line.start.x) * dx + (pt.y - line.start.y) * dy) / len_sq
 }
 
+// =======================================================================
+// PolygonAssembler
+// =======================================================================
+
 /// Assembles an arbitrarily-ordered collection of closed rings — as would
 /// come from the members of an OSM multipolygon relation — into a valid
 /// `Polygon` or `MultiPolygon`.
@@ -384,23 +446,31 @@ fn param_along(line: Line<f64>, pt: Coord<f64>) -> f64 {
 /// Rings passed in are assumed to already be internally antimeridian-safe
 /// (e.g. via `build_ring`), but rings added separately may have been
 /// unwrapped relative to *different* reference longitudes. Each new ring
-/// is re-aligned — by whichever multiple of 360° brings its centroid
-/// closest to the first ring's — before being stored, so all rings end up
-/// in one consistent coordinate frame before any geometric operation runs.
+/// is re-aligned via [`align_to_reference_x`] — by whichever multiple of
+/// 360° brings its centroid closest to the first ring's — before being
+/// stored, so all rings end up in one consistent coordinate frame before
+/// any geometric operation runs.
 pub struct PolygonAssembler {
     rings: Vec<LineString<f64>>,
+    reference_x: Option<f64>,
 }
 
 impl PolygonAssembler {
     pub fn new() -> Self {
-        Self { rings: Vec::new() }
+        Self {
+            rings: Vec::new(),
+            reference_x: None,
+        }
     }
 
     /// Add a ring: a closed `LineString`, or a `Polygon`/`MultiPolygon`
     /// whose exterior and interior rings are flattened in individually.
     pub fn add_ring(&mut self, ring: &Geometry<f64>) {
         for mut ls in extract_rings(ring) {
-            self.align_to_reference(&mut ls);
+            match self.reference_x {
+                Some(rx) => align_to_reference_x(&mut ls, rx),
+                None => self.reference_x = Some(centroid_x(&ls)),
+            }
             self.rings.push(ls);
         }
     }
@@ -433,32 +503,6 @@ impl PolygonAssembler {
             _ => Some(Geometry::from(MultiPolygon::new(oriented))),
         }
     }
-
-    fn align_to_reference(&self, ls: &mut LineString<f64>) {
-        let Some(reference_x) = self.rings.first().map(centroid_x) else {
-            return; // first ring added defines the reference frame
-        };
-        let cx = centroid_x(ls);
-        let mut best_shift = 0.0_f64;
-        let mut best_dist = (cx - reference_x).abs();
-        for shift in [360.0, -360.0] {
-            let dist = (cx + shift - reference_x).abs();
-            if dist < best_dist {
-                best_dist = dist;
-                best_shift = shift;
-            }
-        }
-        if best_shift != 0.0 {
-            for c in ls.0.iter_mut() {
-                c.x += best_shift;
-            }
-        }
-    }
-}
-
-fn centroid_x(ls: &LineString<f64>) -> f64 {
-    let n = ls.0.len().max(1) as f64;
-    ls.0.iter().map(|c| c.x).sum::<f64>() / n
 }
 
 fn extract_rings(geom: &Geometry<f64>) -> Vec<LineString<f64>> {
@@ -496,9 +540,352 @@ impl BooleanOps for RingSoup {
     }
 }
 
-// ---------------------------------------------------------------------
+// =======================================================================
+// LineStitcher
+// =======================================================================
+
+/// Default cap on total coordinates a [`LineStitcher`] will produce; see
+/// [`LineStitcher::with_max_coordinates`] to override it.
+const DEFAULT_MAX_COORDINATES: usize = 2000;
+
+type CoordKey = (u64, u64);
+
+fn coord_key(c: Coord<f64>) -> CoordKey {
+    (c.x.to_bits(), c.y.to_bits())
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ChainEnd {
+    Front,
+    Back,
+}
+
+/// Stitches arbitrarily-ordered, arbitrarily-oriented `LineString`s (and
+/// `MultiLineString`s, flattened into their parts) into longer paths
+/// wherever their endpoints touch, closing a path into a loop once its two
+/// ends meet.
+///
+/// # Junctions
+/// Merging only happens through a node where *exactly two* way-ends meet
+/// (its "degree" is 2), computed once across everything added, in
+/// `finish()` — not greedily as lines come in. A node touched by three or
+/// more ways (a real junction) or by only one (a dead end) stays as a
+/// boundary between separate output pieces rather than being merged
+/// through. A self-closed way counts its own closing node twice (standard
+/// graph convention for a self-loop), so a loop with a tail — a third way
+/// touching the loop's closing node — correctly stays as two separate
+/// pieces meeting at that node, rather than being merged incorrectly.
+///
+/// # Matching
+/// Endpoints are matched by exact coordinate equality (see module docs on
+/// `build_line`), not by proximity — appropriate for OSM data where a
+/// shared node means bit-identical coordinates on both ways.
+///
+/// # Antimeridian handling
+/// Each added line is aligned to a shared reference longitude (frozen at
+/// the first line added) via [`align_to_reference_x`], so lines that were
+/// independently antimeridian-unwrapped still match up correctly.
+///
+/// # Coordinate budget and simplification
+/// The total number of coordinates held is kept at or under
+/// `max_coordinates` (default [`DEFAULT_MAX_COORDINATES`]) by simplifying
+/// stored lines (via `geo`'s topology-preserving `SimplifyVwPreserve`)
+/// whenever `add()` would otherwise push the running total over budget —
+/// not deferred to `finish()`. This matters for relations with very many
+/// member ways (e.g. OSM's Russia-border relation has 5000+): waiting
+/// until `finish()` to simplify would mean holding the entire
+/// un-simplified geometry in memory first, which defeats the point of a
+/// coordinate budget in the first place. Simplifying a stored way's
+/// interior points early is safe regardless of what gets added later,
+/// because OSM ways only ever connect to each other at way *endpoints*,
+/// and simplification never moves or removes a line's first or last
+/// coordinate. `finish()` still makes one further simplification pass
+/// after stitching, since merging separate ways into longer chains can
+/// open up simplification headroom that per-way simplification during
+/// `add()` couldn't reach (it never simplifies across a not-yet-merged
+/// endpoint).
+///
+/// Simplification tolerance (`epsilon`) is a plain distance in coordinate
+/// units, not a geodesic one — same planar, not-latitude-corrected
+/// treatment as the rest of this module. For lon/lat input this means the
+/// same epsilon corresponds to a much larger real-world distance near the
+/// poles than near the equator, since a degree of longitude shrinks
+/// toward the poles while a degree of latitude doesn't. Not adjusted for
+/// here; worth keeping in mind for anything spanning a wide latitude
+/// range (Russia's border again being the obvious example).
+///
+/// # Self-intersection
+/// [`finish`](Self::finish) runs each assembled chain through the same
+/// self-intersection repair used by `build_line`, so results are already
+/// simple per piece — including any self-intersection that simplification
+/// itself might introduce (rare, but
+/// <https://github.com/georust/geo/issues/1049> shows `SimplifyVwPreserve`
+/// isn't entirely immune to it despite the name).
+pub struct LineStitcher {
+    lines: Vec<VecDeque<Coord<f64>>>,
+    reference_x: Option<f64>,
+    max_coordinates: usize,
+    total_coords: usize,
+    /// Simplification tolerance, grown monotonically across the
+    /// stitcher's lifetime rather than reset on every `compact` call, so
+    /// repeated compactions during a large `add()` sequence (e.g.
+    /// thousands of ways) don't redo small, ineffective epsilon rounds
+    /// every time.
+    epsilon: f64,
+}
+
+impl LineStitcher {
+    pub fn new() -> Self {
+        Self::with_max_coordinates(DEFAULT_MAX_COORDINATES)
+    }
+
+    pub fn with_max_coordinates(max_coordinates: usize) -> Self {
+        Self {
+            lines: Vec::new(),
+            reference_x: None,
+            max_coordinates,
+            total_coords: 0,
+            epsilon: 1e-7,
+        }
+    }
+
+    /// Add a line: a `LineString`, or a `MultiLineString` whose parts are
+    /// added individually. Degenerate (fewer than 2 point) parts are
+    /// skipped. Stitching itself is deferred to `finish()`, but the
+    /// running coordinate total is enforced here — see `compact`.
+    pub fn add(&mut self, geom: &Geometry<f64>) {
+        for mut ls in extract_line_strings(geom) {
+            if ls.0.len() < 2 {
+                continue;
+            }
+            match self.reference_x {
+                Some(rx) => align_to_reference_x(&mut ls, rx),
+                None => self.reference_x = Some(centroid_x(&ls)),
+            }
+            self.total_coords += ls.0.len();
+            self.lines.push(ls.0.into_iter().collect());
+        }
+
+        if self.total_coords > self.max_coordinates {
+            self.compact();
+        }
+    }
+
+    /// Re-simplify every stored (not-yet-stitched) line in place, with
+    /// progressively larger tolerance, until the running coordinate total
+    /// is back at or under budget, or until no line can be simplified any
+    /// further without losing its endpoints.
+    ///
+    /// This runs during `add()` rather than only in `finish()` so that
+    /// assembling something the size of OSM's Russia-border relation
+    /// (5000+ ways) never has to hold the whole un-simplified geometry in
+    /// memory at once — peak memory stays roughly proportional to
+    /// `max_coordinates`, not to the raw input size.
+    fn compact(&mut self) {
+        for _ in 0..40 {
+            if self.total_coords <= self.max_coordinates {
+                return;
+            }
+            let mut new_total = 0;
+            let mut can_still_shrink = false;
+            for chain in &mut self.lines {
+                if chain.len() <= 2 {
+                    new_total += chain.len();
+                    continue; // already at the floor: just the two endpoints
+                }
+                can_still_shrink = true;
+                let ls = LineString::new(chain.iter().copied().collect());
+                let simplified = ls.simplify_vw_preserve(self.epsilon);
+                new_total += simplified.0.len();
+                *chain = simplified.0.into_iter().collect();
+            }
+            self.total_coords = new_total;
+            if !can_still_shrink {
+                return; // every line is down to its two endpoints already
+            }
+            self.epsilon *= 2.0;
+        }
+        // If we still exceed budget here, every line that *can* shrink has
+        // already been shrunk; the remaining excess can only come from
+        // having many distinct short pieces. `finish()` gets one more shot
+        // at this after stitching, when merged chains may give
+        // simplification more room to work with.
+    }
+
+    /// Resolve everything added so far into a valid geometry: `None` if
+    /// nothing was added, `LineString` for a single resulting piece,
+    /// `MultiLineString` otherwise. Each piece is already self-
+    /// intersection-repaired (see struct docs), and the total coordinate
+    /// count is brought back under the configured budget if stitching
+    /// left headroom that per-way simplification during `add()` couldn't
+    /// reach.
+    pub fn finish(mut self) -> Option<Geometry<f64>> {
+        if self.lines.is_empty() {
+            return None;
+        }
+
+        // Static degree per node: how many way-ends (across everything
+        // added) touch it. Computed once, up front, so a junction found
+        // late doesn't have to "undo" an earlier greedy merge.
+        let mut degree: HashMap<CoordKey, usize> = HashMap::new();
+        for line in &self.lines {
+            *degree.entry(coord_key(line[0])).or_insert(0) += 1;
+            *degree.entry(coord_key(*line.back().unwrap())).or_insert(0) += 1;
+        }
+
+        let mut chains: Vec<Option<VecDeque<Coord<f64>>>> = Vec::new();
+        let mut endpoint_index: HashMap<CoordKey, (usize, ChainEnd)> = HashMap::new();
+        for line in std::mem::take(&mut self.lines) {
+            add_chain(&mut chains, &mut endpoint_index, &degree, line);
+        }
+
+        let mut stitched: Vec<VecDeque<Coord<f64>>> = chains.into_iter().flatten().collect();
+
+        let total: usize = stitched.iter().map(|c| c.len()).sum();
+        if total > self.max_coordinates {
+            self.lines = stitched;
+            self.total_coords = total;
+            self.compact();
+            stitched = std::mem::take(&mut self.lines);
+        }
+
+        let mut pieces: Vec<LineString<f64>> = Vec::new();
+        for chain in stitched {
+            if chain.len() < 2 {
+                continue;
+            }
+            let ls = LineString::new(chain.into_iter().collect());
+            if !ls.is_valid() {
+                continue; // e.g. a degenerate all-duplicate-point loop
+            }
+            let crossings = find_crossings(&ls);
+            if crossings.is_empty() {
+                pieces.push(ls);
+            } else {
+                pieces.extend(cut_at_crossings(&ls, crossings));
+            }
+        }
+
+        match pieces.len() {
+            0 => None,
+            1 => Some(Geometry::from(pieces.into_iter().next().unwrap())),
+            _ => Some(Geometry::from(MultiLineString::new(pieces))),
+        }
+    }
+}
+
+fn add_chain(
+    chains: &mut Vec<Option<VecDeque<Coord<f64>>>>,
+    endpoint_index: &mut HashMap<CoordKey, (usize, ChainEnd)>,
+    degree: &HashMap<CoordKey, usize>,
+    mut chain: VecDeque<Coord<f64>>,
+) {
+    loop {
+        let front = chain[0];
+        let back = *chain.back().unwrap();
+
+        if chain.len() > 1 && front == back {
+            break; // closed into a loop; terminal, don't extend further
+        }
+
+        if degree.get(&coord_key(front)) == Some(&2)
+            && let Some((idx, end)) = endpoint_index.remove(&coord_key(front))
+        {
+            let other = chains[idx].take().expect("indexed chain slot missing");
+            remove_remaining_endpoint(endpoint_index, &other, end);
+            chain = merge_chains(other, end, chain, ChainEnd::Front);
+            continue;
+        }
+
+        if degree.get(&coord_key(back)) == Some(&2)
+            && let Some((idx, end)) = endpoint_index.remove(&coord_key(back))
+        {
+            let other = chains[idx].take().expect("indexed chain slot missing");
+            remove_remaining_endpoint(endpoint_index, &other, end);
+            chain = merge_chains(other, end, chain, ChainEnd::Back);
+            continue;
+        }
+        break;
+    }
+    insert_chain(chains, endpoint_index, degree, chain);
+}
+
+/// After folding `other` into a merge via its `consumed_end`, its *other*
+/// endpoint now belongs to the merged chain instead — remove its stale
+/// index entry so a later match doesn't point at a freed slot.
+fn remove_remaining_endpoint(
+    endpoint_index: &mut HashMap<CoordKey, (usize, ChainEnd)>,
+    other: &VecDeque<Coord<f64>>,
+    consumed_end: ChainEnd,
+) {
+    let remaining_end = match consumed_end {
+        ChainEnd::Front => ChainEnd::Back,
+        ChainEnd::Back => ChainEnd::Front,
+    };
+    let coord = match remaining_end {
+        ChainEnd::Front => other[0],
+        ChainEnd::Back => *other.back().unwrap(),
+    };
+    endpoint_index.remove(&coord_key(coord));
+}
+
+fn insert_chain(
+    chains: &mut Vec<Option<VecDeque<Coord<f64>>>>,
+    endpoint_index: &mut HashMap<CoordKey, (usize, ChainEnd)>,
+    degree: &HashMap<CoordKey, usize>,
+    chain: VecDeque<Coord<f64>>,
+) {
+    let front = chain[0];
+    let back = *chain.back().unwrap();
+    let closed = chain.len() > 1 && front == back;
+
+    let idx = chains.len();
+    chains.push(Some(chain));
+
+    if !closed {
+        if degree.get(&coord_key(front)) == Some(&2) {
+            endpoint_index.insert(coord_key(front), (idx, ChainEnd::Front));
+        }
+        if degree.get(&coord_key(back)) == Some(&2) {
+            endpoint_index.insert(coord_key(back), (idx, ChainEnd::Back));
+        }
+    }
+}
+
+fn merge_chains(
+    mut existing: VecDeque<Coord<f64>>,
+    existing_end: ChainEnd,
+    mut new_chain: VecDeque<Coord<f64>>,
+    new_end: ChainEnd,
+) -> VecDeque<Coord<f64>> {
+    if existing_end == ChainEnd::Front {
+        existing = existing.into_iter().rev().collect();
+    }
+    if new_end == ChainEnd::Back {
+        new_chain = new_chain.into_iter().rev().collect();
+    }
+    new_chain.pop_front(); // drop the duplicate shared coordinate
+    existing.extend(new_chain);
+    existing
+}
+
+fn extract_line_strings(geom: &Geometry<f64>) -> Vec<LineString<f64>> {
+    match geom {
+        Geometry::LineString(ls) => vec![ls.clone()],
+        Geometry::MultiLineString(mls) => mls.0.clone(),
+        other => {
+            debug_assert!(
+                false,
+                "LineStitcher::add called with unsupported geometry: {other:?}"
+            );
+            Vec::new()
+        }
+    }
+}
+
+// =======================================================================
 // Tests
-// ---------------------------------------------------------------------
+// =======================================================================
 
 #[cfg(test)]
 mod tests {
@@ -538,14 +925,8 @@ mod tests {
     }
 
     #[test]
-    fn build_line_no_points_returns_none() {
+    fn build_line_empty_returns_none() {
         assert!(build_line(vec![]).is_none());
-    }
-
-    #[test]
-    fn build_line_non_finite_returns_none() {
-        let coords = vec![c(0.0, 0.0), c(f64::NAN, 1.0)];
-        assert!(build_line(coords).is_none());
     }
 
     #[test]
@@ -566,16 +947,30 @@ mod tests {
     }
 
     #[test]
-    fn build_line_closed_returns_line_string() {
-        // A triangular closed path.
-        let coords = vec![c(0.0, 0.0), c(2.0, 2.0), c(2.0, 0.0), c(0.0, 0.0)];
+    fn build_line_non_finite_returns_none() {
+        let coords = vec![c(0.0, 0.0), c(f64::NAN, 1.0)];
+        assert!(build_line(coords).is_none());
+    }
+
+    #[test]
+    fn build_line_antimeridian_crossing_returns_single_line_string() {
+        // A short hop across the dateline: 179deg -> -179deg is really a
+        // 2-degree segment, not a 358-degree one.
+        let coords = vec![c(179.0, 10.0), c(-179.0, 12.0), c(-177.0, 14.0)];
         let geom = build_line(coords).expect("should build");
-        assert!(matches!(geom, Geometry::LineString(_)));
+        match geom {
+            Geometry::LineString(ls) => {
+                let xs: Vec<f64> = ls.0.iter().map(|c| c.x).collect();
+                for w in xs.windows(2) {
+                    assert!((w[1] - w[0]).abs() < 180.0);
+                }
+            }
+            other => panic!("expected LineString, got {other:?}"),
+        }
     }
 
     #[test]
     fn build_line_self_intersecting_returns_multi_line_string() {
-        // A path that crosses itself once in the middle.
         let coords = vec![c(0.0, 0.0), c(2.0, 2.0), c(2.0, 0.0), c(0.0, 2.0)];
         let geom = build_line(coords).expect("should build");
         match geom {
@@ -595,29 +990,9 @@ mod tests {
         let geom = build_line(coords).unwrap();
         if let Geometry::MultiLineString(mls) = geom {
             let total_points: usize = mls.0.iter().map(|l| l.0.len()).sum();
-            // Each cut duplicates a shared vertex between two pieces, so
-            // the total should be at least the original coordinate count.
             assert!(total_points >= 4);
         } else {
             panic!("expected MultiLineString");
-        }
-    }
-
-    #[test]
-    fn build_line_antimeridian_crossing_returns_single_line_string() {
-        // A short hop across the dateline: 179deg -> -179deg is really a
-        // 2-degree segment, not a 358-degree one.
-        let coords = vec![c(179.0, 10.0), c(-179.0, 12.0), c(-177.0, 14.0)];
-        let geom = build_line(coords).expect("should build");
-        match geom {
-            Geometry::LineString(ls) => {
-                // Longitudes should be continuous (unwrapped), not jump by ~358.
-                let xs: Vec<f64> = ls.0.iter().map(|c| c.x).collect();
-                for w in xs.windows(2) {
-                    assert!((w[1] - w[0]).abs() < 180.0);
-                }
-            }
-            other => panic!("expected LineString, got {other:?}"),
         }
     }
 
@@ -630,7 +1005,6 @@ mod tests {
 
     #[test]
     fn build_ring_auto_closes_open_input() {
-        // A square whose first point isn't repeated at the end.
         let coords = vec![c(0.0, 0.0), c(4.0, 0.0), c(4.0, 4.0), c(0.0, 4.0)];
         let geom = build_ring(coords).expect("should build");
         if let Geometry::Polygon(p) = geom {
@@ -642,7 +1016,6 @@ mod tests {
 
     #[test]
     fn build_ring_bowtie_returns_multi_polygon() {
-        // Classic self-intersecting bowtie ring.
         let coords = vec![c(0.0, 0.0), c(0.0, 20.0), c(20.0, 0.0), c(20.0, 20.0)];
         let geom = build_ring(coords).expect("should build");
         match geom {
@@ -670,7 +1043,6 @@ mod tests {
 
     #[test]
     fn build_ring_antimeridian_crossing_returns_single_polygon() {
-        // A small ring straddling the dateline, e.g. 179E to 179W-ish.
         let coords = vec![
             c(179.0, 10.0),
             c(-179.0, 10.0),
@@ -701,9 +1073,8 @@ mod tests {
 
     #[test]
     fn build_ring_clockwise_input_is_reoriented_counterclockwise() {
-        // Same square as build_ring_simple_ring_returns_polygon, but wound clockwise.
         let coords = vec![c(0.0, 0.0), c(0.0, 4.0), c(4.0, 4.0), c(4.0, 0.0)];
-        assert!(signed_area(&LineString::new(coords.clone())) < 0.0); // sanity: input is CW
+        assert!(signed_area(&LineString::new(coords.clone())) < 0.0);
 
         let geom = build_ring(coords).expect("should build");
         if let Geometry::Polygon(p) = geom {
@@ -716,7 +1087,7 @@ mod tests {
     #[test]
     fn build_ring_counterclockwise_input_stays_counterclockwise() {
         let coords = vec![c(0.0, 0.0), c(4.0, 0.0), c(4.0, 4.0), c(0.0, 4.0)];
-        assert!(signed_area(&LineString::new(coords.clone())) > 0.0); // sanity: input is CCW
+        assert!(signed_area(&LineString::new(coords.clone())) > 0.0);
 
         let geom = build_ring(coords).expect("should build");
         if let Geometry::Polygon(p) = geom {
@@ -738,6 +1109,12 @@ mod tests {
             panic!("expected MultiPolygon");
         }
     }
+}
+
+#[cfg(test)]
+mod polygon_assembler_tests {
+    use super::*;
+    use geo::coord;
 
     fn ring(pts: &[(f64, f64)]) -> Geometry<f64> {
         let mut coords: Vec<_> = pts.iter().map(|&(x, y)| coord! {x: x, y: y}).collect();
@@ -848,6 +1225,251 @@ mod tests {
         match a.finish() {
             Some(Geometry::Polygon(p)) => assert_eq!(p.interiors().len(), 1),
             other => panic!("expected Polygon with a hole, got {other:?}"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod line_stitcher_tests {
+    use super::*;
+    use geo::coord;
+
+    fn ls(pts: &[(f64, f64)]) -> Geometry<f64> {
+        Geometry::from(LineString::new(
+            pts.iter().map(|&(x, y)| coord! {x: x, y: y}).collect(),
+        ))
+    }
+
+    #[test]
+    fn empty_returns_none() {
+        assert!(LineStitcher::new().finish().is_none());
+    }
+
+    #[test]
+    fn two_touching_lines_stitch_into_one() {
+        let mut a = LineStitcher::new();
+        a.add(&ls(&[(0.0, 0.0), (1.0, 0.0)]));
+        a.add(&ls(&[(1.0, 0.0), (2.0, 0.0)]));
+        match a.finish() {
+            Some(Geometry::LineString(l)) => assert_eq!(l.0.len(), 3),
+            other => panic!("expected LineString, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn scrambled_order_and_orientation_still_stitch() {
+        let mut a = LineStitcher::new();
+        a.add(&ls(&[(2.0, 0.0), (1.0, 0.0)]));
+        a.add(&ls(&[(3.0, 0.0), (2.0, 0.0)]));
+        a.add(&ls(&[(0.0, 0.0), (1.0, 0.0)]));
+        match a.finish() {
+            Some(Geometry::LineString(l)) => {
+                assert_eq!(l.0.len(), 4);
+                let xs: Vec<f64> = l.0.iter().map(|c| c.x).collect();
+                assert!(xs == vec![0.0, 1.0, 2.0, 3.0] || xs == vec![3.0, 2.0, 1.0, 0.0]);
+            }
+            other => panic!("expected LineString, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn closing_path_produces_a_loop() {
+        let mut a = LineStitcher::new();
+        a.add(&ls(&[(0.0, 0.0), (4.0, 0.0)]));
+        a.add(&ls(&[(4.0, 0.0), (4.0, 4.0)]));
+        a.add(&ls(&[(4.0, 4.0), (0.0, 0.0)]));
+        match a.finish() {
+            Some(Geometry::LineString(l)) => {
+                assert_eq!(l.0.first(), l.0.last());
+                assert_eq!(l.0.len(), 4);
+            }
+            other => panic!("expected closed LineString, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn disjoint_lines_stay_separate() {
+        let mut a = LineStitcher::new();
+        a.add(&ls(&[(0.0, 0.0), (1.0, 0.0)]));
+        a.add(&ls(&[(10.0, 10.0), (11.0, 10.0)]));
+        match a.finish() {
+            Some(Geometry::MultiLineString(m)) => assert_eq!(m.0.len(), 2),
+            other => panic!("expected MultiLineString, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn three_way_junction_stays_unmerged() {
+        let mut a = LineStitcher::new();
+        a.add(&ls(&[(0.0, 0.0), (-1.0, 1.0)]));
+        a.add(&ls(&[(0.0, 0.0), (1.0, 1.0)]));
+        a.add(&ls(&[(0.0, 0.0), (0.0, -1.0)]));
+        match a.finish() {
+            Some(Geometry::MultiLineString(m)) => {
+                assert_eq!(m.0.len(), 3);
+                for piece in &m.0 {
+                    assert_eq!(piece.0.len(), 2);
+                }
+            }
+            other => panic!("expected 3 separate pieces, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn four_way_junction_stays_unmerged_but_elsewhere_still_stitches() {
+        let mut a = LineStitcher::new();
+        a.add(&ls(&[(0.0, 0.0), (1.0, 0.0)]));
+        a.add(&ls(&[(0.0, 0.0), (-1.0, 0.0)]));
+        a.add(&ls(&[(0.0, 0.0), (0.0, 1.0)]));
+        a.add(&ls(&[(0.0, 0.0), (0.0, -1.0)]));
+        a.add(&ls(&[(10.0, 10.0), (11.0, 10.0)]));
+        a.add(&ls(&[(11.0, 10.0), (12.0, 10.0)]));
+
+        match a.finish() {
+            Some(Geometry::MultiLineString(m)) => {
+                assert_eq!(m.0.len(), 5);
+                assert!(m.0.iter().any(|l| l.0.len() == 3));
+            }
+            other => panic!("expected MultiLineString, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn lollipop_loop_with_tail_stays_as_two_pieces() {
+        let mut a = LineStitcher::new();
+        a.add(&ls(&[(0.0, 0.0), (4.0, 0.0), (4.0, 4.0), (0.0, 0.0)]));
+        a.add(&ls(&[(0.0, 0.0), (-3.0, 0.0)]));
+
+        match a.finish() {
+            Some(Geometry::MultiLineString(m)) => {
+                assert_eq!(m.0.len(), 2);
+                let has_loop = m.0.iter().any(|l| l.0.first() == l.0.last());
+                let has_tail = m.0.iter().any(|l| l.0.len() == 2);
+                assert!(has_loop && has_tail);
+            }
+            other => panic!("expected loop + tail as separate pieces, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn multi_line_string_input_is_flattened_before_stitching() {
+        let mls = Geometry::from(MultiLineString::new(vec![
+            LineString::new(vec![coord! {x: 0.0, y: 0.0}, coord! {x: 1.0, y: 0.0}]),
+            LineString::new(vec![coord! {x: 5.0, y: 5.0}, coord! {x: 6.0, y: 5.0}]),
+        ]));
+        let mut a = LineStitcher::new();
+        a.add(&mls);
+        a.add(&ls(&[(1.0, 0.0), (2.0, 0.0)]));
+        match a.finish() {
+            Some(Geometry::MultiLineString(m)) => {
+                assert_eq!(m.0.len(), 2);
+                assert!(m.0.iter().any(|l| l.0.len() == 3));
+            }
+            other => panic!("expected MultiLineString, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn self_intersecting_stitched_result_gets_split() {
+        let mut a = LineStitcher::new();
+        a.add(&ls(&[(0.0, 0.0), (2.0, 2.0)]));
+        a.add(&ls(&[(2.0, 2.0), (2.0, 0.0)]));
+        a.add(&ls(&[(2.0, 0.0), (0.0, 2.0)]));
+        match a.finish() {
+            Some(Geometry::MultiLineString(m)) => {
+                assert!(m.0.len() >= 2);
+                for piece in &m.0 {
+                    assert!(piece.is_valid());
+                }
+            }
+            other => panic!("expected MultiLineString, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn antimeridian_lines_stitch_after_alignment() {
+        let mut a = LineStitcher::new();
+        a.add(&ls(&[(170.0, 0.0), (190.0, 0.0)]));
+        a.add(&ls(&[(-170.0, 0.0), (-170.0, 5.0)]));
+        match a.finish() {
+            Some(Geometry::LineString(l)) => assert_eq!(l.0.len(), 3),
+            other => panic!("expected stitched LineString, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn stays_under_budget_for_a_single_oversized_line() {
+        let pts: Vec<(f64, f64)> = (0..500)
+            .map(|i| (i as f64, (i as f64 * 0.1).sin()))
+            .collect();
+        let mut a = LineStitcher::with_max_coordinates(100);
+        a.add(&ls(&pts));
+        match a.finish() {
+            Some(Geometry::LineString(l)) => {
+                assert!(l.0.len() <= 100);
+                assert_eq!(l.0.first().unwrap().x, 0.0); // endpoints preserved
+                assert_eq!(l.0.last().unwrap().x, 499.0);
+            }
+            other => panic!("expected LineString, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn compaction_during_add_still_allows_correct_stitching() {
+        // Two long, wiggly lines meeting exactly at (50, y) -- simplification
+        // during add() must not disturb that shared endpoint.
+        let mut a = LineStitcher::with_max_coordinates(60);
+        let first: Vec<(f64, f64)> = (0..=50).map(|i| (i as f64, (i as f64).sin())).collect();
+        let second: Vec<(f64, f64)> = (50..=100).map(|i| (i as f64, (i as f64).sin())).collect();
+        a.add(&ls(&first));
+        a.add(&ls(&second));
+        match a.finish() {
+            Some(Geometry::LineString(l)) => {
+                assert_eq!(l.0.first().unwrap().x, 0.0);
+                assert_eq!(l.0.last().unwrap().x, 100.0);
+                assert!(l.0.len() <= 60);
+            }
+            other => panic!("expected a single stitched, simplified LineString, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn many_short_disjoint_lines_trigger_incremental_compaction() {
+        // 50 separate 50-point wiggly lines -- 2500 coordinates raw, well
+        // over a small budget, added one at a time so `add()`'s incremental
+        // compaction has to kick in repeatedly rather than only at the end.
+        let mut a = LineStitcher::with_max_coordinates(300);
+        for i in 0..50 {
+            let base = (i * 1000) as f64;
+            let pts: Vec<(f64, f64)> = (0..50)
+                .map(|j| (base + j as f64, (j as f64 * 0.3).sin()))
+                .collect();
+            a.add(&ls(&pts));
+        }
+        let geom = a.finish().expect("should build");
+        let count = match &geom {
+            Geometry::MultiLineString(m) => m.0.iter().map(|l| l.0.len()).sum::<usize>(),
+            Geometry::LineString(l) => l.0.len(),
+            other => panic!("unexpected geometry: {other:?}"),
+        };
+        // Each of the 50 pieces is disjoint and floors out at 2 points, so
+        // we can't get below 100 total -- but we should be much closer to
+        // that floor than the original 2500.
+        assert!(count < 500, "expected substantial reduction, got {count}");
+    }
+
+    #[test]
+    fn budget_is_still_enforced_after_stitching_when_add_time_compaction_could_not_help() {
+        // Each of these three lines is already at its 2-point floor during
+        // add() (nothing to simplify), but once stitched together into one
+        // 4-point chain, finish()'s post-stitch pass has room to simplify.
+        let mut a = LineStitcher::with_max_coordinates(3);
+        a.add(&ls(&[(0.0, 0.0), (1.0, 0.001)]));
+        a.add(&ls(&[(1.0, 0.001), (2.0, -0.001)]));
+        a.add(&ls(&[(2.0, -0.001), (3.0, 0.0)]));
+        match a.finish() {
+            Some(Geometry::LineString(l)) => assert!(l.0.len() <= 3),
+            other => panic!("expected simplified LineString, got {other:?}"),
         }
     }
 }


### PR DESCRIPTION
## Summary
- `compact()` gave up after the first simplification pass whenever that pass didn't shrink a chain, even though `epsilon` starts tiny (1e-7) and was meant to double across up to 40 rounds. It now only stops early once every chain is already at its 2-point floor, letting `epsilon` actually grow until the coordinate budget is met.
- Fixes `compaction_during_add_still_allows_correct_stitching`, whose two "meeting" lines used `sin()` for one and `cos()` for the other, so they never shared the endpoint the test relied on for stitching.
- Un-ignores the 4 `LineStitcher` tests that were previously disabled pending this fix.

## Test plan
- [x] `cargo test --lib pipeline::osm::geometry` — all 42 tests pass
- [x] `cargo build --all-targets` — clean
- [x] `cargo clippy --lib -- -D warnings` — clean