### PR TITLE
Add GeometryBuilder to combine mixed-type geometries

### DIFF
--- a/src/pipeline/osm/geometry.rs
+++ b/src/pipeline/osm/geometry.rs
@@ -34,12 +34,14 @@ use std::{
 use geo::MakeValid;
 use geo::SimplifyVwPreserve;
 use geo::algorithm::bool_ops::BooleanOps;
+use geo::algorithm::intersects::Intersects;
 use geo::algorithm::line_intersection::{LineIntersection, line_intersection};
 use geo::algorithm::sweep::{Cross, Intersections};
 use geo::algorithm::validation::Validation;
 use geo::orient::{Direction, Orient};
 use geo::{
-    Coord, Geometry, Line, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon,
+    Coord, Geometry, GeometryCollection, Line, LineString, MultiLineString, MultiPoint,
+    MultiPolygon, Point, Polygon,
 };
 
 // =======================================================================
@@ -1015,6 +1017,202 @@ fn extract_line_strings(geom: &Geometry<f64>) -> Vec<LineString<f64>> {
 }
 
 // =======================================================================
+// GeometryBuilder
+// =======================================================================
+
+/// Accumulates an arbitrarily-typed, arbitrarily-ordered stream of `geo`
+/// geometries — as would come from resolving the members of an OSM
+/// relation of unknown or mixed geometry type — and assembles them into
+/// one combined geometry.
+///
+/// Each added geometry is routed by kind:
+/// * `LineString`/`MultiLineString` (and, degenerately, `Line`) go to an
+///   internal [`LineStitcher`], which stitches touching endpoints into
+///   longer paths.
+/// * `Polygon`/`MultiPolygon` (and, degenerately, `Rect`/`Triangle`) go to
+///   an internal [`PolygonAssembler`], which resolves fill from geometric
+///   nesting.
+/// * `Point`/`MultiPoint` coordinates are simply collected; there's
+///   nothing to stitch or nest, so no assembler is needed for them.
+/// * `GeometryCollection` is flattened: each member is added individually.
+///
+/// # Result shape
+/// [`finish`](Self::finish) combines whatever was added into the smallest
+/// geometry type that represents it:
+/// * Only one kind was added (the common case: an OSM multipolygon
+///   relation is *all* rings, a route relation is *all* ways) — its
+///   assembler's own `finish()` result is returned directly, doing no
+///   extra work at all.
+/// * More than one kind was added — the result is a [`Geometry::GeometryCollection`]
+///   of the non-empty parts (polygon area first, then line, then points),
+///   after two corrections so the combination is a true set-theoretic
+///   union rather than a naive bag of parts:
+///     1. Any part of the stitched lines that falls inside the assembled
+///        polygon area is clipped away (via `geo`'s [`BooleanOps::clip`]):
+///        that area is already part of the union through the polygon, so
+///        keeping it in the line piece too would just be a redundant
+///        (and, for consumers expecting a partition, confusing) overlap.
+///     2. Any point that lies on the (clipped) lines or on/in the polygon
+///        area is dropped for the same reason: it contributes no new
+///        territory to the union.
+///
+/// This makes the common single-kind case allocation-free beyond what the
+/// relevant assembler already does, while staying correct — if unavoidably
+/// pricier, due to the clip and containment checks — for the rarer mixed
+/// case.
+///
+/// # Antimeridian handling
+/// Delegated entirely to the inner [`LineStitcher`] and [`PolygonAssembler`],
+/// each of which aligns everything it receives to its own first-added
+/// reference longitude. Points are not antimeridian-aligned: OSM node
+/// coordinates are never split across the dateline the way a way's
+/// vertices can be, so there's nothing to align them *to*.
+pub struct GeometryBuilder {
+    lines: LineStitcher,
+    polygons: PolygonAssembler,
+    points: Vec<Coord<f64>>,
+    has_lines: bool,
+    has_polygons: bool,
+}
+
+impl GeometryBuilder {
+    pub fn new() -> Self {
+        Self {
+            lines: LineStitcher::new(),
+            polygons: PolygonAssembler::new(),
+            points: Vec::new(),
+            has_lines: false,
+            has_polygons: false,
+        }
+    }
+
+    /// Add one geometry of any kind, routing it to the matching
+    /// accumulator (see struct docs). A `GeometryCollection` is flattened
+    /// by adding each of its members individually.
+    pub fn add(&mut self, g: &Geometry<f64>) {
+        match g {
+            Geometry::LineString(_) | Geometry::MultiLineString(_) => {
+                self.has_lines = true;
+                self.lines.add(g);
+            }
+            Geometry::Polygon(_) | Geometry::MultiPolygon(_) => {
+                self.has_polygons = true;
+                self.polygons.add_ring(g);
+            }
+            Geometry::Point(p) => self.points.push(p.0),
+            Geometry::MultiPoint(mp) => self.points.extend(mp.0.iter().map(|p| p.0)),
+            Geometry::Line(line) => {
+                self.has_lines = true;
+                self.lines
+                    .add(&Geometry::from(LineString::new(vec![line.start, line.end])));
+            }
+            Geometry::Triangle(t) => {
+                self.has_polygons = true;
+                self.polygons.add_ring(&Geometry::from((*t).to_polygon()));
+            }
+            Geometry::Rect(r) => {
+                self.has_polygons = true;
+                self.polygons.add_ring(&Geometry::from((*r).to_polygon()));
+            }
+            Geometry::GeometryCollection(gc) => {
+                for geom in &gc.0 {
+                    self.add(geom);
+                }
+            }
+        }
+    }
+
+    /// Resolve everything added so far into a single combined geometry.
+    /// `None` if nothing was added. See struct docs for how mixed-kind
+    /// input is combined.
+    pub fn finish(self) -> Option<Geometry<f64>> {
+        let has_points = !self.points.is_empty();
+
+        // Fast path: only one kind was ever added, so there's nothing to
+        // combine and no need to even look at the other two accumulators.
+        match (self.has_lines, self.has_polygons, has_points) {
+            (false, false, false) => return None,
+            (true, false, false) => return self.lines.finish(),
+            (false, true, false) => return self.polygons.finish(),
+            (false, false, true) => return build_points(self.points),
+            _ => {}
+        }
+
+        let mut line_geom = if self.has_lines {
+            self.lines.finish()
+        } else {
+            None
+        };
+        let poly_geom = if self.has_polygons {
+            self.polygons.finish()
+        } else {
+            None
+        };
+
+        // Clip away whatever part of the stitched lines already falls
+        // inside the assembled polygon area, so it isn't double-counted as
+        // separate territory in the union.
+        if let (Some(lg), Some(pg)) = (&line_geom, &poly_geom) {
+            let outside = multi_polygon_of(pg).clip(&multi_line_string_of(lg), true);
+            line_geom = match outside.0.len() {
+                0 => None,
+                1 => Some(Geometry::from(outside.0.into_iter().next().unwrap())),
+                _ => Some(Geometry::from(outside)),
+            };
+        }
+
+        // Drop any point that contributes no new territory: one already on
+        // the (clipped) lines, or on/in the polygon area.
+        let points_geom = if has_points {
+            let mut coords = self.points;
+            coords.retain(|c| {
+                let p = Point::from(*c);
+                !line_geom.as_ref().is_some_and(|g| g.intersects(&p))
+                    && !poly_geom.as_ref().is_some_and(|g| g.intersects(&p))
+            });
+            build_points(coords)
+        } else {
+            None
+        };
+
+        let parts: Vec<Geometry<f64>> = [poly_geom, line_geom, points_geom]
+            .into_iter()
+            .flatten()
+            .collect();
+
+        match parts.len() {
+            0 => None,
+            1 => Some(parts.into_iter().next().unwrap()),
+            _ => Some(Geometry::GeometryCollection(GeometryCollection::new_from(
+                parts,
+            ))),
+        }
+    }
+}
+
+/// `pg` as a `MultiPolygon`, for feeding into [`BooleanOps::clip`]; `pg` is
+/// always [`Geometry::Polygon`] or [`Geometry::MultiPolygon`], since it can
+/// only come from [`PolygonAssembler::finish`].
+fn multi_polygon_of(pg: &Geometry<f64>) -> MultiPolygon<f64> {
+    match pg {
+        Geometry::Polygon(p) => MultiPolygon::new(vec![p.clone()]),
+        Geometry::MultiPolygon(mp) => mp.clone(),
+        other => unreachable!("PolygonAssembler::finish returned {other:?}"),
+    }
+}
+
+/// `lg` as a `MultiLineString`, for feeding into [`BooleanOps::clip`]; `lg`
+/// is always [`Geometry::LineString`] or [`Geometry::MultiLineString`],
+/// since it can only come from [`LineStitcher::finish`].
+fn multi_line_string_of(lg: &Geometry<f64>) -> MultiLineString<f64> {
+    match lg {
+        Geometry::LineString(ls) => MultiLineString::new(vec![ls.clone()]),
+        Geometry::MultiLineString(mls) => mls.clone(),
+        other => unreachable!("LineStitcher::finish returned {other:?}"),
+    }
+}
+
+// =======================================================================
 // Tests
 // =======================================================================
 
@@ -1643,6 +1841,326 @@ mod line_stitcher_tests {
         match a.finish() {
             Some(Geometry::LineString(l)) => assert!(l.0.len() <= 3),
             other => panic!("expected simplified LineString, got {other:?}"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod geometry_builder_tests {
+    use super::*;
+    use geo::{Rect, Triangle, coord};
+
+    fn c(x: f64, y: f64) -> Coord<f64> {
+        coord! { x: x, y: y }
+    }
+
+    fn ls(pts: &[(f64, f64)]) -> Geometry<f64> {
+        Geometry::from(LineString::new(pts.iter().map(|&(x, y)| c(x, y)).collect()))
+    }
+
+    /// Unlike [`PolygonAssembler::add_ring`], `GeometryBuilder::add` routes
+    /// purely by `Geometry` variant, so a polygon has to actually be a
+    /// `Geometry::Polygon` here rather than a bare closed `LineString`
+    /// (which `add` would -- correctly -- treat as a line).
+    fn polygon(pts: &[(f64, f64)]) -> Geometry<f64> {
+        let mut coords: Vec<_> = pts.iter().map(|&(x, y)| c(x, y)).collect();
+        if coords.first() != coords.last() {
+            coords.push(coords[0]);
+        }
+        Geometry::from(Polygon::new(LineString::new(coords), vec![]))
+    }
+
+    fn point(x: f64, y: f64) -> Geometry<f64> {
+        Geometry::from(Point::new(x, y))
+    }
+
+    #[test]
+    fn empty_returns_none() {
+        assert!(GeometryBuilder::new().finish().is_none());
+    }
+
+    #[test]
+    fn only_lines_takes_the_line_stitcher_fast_path() {
+        let mut b = GeometryBuilder::new();
+        b.add(&ls(&[(0.0, 0.0), (1.0, 0.0)]));
+        b.add(&ls(&[(1.0, 0.0), (2.0, 0.0)]));
+        match b.finish() {
+            Some(Geometry::LineString(l)) => assert_eq!(l.0.len(), 3),
+            other => panic!("expected stitched LineString, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn only_polygons_takes_the_polygon_assembler_fast_path() {
+        let mut b = GeometryBuilder::new();
+        b.add(&polygon(&[(0.0, 0.0), (4.0, 0.0), (4.0, 4.0), (0.0, 4.0)]));
+        match b.finish() {
+            Some(Geometry::Polygon(p)) => assert_eq!(p.interiors().len(), 0),
+            other => panic!("expected Polygon, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn only_points_returns_multi_point() {
+        let mut b = GeometryBuilder::new();
+        b.add(&point(0.0, 0.0));
+        b.add(&point(1.0, 1.0));
+        match b.finish() {
+            Some(Geometry::MultiPoint(mp)) => assert_eq!(mp.len(), 2),
+            other => panic!("expected MultiPoint, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn multi_point_input_is_flattened() {
+        let mp = Geometry::from(MultiPoint::new(vec![
+            Point::new(0.0, 0.0),
+            Point::new(1.0, 1.0),
+        ]));
+        let mut b = GeometryBuilder::new();
+        b.add(&mp);
+        match b.finish() {
+            Some(Geometry::MultiPoint(mp)) => assert_eq!(mp.len(), 2),
+            other => panic!("expected MultiPoint, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn multi_line_string_and_multi_polygon_inputs_are_routed_correctly() {
+        let mls = Geometry::from(MultiLineString::new(vec![
+            LineString::new(vec![c(0.0, 0.0), c(1.0, 0.0)]),
+            LineString::new(vec![c(5.0, 5.0), c(6.0, 5.0)]),
+        ]));
+        let mut lines_only = GeometryBuilder::new();
+        lines_only.add(&mls);
+        match lines_only.finish() {
+            Some(Geometry::MultiLineString(m)) => assert_eq!(m.0.len(), 2),
+            other => panic!("expected MultiLineString, got {other:?}"),
+        }
+
+        let mpoly = Geometry::from(MultiPolygon::new(vec![
+            Polygon::new(
+                LineString::new(vec![
+                    c(0.0, 0.0),
+                    c(2.0, 0.0),
+                    c(2.0, 2.0),
+                    c(0.0, 2.0),
+                    c(0.0, 0.0),
+                ]),
+                vec![],
+            ),
+            Polygon::new(
+                LineString::new(vec![
+                    c(10.0, 10.0),
+                    c(12.0, 10.0),
+                    c(12.0, 12.0),
+                    c(10.0, 12.0),
+                    c(10.0, 10.0),
+                ]),
+                vec![],
+            ),
+        ]));
+        let mut polys_only = GeometryBuilder::new();
+        polys_only.add(&mpoly);
+        match polys_only.finish() {
+            Some(Geometry::MultiPolygon(mp)) => assert_eq!(mp.0.len(), 2),
+            other => panic!("expected MultiPolygon, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn disjoint_line_and_polygon_combine_into_geometry_collection() {
+        let mut b = GeometryBuilder::new();
+        b.add(&polygon(&[(0.0, 0.0), (4.0, 0.0), (4.0, 4.0), (0.0, 4.0)]));
+        b.add(&ls(&[(10.0, 10.0), (11.0, 10.0)]));
+        match b.finish() {
+            Some(Geometry::GeometryCollection(gc)) => {
+                assert_eq!(gc.0.len(), 2);
+                assert!(gc.0.iter().any(|g| matches!(g, Geometry::Polygon(_))));
+                assert!(gc.0.iter().any(|g| matches!(g, Geometry::LineString(_))));
+            }
+            other => panic!("expected GeometryCollection, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn line_fully_inside_polygon_is_clipped_away_entirely() {
+        let mut b = GeometryBuilder::new();
+        b.add(&polygon(&[
+            (0.0, 0.0),
+            (10.0, 0.0),
+            (10.0, 10.0),
+            (0.0, 10.0),
+        ]));
+        b.add(&ls(&[(2.0, 2.0), (8.0, 8.0)])); // wholly inside, touches no boundary
+        match b.finish() {
+            // The line contributes no new territory, so only the polygon survives
+            // -- and since only one part is left, it's returned unwrapped rather
+            // than as a 1-element GeometryCollection.
+            Some(Geometry::Polygon(_)) => {}
+            other => panic!("expected the line to be clipped away, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn line_crossing_polygon_boundary_keeps_only_its_outside_portion() {
+        let mut b = GeometryBuilder::new();
+        b.add(&polygon(&[
+            (0.0, 0.0),
+            (10.0, 0.0),
+            (10.0, 10.0),
+            (0.0, 10.0),
+        ]));
+        // Crosses clean through the square at y=5: outside on both ends.
+        b.add(&ls(&[(-5.0, 5.0), (15.0, 5.0)]));
+        match b.finish() {
+            Some(Geometry::GeometryCollection(gc)) => {
+                assert_eq!(gc.0.len(), 2);
+                assert!(gc.0.iter().any(|g| matches!(g, Geometry::Polygon(_))));
+                let remaining_line_coords: usize =
+                    gc.0.iter()
+                        .map(|g| match g {
+                            Geometry::LineString(l) => l.0.len(),
+                            Geometry::MultiLineString(m) => m.0.iter().map(|l| l.0.len()).sum(),
+                            _ => 0,
+                        })
+                        .sum();
+                // Both outside segments ((-5,5)-(0,5) and (10,5)-(15,5)) should
+                // remain; none of the coordinates should fall strictly inside
+                // the square.
+                assert!(remaining_line_coords >= 4);
+                for g in &gc.0 {
+                    let coords: Vec<Coord<f64>> = match g {
+                        Geometry::LineString(l) => l.0.clone(),
+                        Geometry::MultiLineString(m) => {
+                            m.0.iter().flat_map(|l| l.0.clone()).collect()
+                        }
+                        _ => continue,
+                    };
+                    for c in coords {
+                        assert!(
+                            c.x <= 0.0 || c.x >= 10.0,
+                            "expected only the outside portion, found {c:?}"
+                        );
+                    }
+                }
+            }
+            other => panic!("expected GeometryCollection, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn point_inside_polygon_is_omitted() {
+        let mut b = GeometryBuilder::new();
+        b.add(&polygon(&[
+            (0.0, 0.0),
+            (10.0, 0.0),
+            (10.0, 10.0),
+            (0.0, 10.0),
+        ]));
+        b.add(&point(5.0, 5.0));
+        match b.finish() {
+            Some(Geometry::Polygon(_)) => {}
+            other => panic!("expected the point to be omitted, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn point_outside_polygon_is_kept() {
+        let mut b = GeometryBuilder::new();
+        b.add(&polygon(&[
+            (0.0, 0.0),
+            (10.0, 0.0),
+            (10.0, 10.0),
+            (0.0, 10.0),
+        ]));
+        b.add(&point(50.0, 50.0));
+        match b.finish() {
+            Some(Geometry::GeometryCollection(gc)) => {
+                assert_eq!(gc.0.len(), 2);
+                assert!(gc.0.iter().any(|g| matches!(g, Geometry::Polygon(_))));
+                assert!(gc.0.iter().any(|g| matches!(g, Geometry::Point(_))));
+            }
+            other => panic!("expected GeometryCollection, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn point_on_line_is_omitted() {
+        let mut b = GeometryBuilder::new();
+        b.add(&ls(&[(0.0, 0.0), (10.0, 0.0)]));
+        b.add(&point(5.0, 0.0)); // sits exactly on the line
+        match b.finish() {
+            Some(Geometry::LineString(_)) => {}
+            other => panic!("expected the point to be omitted, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn point_off_line_is_kept() {
+        let mut b = GeometryBuilder::new();
+        b.add(&ls(&[(0.0, 0.0), (10.0, 0.0)]));
+        b.add(&point(5.0, 5.0));
+        match b.finish() {
+            Some(Geometry::GeometryCollection(gc)) => {
+                assert_eq!(gc.0.len(), 2);
+                assert!(gc.0.iter().any(|g| matches!(g, Geometry::LineString(_))));
+                assert!(gc.0.iter().any(|g| matches!(g, Geometry::Point(_))));
+            }
+            other => panic!("expected GeometryCollection, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn geometry_collection_input_is_flattened() {
+        let gc = Geometry::GeometryCollection(GeometryCollection::new_from(vec![
+            ls(&[(10.0, 10.0), (11.0, 10.0)]),
+            polygon(&[(0.0, 0.0), (4.0, 0.0), (4.0, 4.0), (0.0, 4.0)]),
+        ]));
+        let mut b = GeometryBuilder::new();
+        b.add(&gc);
+        match b.finish() {
+            Some(Geometry::GeometryCollection(gc)) => {
+                assert_eq!(gc.0.len(), 2);
+                assert!(gc.0.iter().any(|g| matches!(g, Geometry::Polygon(_))));
+                assert!(gc.0.iter().any(|g| matches!(g, Geometry::LineString(_))));
+            }
+            other => panic!("expected GeometryCollection, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn line_variant_is_routed_to_line_stitcher() {
+        let mut b = GeometryBuilder::new();
+        b.add(&Geometry::from(Line::new(c(0.0, 0.0), c(1.0, 0.0))));
+        b.add(&Geometry::from(Line::new(c(1.0, 0.0), c(2.0, 0.0))));
+        match b.finish() {
+            Some(Geometry::LineString(l)) => assert_eq!(l.0.len(), 3),
+            other => panic!("expected stitched LineString, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rect_variant_is_routed_to_polygon_assembler() {
+        let mut b = GeometryBuilder::new();
+        b.add(&Geometry::from(Rect::new(c(0.0, 0.0), c(4.0, 4.0))));
+        match b.finish() {
+            Some(Geometry::Polygon(p)) => assert_eq!(p.interiors().len(), 0),
+            other => panic!("expected Polygon, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn triangle_variant_is_routed_to_polygon_assembler() {
+        let mut b = GeometryBuilder::new();
+        b.add(&Geometry::from(Triangle::new(
+            c(0.0, 0.0),
+            c(4.0, 0.0),
+            c(0.0, 4.0),
+        )));
+        match b.finish() {
+            Some(Geometry::Polygon(p)) => assert_eq!(p.interiors().len(), 0),
+            other => panic!("expected Polygon, got {other:?}"),
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adds `GeometryBuilder` to `src/pipeline/osm/geometry.rs`, which accepts any `geo::Geometry` and routes it to the existing `LineStitcher` (lines) or `PolygonAssembler` (polygons), or accumulates raw coordinates (points).
- `finish()` fast-paths the common case (only lines, or only polygons) by returning the relevant assembler's result directly.
- When mixed types are added, `finish()` computes a true set-theoretic union: lines are clipped to the portion outside the assembled polygon area (via `geo`'s `BooleanOps::clip`), and points already covered by the (clipped) lines or polygon are dropped, since they add no new territory. The surviving parts are combined into a `GeometryCollection` (or returned unwrapped if only one part survives).
- `GeometryCollection` input is flattened by recursing into its members; `Line`/`Rect`/`Triangle` variants are routed to the line/polygon accumulators respectively.

## Test plan
- [x] `cargo test --lib pipeline::osm::geometry` — 61 tests pass, including 16 new tests covering the fast paths, mixed-type union/clipping behavior, point containment filtering, and `GeometryCollection`/`Line`/`Rect`/`Triangle` routing.
- [x] `cargo clippy --lib -- -D warnings` — clean.
- [x] `cargo fmt --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)