### PR TITLE
Add BlobTable::iter()

### DIFF
--- a/src/tables/blob_table.rs
+++ b/src/tables/blob_table.rs
@@ -139,6 +139,16 @@ impl<'a> BlobTable<'a> {
         self.entries_count
     }
 
+    /// Returns an iterator over all entries, in ascending order of key.
+    pub fn iter(&self) -> impl Iterator<Item = (u64, &'a [u8])> + '_ {
+        (0..self.entries_count).map(move |i| {
+            let key = u64::from_le(self.keys[i]);
+            let start = u64::from_le(self.starts[i]) as usize;
+            let end = u64::from_le(self.starts[i + 1]) as usize;
+            (key, &self.blob[start..end])
+        })
+    }
+
     /// Returns the modification time of the backing file.
     #[allow(unused)]
     pub fn modified(&self) -> Result<SystemTime> {
@@ -306,6 +316,29 @@ mod tests {
         assert_eq!(table.lookup(43), None);
         assert_eq!(table.lookup(44), Some(b"melbourne".as_slice()));
         assert_eq!(table.lookup(99), None);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_iter() -> Result<()> {
+        let file = NamedTempFile::new()?;
+        let mut writer = Writer::create(file.path())?;
+        writer.write(17, b"bern")?;
+        writer.write(41, b"")?;
+        writer.write(42, b"ottawa")?;
+        writer.close()?;
+
+        let table = BlobTable::open(file.path())?;
+        let entries: Vec<(u64, &[u8])> = table.iter().collect();
+        assert_eq!(
+            entries,
+            vec![
+                (17, b"bern".as_slice()),
+                (41, b"".as_slice()),
+                (42, b"ottawa".as_slice()),
+            ]
+        );
 
         Ok(())
     }


### PR DESCRIPTION
## Summary
- Add `BlobTable::iter()`, returning an iterator over all entries as `(u64, &[u8])` pairs in ascending key order, mirroring the indexing logic already used by `lookup()`.
- Add `test_iter` unit test.

## Test plan
- [x] `cargo test --lib tables::blob_table`