### PR TITLE
Document file formats and fill test gaps in src/tables

### DIFF
--- a/src/tables/coord_table.rs
+++ b/src/tables/coord_table.rs
@@ -274,11 +274,41 @@ impl Writer {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tempfile::NamedTempFile;
+    use tempfile::{NamedTempFile, TempDir};
 
     fn almost_equal(a: Coord, b: Coord) -> bool {
         const EPSILON: f64 = 1e-10;
         (a.x - b.x).abs() < EPSILON && (a.y - b.y).abs() < EPSILON
+    }
+
+    #[test]
+    fn test_create_sorts_unsorted_input() -> Result<()> {
+        let workdir = TempDir::new()?;
+        let file = NamedTempFile::new()?;
+        let coords = vec![
+            (44, Coord { x: 144.96332, y: -37.814 }),
+            (17, Coord { x: 7.44744, y: 46.94809 }),
+            (42, Coord { x: -75.69812, y: 45.41117 }),
+        ];
+
+        let table = CoordTable::create(coords.into_iter(), workdir.path(), file.path())?;
+        assert_eq!(table.len(), 3);
+        assert_eq!(table.get(0), None);
+        assert!(almost_equal(
+            table.get(17).unwrap(),
+            Coord { x: 7.44744, y: 46.94809 }
+        ));
+        assert!(almost_equal(
+            table.get(42).unwrap(),
+            Coord { x: -75.69812, y: 45.41117 }
+        ));
+        assert!(almost_equal(
+            table.get(44).unwrap(),
+            Coord { x: 144.96332, y: -37.814 }
+        ));
+        assert_eq!(table.get(99), None);
+
+        Ok(())
     }
 
     #[test]

--- a/src/tables/coord_table.rs
+++ b/src/tables/coord_table.rs
@@ -286,9 +286,27 @@ mod tests {
         let workdir = TempDir::new()?;
         let file = NamedTempFile::new()?;
         let coords = vec![
-            (44, Coord { x: 144.96332, y: -37.814 }),
-            (17, Coord { x: 7.44744, y: 46.94809 }),
-            (42, Coord { x: -75.69812, y: 45.41117 }),
+            (
+                44,
+                Coord {
+                    x: 144.96332,
+                    y: -37.814,
+                },
+            ),
+            (
+                17,
+                Coord {
+                    x: 7.44744,
+                    y: 46.94809,
+                },
+            ),
+            (
+                42,
+                Coord {
+                    x: -75.69812,
+                    y: 45.41117,
+                },
+            ),
         ];
 
         let table = CoordTable::create(coords.into_iter(), workdir.path(), file.path())?;
@@ -296,15 +314,24 @@ mod tests {
         assert_eq!(table.get(0), None);
         assert!(almost_equal(
             table.get(17).unwrap(),
-            Coord { x: 7.44744, y: 46.94809 }
+            Coord {
+                x: 7.44744,
+                y: 46.94809
+            }
         ));
         assert!(almost_equal(
             table.get(42).unwrap(),
-            Coord { x: -75.69812, y: 45.41117 }
+            Coord {
+                x: -75.69812,
+                y: 45.41117
+            }
         ));
         assert!(almost_equal(
             table.get(44).unwrap(),
-            Coord { x: 144.96332, y: -37.814 }
+            Coord {
+                x: 144.96332,
+                y: -37.814
+            }
         ));
         assert_eq!(table.get(99), None);
 

--- a/src/tables/graph.rs
+++ b/src/tables/graph.rs
@@ -1,3 +1,36 @@
+//! Disk-based, memory-mapped directed graph with `u64` node IDs.
+//!
+//! `GraphTable` is used to represent the "is member of" relation between
+//! OpenStreetMap relations: a relation may itself be a member of other,
+//! "super", relations, so the pipeline needs a graph of which relation
+//! (the child) is contained in which other relation (the parent).
+//! [GraphTable::ancestors] walks the transitive closure of that relation
+//! starting at a node; [GraphTable::nodes] yields every node bottom-up,
+//! which is useful for building the geometry of a relation only once the
+//! geometries of every relation it contains have already been built.
+//!
+//! # File format
+//!
+//! ```text
+//! byte 0..8:  magic "graph_v0"
+//! byte 8..16: edge count, u64 little-endian
+//! byte 16..:  children array, `edge count` entries, u64 little-endian
+//!             each
+//! byte ..:    parents array, `edge count` entries, u64 little-endian
+//!             each, aligned 1:1 with the children array
+//! ```
+//!
+//! The children and parents arrays are two parallel columns of one
+//! `(child, parent)` edge list: edge `i` is `(children[i], parents[i])`.
+//! They are sorted ascending by `(child, parent)` (see [Edge]'s derived
+//! [Ord]), which is what makes the binary search in
+//! [GraphTable::parent_range] possible; a node with several outgoing
+//! edges appears several times in `children`.
+//!
+//! The header is a fixed 16 bytes so that the children and parents
+//! arrays, which follow it back to back, stay 8-byte aligned and can be
+//! reinterpreted as `&[u64]` slices directly on the mmap'd bytes.
+
 use anyhow::{Ok, Result};
 use ext_sort::{ExternalSorter, ExternalSorterBuilder, buffer::LimitedBufferBuilder};
 use memmap2::Mmap;
@@ -12,6 +45,15 @@ use std::{
     time::SystemTime,
 };
 
+/// Size of the file header, in bytes: see the "File format" section above.
+const HEADER_SIZE: usize = 16;
+
+/// Magic bytes identifying a `GraphTable` file, written as the first
+/// eight bytes of the file header.
+const FILE_SIGNATURE: &[u8; 8] = b"graph_v0";
+
+/// Read-only, memory-mapped directed graph of `(child, parent)` edges. See
+/// the "File format" section above.
 pub struct GraphTable<'a> {
     file: File,
     _mmap: Mmap,
@@ -20,6 +62,11 @@ pub struct GraphTable<'a> {
 }
 
 impl<'a> GraphTable<'a> {
+    /// Builds a `GraphTable` from `edges`, which may be in any order.
+    ///
+    /// Since [Writer::write] requires edges in ascending `(child, parent)`
+    /// order, `edges` is first sorted using external sorting (spilling to
+    /// `workdir` as needed), and only then written to `out`.
     pub fn create(
         edges: impl Iterator<Item = Edge>,
         workdir: &Path,
@@ -46,14 +93,22 @@ impl<'a> GraphTable<'a> {
         Self::open(out)
     }
 
+    /// Opens a `GraphTable` previously written by [GraphTable::create],
+    /// mapping it into memory rather than reading it into a
+    /// heap-allocated buffer.
     #[cfg(target_pointer_width = "64")]
     pub fn open(path: &Path) -> Result<GraphTable<'a>> {
         let file = File::open(path)?;
 
         // SAFETY: We don’t truncate the file while it’s mapped into memory.
         let mmap = unsafe { Mmap::map(&file)? };
-        let edge_count = usize::from_le_bytes(mmap[0..8].try_into().expect("edge_count"));
-        let expected_size = 8 + edge_count * 16;
+        if mmap.len() < HEADER_SIZE || mmap[0..8] != *FILE_SIGNATURE {
+            anyhow::bail!("not a GraphTable: {}", path.display());
+        }
+
+        let edge_count =
+            usize::try_from(u64::from_le_bytes(mmap[8..16].try_into().expect("edge_count")))?;
+        let expected_size = HEADER_SIZE + edge_count * 16;
         if mmap.len() != expected_size {
             anyhow::bail!(
                 "{} has wrong file size, expected {}, got {}",
@@ -65,13 +120,13 @@ impl<'a> GraphTable<'a> {
 
         // SAFETY: mmap.len() checked above.
         let children = unsafe {
-            let ptr = mmap.as_ptr().add(8) as *const u64;
+            let ptr = mmap.as_ptr().add(HEADER_SIZE) as *const u64;
             std::slice::from_raw_parts(ptr, edge_count)
         };
 
         // SAFETY: mmap.len() checked above.
         let parents = unsafe {
-            let ptr = mmap.as_ptr().add(8 + edge_count * 8) as *const u64;
+            let ptr = mmap.as_ptr().add(HEADER_SIZE + edge_count * 8) as *const u64;
             std::slice::from_raw_parts(ptr, edge_count)
         };
 
@@ -83,6 +138,7 @@ impl<'a> GraphTable<'a> {
         })
     }
 
+    /// Returns the modification time of the backing file.
     #[allow(unused)]
     pub fn modified(&'a self) -> Result<SystemTime> {
         Ok(self.file.metadata()?.modified()?)
@@ -187,6 +243,12 @@ impl<'a> GraphTable<'a> {
     }
 }
 
+/// One edge of a [GraphTable]: `child` is contained in `parent`.
+///
+/// Derives [Ord] over `(child, parent)` in field-declaration order, which
+/// [GraphTable::create] relies on to sort edges into the ascending order
+/// required by [Writer::write] (see the "File format" section at the top
+/// of this module).
 #[derive(Serialize, Deserialize, Ord, PartialOrd, PartialEq, Eq)]
 pub struct Edge {
     pub child: u64,
@@ -256,6 +318,14 @@ impl<'a> Iterator for NodesIter<'a> {
     }
 }
 
+/// Writes a [GraphTable] file, one edge at a time.
+///
+/// Children and parents are appended to separate files as edges arrive
+/// (parents to a temporary side file); [Writer::close] then concatenates
+/// them behind a fixed-size header and atomically renames the result into
+/// place. Splitting the files this way avoids seeking back and forth in
+/// the output file, since the total number of edges — and thus the offset
+/// of the parents array — is not known until all edges have been written.
 pub struct Writer {
     edge_count: u64,
     path: PathBuf,
@@ -269,7 +339,8 @@ impl Writer {
         let mut tmp_path = PathBuf::from(path);
         tmp_path.add_extension("tmp");
         let mut out = BufWriter::with_capacity(32768, File::create(&tmp_path)?);
-        out.write_all(&0_u64.to_le_bytes())?;
+        out.write_all(FILE_SIGNATURE)?;
+        out.write_all(&0_u64.to_le_bytes())?; // placeholder edge count
 
         let parents_file = File::create(Self::parents_path(path))?;
 
@@ -282,6 +353,9 @@ impl Writer {
         })
     }
 
+    /// Appends `edge`. Edges must be written in ascending `(child, parent)`
+    /// order, so that [GraphTable::parent_range] can binary-search the
+    /// children array.
     pub fn write(&mut self, edge: Edge) -> Result<()> {
         self.edge_count += 1;
         self.out.write_all(&edge.child.to_le_bytes())?;
@@ -301,7 +375,7 @@ impl Writer {
         remove_file(&parents_path)?;
         drop(parents_path);
 
-        self.out.seek(SeekFrom::Start(0))?;
+        self.out.seek(SeekFrom::Start(8))?;
         self.out.write_all(&self.edge_count.to_le_bytes())?;
 
         self.out.flush()?;
@@ -383,6 +457,56 @@ mod tests {
         let path = workdir.path().join("testgraph");
         let graph = GraphTable::create(edges_iter, &workdir.path(), &path)?;
         assert_eq!(graph.nodes().collect::<Vec<u64>>(), Vec::<u64>::new());
+        Ok(())
+    }
+
+    #[test]
+    fn test_writer_used_directly() -> Result<()> {
+        let workdir = TempDir::new()?;
+        let path = workdir.path().join("testgraph");
+        let mut writer = Writer::create(&path)?;
+        writer.write(Edge { child: 1, parent: 2 })?;
+        writer.write(Edge { child: 2, parent: 3 })?;
+        writer.close()?;
+
+        let graph = GraphTable::open(&path)?;
+        assert_eq!(graph.ancestors(1).collect::<Vec<u64>>(), &[1, 2, 3]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_open_rejects_file_without_signature() -> Result<()> {
+        let workdir = TempDir::new()?;
+        let path = workdir.path().join("not-a-graph");
+        std::fs::write(&path, [0u8; HEADER_SIZE])?;
+        assert!(GraphTable::open(&path).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn test_open_rejects_truncated_file() -> Result<()> {
+        let workdir = TempDir::new()?;
+        let path = workdir.path().join("too-short");
+        std::fs::write(&path, FILE_SIGNATURE)?;
+        assert!(GraphTable::open(&path).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn test_open_rejects_wrong_file_size() -> Result<()> {
+        let workdir = TempDir::new()?;
+        let path = workdir.path().join("wrong-size");
+        let mut writer = Writer::create(&path)?;
+        writer.write(Edge { child: 1, parent: 2 })?;
+        writer.close()?;
+
+        // Truncate the file so the edge count in the header no longer
+        // matches the actual size of the children/parents arrays.
+        let file = std::fs::OpenOptions::new().write(true).open(&path)?;
+        file.set_len(HEADER_SIZE as u64 + 8)?;
+        drop(file);
+
+        assert!(GraphTable::open(&path).is_err());
         Ok(())
     }
 }

--- a/src/tables/graph.rs
+++ b/src/tables/graph.rs
@@ -106,8 +106,9 @@ impl<'a> GraphTable<'a> {
             anyhow::bail!("not a GraphTable: {}", path.display());
         }
 
-        let edge_count =
-            usize::try_from(u64::from_le_bytes(mmap[8..16].try_into().expect("edge_count")))?;
+        let edge_count = usize::try_from(u64::from_le_bytes(
+            mmap[8..16].try_into().expect("edge_count"),
+        ))?;
         let expected_size = HEADER_SIZE + edge_count * 16;
         if mmap.len() != expected_size {
             anyhow::bail!(
@@ -465,8 +466,14 @@ mod tests {
         let workdir = TempDir::new()?;
         let path = workdir.path().join("testgraph");
         let mut writer = Writer::create(&path)?;
-        writer.write(Edge { child: 1, parent: 2 })?;
-        writer.write(Edge { child: 2, parent: 3 })?;
+        writer.write(Edge {
+            child: 1,
+            parent: 2,
+        })?;
+        writer.write(Edge {
+            child: 2,
+            parent: 3,
+        })?;
         writer.close()?;
 
         let graph = GraphTable::open(&path)?;
@@ -497,7 +504,10 @@ mod tests {
         let workdir = TempDir::new()?;
         let path = workdir.path().join("wrong-size");
         let mut writer = Writer::create(&path)?;
-        writer.write(Edge { child: 1, parent: 2 })?;
+        writer.write(Edge {
+            child: 1,
+            parent: 2,
+        })?;
         writer.close()?;
 
         // Truncate the file so the edge count in the header no longer

--- a/src/tables/string_counts.rs
+++ b/src/tables/string_counts.rs
@@ -1,3 +1,48 @@
+//! Disk-based, potentially very large map with `String` keys and `u64`
+//! counter values.
+//!
+//! `StringCounts` is used to tally how often each distinct string occurs
+//! across a large input (for example, how often each tag key appears in
+//! an OpenStreetMap planet dump), without keeping every string in RAM at
+//! once. Entries with the same key passed to [StringCounts::create] are
+//! summed into a single counter; an entry whose total ends up at zero is
+//! dropped rather than written out.
+//!
+//! # File format
+//!
+//! ```text
+//! byte 0..8:   magic "strcnt_0"
+//! byte 8..16:  entry count, u64 little-endian
+//! byte 16..24: offset of the chars array, u64 little-endian
+//! byte 24..32: size of the chars array, u64 little-endian
+//! byte 32..40: offset of the char_offsets array, u64 little-endian
+//!              (always equal to the header size, 64)
+//! byte 40..48: offset of the counter_values array, u64 little-endian
+//! byte 48..64: reserved, zero-filled
+//!
+//! char_offsets array:   `entry count + 1` entries, u64 little-endian
+//!                       each, immediately following the header.
+//!                       `char_offsets[i]` is the byte offset into the
+//!                       chars array where the string of the i-th entry
+//!                       (in ascending order) begins;
+//!                       `char_offsets[entry count]` is a sentinel equal
+//!                       to the size of the chars array.
+//!
+//! counter_values array: `entry count` entries, u64 little-endian each,
+//!                       aligned 1:1 with char_offsets, immediately
+//!                       following it. `counter_values[i]` is the summed
+//!                       count for the i-th entry's string.
+//!
+//! chars array:          the UTF-8 bytes of every string, concatenated in
+//!                       ascending order, immediately following the
+//!                       counter_values array.
+//! ```
+//!
+//! The header is a fixed 64 bytes so that the char_offsets and
+//! counter_values arrays, which follow it back to back, stay 8-byte
+//! aligned and can be reinterpreted as `&[u64]` slices directly on the
+//! mmap'd bytes.
+
 use anyhow::{Ok, Result};
 use ext_sort::{ExternalSorter, ExternalSorterBuilder, buffer::LimitedBufferBuilder};
 use memmap2::Mmap;
@@ -9,6 +54,9 @@ use std::{
     time::SystemTime,
 };
 
+/// Read-only, memory-mapped map from `String` keys to `u64` counter
+/// values, iterated in ascending order of key by [StringCounts::iter].
+/// See the "File format" section above.
 pub struct StringCounts<'a> {
     file: File,
     _mmap: Mmap,
@@ -19,10 +67,21 @@ pub struct StringCounts<'a> {
     counter_values: &'a [u64],
 }
 
+/// Size of the file header, in bytes: see the "File format" section above.
 const HEADER_SIZE: usize = 8 * 8;
+
+/// Magic bytes identifying a `StringCounts` file, written as the first
+/// eight bytes of the file header.
 const FILE_SIGNATURE: &[u8; 8] = b"strcnt_0";
 
 impl<'a> StringCounts<'a> {
+    /// Builds a `StringCounts` from `counts`, which may be in any order
+    /// and may repeat the same key multiple times; repeated keys are
+    /// summed into a single entry.
+    ///
+    /// Since [Writer::write] requires keys in ascending order, `counts` is
+    /// first sorted by key using external sorting (spilling to `workdir`
+    /// as needed), and only then written to `out`.
     pub fn create(
         counts: impl Iterator<Item = (String, u64)>,
         workdir: &Path,
@@ -50,6 +109,9 @@ impl<'a> StringCounts<'a> {
         Self::open(out)
     }
 
+    /// Opens a `StringCounts` previously written by
+    /// [StringCounts::create], mapping it into memory rather than reading
+    /// it into a heap-allocated buffer.
     pub fn open(path: &Path) -> Result<StringCounts<'a>> {
         let file = File::open(path)?;
 
@@ -137,10 +199,13 @@ impl<'a> StringCounts<'a> {
         })
     }
 
+    /// Returns the number of entries in the table.
     pub fn len(&self) -> usize {
         self.entries_count
     }
 
+    /// Returns an iterator over all entries, as `(key, count)` pairs, in
+    /// ascending order of key.
     pub fn iter(&self) -> impl Iterator<Item = (&'a str, u64)> + '_ {
         (0..self.len()).map(move |i| {
             let start = usize::try_from(u64::from_le(self.char_offsets[i])).expect("char_offset");
@@ -154,6 +219,7 @@ impl<'a> StringCounts<'a> {
         })
     }
 
+    /// Returns the modification time of the backing file.
     pub fn modified(&self) -> Result<SystemTime> {
         Ok(self.file.metadata()?.modified()?)
     }
@@ -298,5 +364,38 @@ mod tests {
     #[test]
     fn test_len() {
         assert_eq!(TEST_COUNTER.len(), 2);
+    }
+
+    #[test]
+    fn test_modified() -> Result<()> {
+        let entries = &[("hello", 1_u64)];
+        let workdir = TempDir::new()?;
+        let path = workdir.path().join("test.StringCounts");
+        StringCounts::create(
+            entries.map(|(s, n)| (String::from(s), n)).into_iter(),
+            workdir.path(),
+            &path,
+        )?;
+
+        let table = StringCounts::open(&path)?;
+        let file_metadata = std::fs::metadata(&path)?;
+        assert_eq!(table.modified()?, file_metadata.modified()?);
+        Ok(())
+    }
+
+    #[test]
+    fn test_open_rejects_file_without_signature() {
+        let workdir = TempDir::new().expect("TempDir::new() failed");
+        let path = workdir.path().join("not-a-counter");
+        std::fs::write(&path, [0u8; HEADER_SIZE]).expect("write failed");
+        assert!(StringCounts::open(&path).is_err());
+    }
+
+    #[test]
+    fn test_open_rejects_truncated_file() {
+        let workdir = TempDir::new().expect("TempDir::new() failed");
+        let path = workdir.path().join("too-short");
+        std::fs::write(&path, FILE_SIGNATURE).expect("write failed");
+        assert!(StringCounts::open(&path).is_err());
     }
 }

--- a/src/tables/u64_set.rs
+++ b/src/tables/u64_set.rs
@@ -1,22 +1,42 @@
+//! Disk-based, memory-mapped set of `u64` values.
+//!
+//! `U64Set` is used in the pipeline to represent large sets of identifiers
+//! that may not entirely fit into the available memory. For example, the
+//! set of all OpenStreetMap nodes that are geographically near an
+//! AllThePlaces feature.
+//!
+//! Containment test ([U64Set::contains]) is currently implemented as a
+//! regular binary search. If performance ever becomes an issue, consider
+//! Cache-Sensitive Skip Lists, but this would make the file format
+//! slightly more complicated.
+//!
+//! # File format
+//!
+//! ```text
+//! byte 0..:  the set's elements, sorted ascending, deduplicated, u64
+//!            little-endian each, with no header
+//! ```
+//!
+//! There is no magic signature or header: any file whose size is a
+//! multiple of 8 bytes is accepted by [U64Set::open].
+
 use anyhow::{Ok, Result, anyhow};
 use memmap2::Mmap;
 use std::{fs::File, path::Path, time::SystemTime};
 
-/// A memory-mapped file with sorted 64-bit integers in little-endian encoding.
-///
-/// Used in the pipeline to represent large sets of identifiers that may not
-/// entirely fit into the available memory. For examle, the set of all OpenStreetMap
-/// nodes that are geographically near an AllThePlaces feature.
-///
-/// Containment test is currently implemented as a regular binary search.
-/// If performance ever becomes an issue, consider Cache-Sensitive Skip Lines,
-/// but this would make the file format slightly more complicated.
+/// Read-only, memory-mapped set of `u64` values. See the "File format"
+/// section above.
 pub struct U64Set {
     file: File, // The file that backs mmap.
     mmap: Mmap,
 }
 
 impl U64Set {
+    /// Builds a `U64Set` from `elements`, which may be in any order and
+    /// may contain duplicates.
+    ///
+    /// `elements` is sorted and deduplicated using external sorting
+    /// (spilling to `workdir` as needed), and only then written to `out`.
     pub fn create(
         elements: impl Iterator<Item = u64>,
         workdir: &Path,
@@ -26,6 +46,8 @@ impl U64Set {
         Self::open(out)
     }
 
+    /// Opens a `U64Set` previously written by [U64Set::create], mapping it
+    /// into memory rather than reading it into a heap-allocated buffer.
     pub fn open(path: &Path) -> Result<U64Set> {
         let file_size: u64 = std::fs::metadata(path)?.len();
         if !file_size.is_multiple_of(8) {
@@ -39,6 +61,7 @@ impl U64Set {
         Ok(U64Set { file, mmap })
     }
 
+    /// Returns whether `n` is in the set.
     pub fn contains(&self, n: u64) -> bool {
         // SAFETY: We check in `open()` that the file size is a multiple of eight.
         // Alignment to page size, which is typically 4K or larger and
@@ -56,10 +79,12 @@ impl U64Set {
         }
     }
 
+    /// Returns the number of elements in the set.
     pub fn len(&self) -> usize {
         self.mmap.len() / 8
     }
 
+    /// Returns an iterator over all elements, in ascending order.
     pub fn iter(&self) -> impl Iterator<Item = u64> + '_ {
         // SAFETY: We check in `open()` that the file size is a multiple of eight.
         // Alignment to page size, which is typically 4K or larger and
@@ -83,7 +108,7 @@ impl U64Set {
 mod tests {
     use super::*;
     use std::{io::Write, sync::LazyLock};
-    use tempfile::NamedTempFile;
+    use tempfile::{NamedTempFile, TempDir};
 
     const TEST_TABLE: LazyLock<U64Set> = LazyLock::new(|| {
         let mut file = NamedTempFile::new().expect("NamedTempFile");
@@ -147,6 +172,23 @@ mod tests {
     fn test_open_inexistent_file() {
         let path = Path::new("file/does/not/exist");
         assert!(U64Set::open(&path).is_err());
+    }
+
+    #[test]
+    fn test_create() -> Result<()> {
+        let workdir = TempDir::new()?;
+        let out = workdir.path().join("test.u64set");
+
+        let set = U64Set::create([42, 7, 23, 7].into_iter(), workdir.path(), &out)?;
+        assert_eq!(set.len(), 3);
+        assert_eq!(set.contains(0), false);
+        assert_eq!(set.contains(7), true);
+        assert_eq!(set.contains(23), true);
+        assert_eq!(set.contains(42), true);
+        assert_eq!(set.contains(99), false);
+        assert_eq!(set.iter().collect::<Vec<u64>>(), &[7, 23, 42]);
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## Summary
- Add module-level "File format" doc comments to `graph.rs` and `string_counts.rs`, which had none, and convert `u64_set.rs`'s struct-level docs to the same module-doc convention used by the other tables (`string_pool.rs` etc).
- `graph.rs`'s on-disk format had no magic-signature check, unlike every other table in this module — add one (`"graph_v0"`) so a malformed/foreign file is rejected instead of silently accepted. This only affects files the pipeline generates and reads itself each run, so there's no compatibility concern.
- Add unit tests for public functions that had no direct test coverage: `CoordTable::create`, `U64Set::create`, `StringCounts::modified`, and `GraphTable`'s signature/truncation/size-mismatch error paths.

Test count for `src/tables` went from 41 to 50 (172 total in the crate), all passing; `cargo clippy --lib -- -D warnings` is clean.

## Test plan
- [x] `cargo test --lib tables::` — 50 passed
- [x] `cargo test --lib` — 172 passed (full crate, confirms no regression in callers like `pipeline/osm/prune.rs`)
- [x] `cargo clippy --lib -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)