### PR TITLE
Add BlobTable to store variable-length byte blobs keyed by u64

### DIFF
--- a/src/tables/blob_table.rs
+++ b/src/tables/blob_table.rs
@@ -1,0 +1,269 @@
+//! Disk-based, potentially very large map with `u64` keys and byte-string values.
+//!
+//! Unlike [crate::tables::CoordsMap], whose values have a fixed size,
+//! `BlobTable` values may be of any length, so it is suited for things
+//! like serialized protobuf messages or other opaque binary payloads.
+
+use anyhow::{Ok, Result};
+use memmap2::Mmap;
+use std::{
+    fs::{File, remove_file, rename},
+    io::{BufWriter, Seek, SeekFrom, Write},
+    mem::size_of,
+    path::{Path, PathBuf},
+    time::SystemTime,
+};
+
+const HEADER_SIZE: usize = 8 * 8;
+const FILE_SIGNATURE: &[u8; 8] = b"blobtbl0";
+
+pub struct BlobTable<'a> {
+    file: File,
+    _mmap: Mmap,
+    entries_count: usize,
+    keys: &'a [u64],
+    starts: &'a [u64],
+    blob: &'a [u8],
+}
+
+impl<'a> BlobTable<'a> {
+    pub fn open(path: &Path) -> Result<BlobTable<'a>> {
+        let file = File::open(path)?;
+
+        // SAFETY: We don’t modify the file while it is mapped into memory.
+        let mmap = unsafe { Mmap::map(&file)? };
+        if mmap.len() < HEADER_SIZE || &mmap[0..8] != FILE_SIGNATURE {
+            anyhow::bail!("not a BlobTable: {}", path.display());
+        }
+
+        // SAFETY: mmap.len() checked above; offset 0 is aligned for u64.
+        let header = unsafe {
+            let ptr = mmap.as_ptr() as *const u64;
+            std::slice::from_raw_parts(ptr, HEADER_SIZE / size_of::<u64>())
+        };
+        let entries_count = usize::try_from(header[1])?;
+
+        let keys = {
+            let keys_count = entries_count;
+            let keys_offset = usize::try_from(header[2])?;
+            if keys_offset.is_multiple_of(8) && keys_offset + keys_count * 8 <= mmap.len() {
+                // SAFETY: Verified alignment and length.
+                unsafe {
+                    let ptr = mmap.as_ptr().add(keys_offset) as *const u64;
+                    std::slice::from_raw_parts(ptr, keys_count)
+                }
+            } else {
+                anyhow::bail!("misaligned keys in BlobTable: {}", path.display());
+            }
+        };
+
+        let starts = {
+            let starts_count = entries_count + 1;
+            let starts_offset = usize::try_from(header[3])?;
+            if starts_offset.is_multiple_of(8) && starts_offset + starts_count * 8 <= mmap.len() {
+                // SAFETY: Verified alignment and length.
+                unsafe {
+                    let ptr = mmap.as_ptr().add(starts_offset) as *const u64;
+                    std::slice::from_raw_parts(ptr, starts_count)
+                }
+            } else {
+                anyhow::bail!("misaligned starts in BlobTable: {}", path.display());
+            }
+        };
+
+        let blob = {
+            let blob_offset = usize::try_from(header[4])?;
+            if blob_offset <= mmap.len() {
+                // SAFETY: Verified length; no alignment constraints of &[u8].
+                unsafe {
+                    let ptr = mmap.as_ptr().add(blob_offset);
+                    std::slice::from_raw_parts(ptr, mmap.len() - blob_offset)
+                }
+            } else {
+                anyhow::bail!("misplaced blob in BlobTable: {}", path.display());
+            }
+        };
+
+        Ok(BlobTable {
+            file,
+            _mmap: mmap,
+            entries_count,
+            keys,
+            starts,
+            blob,
+        })
+    }
+
+    pub fn lookup(&self, key: u64) -> Option<&'a [u8]> {
+        let idx = self.keys.partition_point(|&k| u64::from_le(k) < key);
+        if idx < self.keys.len() && u64::from_le(self.keys[idx]) == key {
+            let start = u64::from_le(self.starts[idx]) as usize;
+            let end = u64::from_le(self.starts[idx + 1]) as usize;
+            Some(&self.blob[start..end])
+        } else {
+            None
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries_count
+    }
+
+    /// Returns the modification time of the backing file.
+    #[allow(unused)]
+    pub fn modified(&self) -> Result<SystemTime> {
+        Ok(self.file.metadata()?.modified()?)
+    }
+}
+
+struct Writer {
+    path: PathBuf,
+    tmp_path: PathBuf,
+    writer: BufWriter<File>,
+
+    starts_path: PathBuf,
+    starts_writer: BufWriter<File>,
+
+    blob_path: PathBuf,
+    blob_writer: BufWriter<File>,
+
+    entries_count: u64,
+    last_key: Option<u64>,
+}
+
+impl Writer {
+    pub fn create(path: &Path) -> Result<Writer> {
+        let mut tmp_path = PathBuf::from(path);
+        tmp_path.add_extension("tmp");
+        let mut writer = BufWriter::with_capacity(32 * 1024, File::create(&tmp_path)?);
+        writer.write_all(&[0_u8; HEADER_SIZE])?;
+
+        let mut starts_path = PathBuf::from(path);
+        starts_path.add_extension("starts.tmp");
+        let starts_writer = BufWriter::with_capacity(32 * 1024, File::create(&starts_path)?);
+
+        let mut blob_path = PathBuf::from(path);
+        blob_path.add_extension("blob.tmp");
+        let blob_writer = BufWriter::with_capacity(32 * 1024, File::create(&blob_path)?);
+
+        Ok(Writer {
+            path: PathBuf::from(path),
+            tmp_path,
+            writer,
+            starts_path,
+            starts_writer,
+            blob_path,
+            blob_writer,
+            entries_count: 0,
+            last_key: None,
+        })
+    }
+
+    /// Appends `blob` under `key`. Keys must be written in strictly
+    /// ascending order, so that [BlobTable::lookup] can binary-search them.
+    pub fn write(&mut self, key: u64, blob: &[u8]) -> Result<()> {
+        if let Some(last_key) = self.last_key
+            && key <= last_key
+        {
+            anyhow::bail!(
+                "keys must be written in ascending order, but {} <= {}",
+                key,
+                last_key,
+            );
+        }
+
+        let start: u64 = self.blob_writer.stream_position()?;
+        self.starts_writer.write_all(&start.to_le_bytes())?;
+        self.blob_writer.write_all(blob)?;
+
+        self.writer.write_all(&key.to_le_bytes())?;
+        self.last_key = Some(key);
+        self.entries_count += 1;
+
+        Ok(())
+    }
+
+    pub fn close(mut self) -> Result<()> {
+        // Write sentinel to end of starts array.
+        let blob_size: u64 = self.blob_writer.stream_position()?;
+        self.starts_writer.write_all(&blob_size.to_le_bytes())?;
+
+        let keys_offset = HEADER_SIZE as u64;
+        let starts_offset = keys_offset + self.entries_count * 8;
+        let blob_offset = starts_offset + (self.entries_count + 1) * 8;
+        assert_eq!(self.writer.stream_position()?, starts_offset);
+
+        // Copy starts array into the output file.
+        self.starts_writer.flush()?; // flush() returns errors
+        drop(self.starts_writer); // drop() does not return errors
+        std::io::copy(&mut File::open(&self.starts_path)?, &mut self.writer)?;
+        remove_file(&self.starts_path)?;
+        assert_eq!(self.writer.stream_position()?, blob_offset);
+
+        // Copy blob data into the output file.
+        self.blob_writer.flush()?; // flush() returns errors
+        drop(self.blob_writer); // drop() does not return errors
+        std::io::copy(&mut File::open(&self.blob_path)?, &mut self.writer)?;
+        remove_file(&self.blob_path)?;
+
+        // Write file header.
+        self.writer.seek(SeekFrom::Start(0))?;
+        self.writer.write_all(FILE_SIGNATURE)?; // header[0] = magic
+        self.writer.write_all(&self.entries_count.to_le_bytes())?; // header[1] = entries_count
+        self.writer.write_all(&keys_offset.to_le_bytes())?; // header[2] = keys_offset
+        self.writer.write_all(&starts_offset.to_le_bytes())?; // header[3] = starts_offset
+        self.writer.write_all(&blob_offset.to_le_bytes())?; // header[4] = blob_offset
+        assert!(self.writer.stream_position()? <= HEADER_SIZE as u64);
+
+        self.writer.seek(SeekFrom::End(0))?;
+        self.writer.flush()?; // flush() returns errors
+        drop(self.writer); // drop() does not return errors
+
+        rename(&self.tmp_path, &self.path)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn test_blob_table() -> Result<()> {
+        let file = NamedTempFile::new()?;
+        let mut writer = Writer::create(file.path())?;
+        writer.write(17, b"bern")?;
+        writer.write(41, b"")?;
+        writer.write(42, b"ottawa")?;
+        writer.write(44, b"melbourne")?;
+        writer.close()?;
+        let file_metadata = std::fs::metadata(file.path())?;
+
+        let table = BlobTable::open(file.path())?;
+        assert_eq!(table.modified()?, file_metadata.modified()?);
+        assert_eq!(table.len(), 4);
+
+        assert_eq!(table.lookup(0), None);
+        assert_eq!(table.lookup(16), None);
+        assert_eq!(table.lookup(17), Some(b"bern".as_slice()));
+        assert_eq!(table.lookup(18), None);
+        assert_eq!(table.lookup(41), Some(b"".as_slice()));
+        assert_eq!(table.lookup(42), Some(b"ottawa".as_slice()));
+        assert_eq!(table.lookup(43), None);
+        assert_eq!(table.lookup(44), Some(b"melbourne".as_slice()));
+        assert_eq!(table.lookup(99), None);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_write_requires_ascending_keys() -> Result<()> {
+        let file = NamedTempFile::new()?;
+        let mut writer = Writer::create(file.path())?;
+        writer.write(42, b"a")?;
+        assert!(writer.write(41, b"b").is_err());
+        assert!(writer.write(42, b"c").is_err());
+        Ok(())
+    }
+}

--- a/src/tables/mod.rs
+++ b/src/tables/mod.rs
@@ -5,6 +5,8 @@
 //! physical RAM installed on the machine. This makes it possible to
 //! process the entire OpenStreetMap planet on cheap worker machine.
 
+#[allow(unused)]
+mod blob_table;
 mod coords_map;
 mod graph;
 #[allow(unused)]
@@ -17,6 +19,8 @@ mod features {
     include!(concat!(env!("OUT_DIR"), "/tables.features.rs"));
 }
 
+#[allow(unused)]
+pub use blob_table::BlobTable;
 pub use coords_map::CoordsMap;
 pub use features::{Feature, FeatureToIndex};
 pub use graph::{Edge, GraphTable};


### PR DESCRIPTION
## Summary
- Adds `src/tables/blob_table.rs`, a memory-mapped `u64 -> &[u8]` table in the same on-disk style as `CoordsMap`/`StringPool`: sorted keys for binary-search lookup, plus a `starts` offset array so values can be of arbitrary length.
- `Writer::write(key, blob)` appends entries and requires strictly ascending keys (like `CoordsMap`'s writer); `BlobTable::lookup(key)` returns `Option<&[u8]>`.
- Registered the new module in `src/tables/mod.rs`.

## Test plan
- [x] `cargo test --lib tables::blob_table` passes (lookup behavior incl. empty blobs/missing keys, and ascending-key enforcement)
- [x] `cargo build --lib` and `cargo clippy --lib --tests` show no new warnings

https://github.com/alltheplaces/osm-diffs/issues/187

🤖 Generated with [Claude Code](https://claude.com/claude-code)