### PR TITLE
Add file header (magic + count) to U64Set

### DIFF
--- a/src/tables/u64_set.rs
+++ b/src/tables/u64_set.rs
@@ -13,22 +13,33 @@
 //! # File format
 //!
 //! ```text
-//! byte 0..:  the set's elements, sorted ascending, deduplicated, u64
-//!            little-endian each, with no header
+//! byte 0..8:  magic "u64set_0"
+//! byte 8..16: entry count, u64 little-endian
+//! byte 16..:  the set's elements, sorted ascending, deduplicated, u64
+//!             little-endian each
 //! ```
 //!
-//! There is no magic signature or header: any file whose size is a
-//! multiple of 8 bytes is accepted by [U64Set::open].
+//! The header is a fixed 16 bytes so that the elements array, which
+//! follows it immediately, stays 8-byte aligned and can be reinterpreted
+//! as a `&[u64]` slice directly on the mmap'd bytes.
 
 use anyhow::{Ok, Result, anyhow};
 use memmap2::Mmap;
-use std::{fs::File, path::Path, time::SystemTime};
+use std::{fs::File, mem::size_of, path::Path, time::SystemTime};
+
+/// Size of the file header, in bytes: see the "File format" section above.
+const HEADER_SIZE: usize = 2 * 8;
+
+/// Magic bytes identifying a `U64Set` file, written as the first eight
+/// bytes of the file header.
+const FILE_SIGNATURE: &[u8; 8] = b"u64set_0";
 
 /// Read-only, memory-mapped set of `u64` values. See the "File format"
 /// section above.
 pub struct U64Set {
     file: File, // The file that backs mmap.
     mmap: Mmap,
+    entries_count: usize,
 }
 
 impl U64Set {
@@ -49,27 +60,42 @@ impl U64Set {
     /// Opens a `U64Set` previously written by [U64Set::create], mapping it
     /// into memory rather than reading it into a heap-allocated buffer.
     pub fn open(path: &Path) -> Result<U64Set> {
-        let file_size: u64 = std::fs::metadata(path)?.len();
-        if !file_size.is_multiple_of(8) {
-            return Err(anyhow!("file size must be multiple of 8"));
-        }
-
         let file = File::open(path)?;
 
         // SAFETY: We don’t truncate the file while it is mapped into memory.
         let mmap = unsafe { Mmap::map(&file)? };
-        Ok(U64Set { file, mmap })
+        if mmap.len() < HEADER_SIZE || &mmap[0..8] != FILE_SIGNATURE {
+            return Err(anyhow!("not a U64Set: {}", path.display()));
+        }
+
+        // SAFETY: mmap.len() checked above; offset 0 is aligned for u64.
+        let header = unsafe {
+            let ptr = mmap.as_ptr() as *const u64;
+            std::slice::from_raw_parts(ptr, HEADER_SIZE / size_of::<u64>())
+        };
+        let entries_count = usize::try_from(header[1])?;
+        if HEADER_SIZE + entries_count * 8 != mmap.len() {
+            return Err(anyhow!("bad element count in U64Set: {}", path.display()));
+        }
+
+        Ok(U64Set {
+            file,
+            mmap,
+            entries_count,
+        })
     }
 
     /// Returns whether `n` is in the set.
     pub fn contains(&self, n: u64) -> bool {
-        // SAFETY: We check in `open()` that the file size is a multiple of eight.
-        // Alignment to page size, which is typically 4K or larger and
-        // always than eight bytes, is guaranteed by the mmap system
-        // call.
+        // SAFETY: We check in `open()` that the file holds `entries_count`
+        // elements after the header. Alignment to page size, which is
+        // typically 4K or larger and always than eight bytes, is
+        // guaranteed by the mmap system call; the header size is a
+        // multiple of eight bytes, so the elements stay eight-byte
+        // aligned too.
         let slice = unsafe {
-            let ptr = self.mmap.as_ptr() as *const u64;
-            std::slice::from_raw_parts(ptr, self.mmap.len() / 8)
+            let ptr = self.mmap.as_ptr().add(HEADER_SIZE) as *const u64;
+            std::slice::from_raw_parts(ptr, self.entries_count)
         };
 
         if cfg!(target_endian = "little") {
@@ -81,20 +107,17 @@ impl U64Set {
 
     /// Returns the number of elements in the set.
     pub fn len(&self) -> usize {
-        self.mmap.len() / 8
+        self.entries_count
     }
 
     /// Returns an iterator over all elements, in ascending order.
     pub fn iter(&self) -> impl Iterator<Item = u64> + '_ {
-        // SAFETY: We check in `open()` that the file size is a multiple of eight.
-        // Alignment to page size, which is typically 4K or larger and
-        // always than eight bytes, is guaranteed by the mmap system
-        // call.
+        // SAFETY: See `contains()` above.
         let slice = unsafe {
-            let ptr = self.mmap.as_ptr() as *const u64;
-            std::slice::from_raw_parts(ptr, self.mmap.len() / 8)
+            let ptr = self.mmap.as_ptr().add(HEADER_SIZE) as *const u64;
+            std::slice::from_raw_parts(ptr, self.entries_count)
         };
-        (0..self.len()).map(move |i| u64::from_le(slice[i]))
+        (0..self.entries_count).map(move |i| u64::from_le(slice[i]))
     }
 
     /// Returns the modification time of the underlying file.
@@ -112,6 +135,8 @@ mod tests {
 
     const TEST_TABLE: LazyLock<U64Set> = LazyLock::new(|| {
         let mut file = NamedTempFile::new().expect("NamedTempFile");
+        file.write_all(FILE_SIGNATURE).expect("File::write");
+        file.write_all(&3_u64.to_le_bytes()).expect("File::write");
         for i in [7_u64, 23, 42] {
             file.write_all(&i.to_le_bytes()).expect("File::write");
         }
@@ -142,6 +167,8 @@ mod tests {
     #[test]
     fn test_modified() -> Result<()> {
         let mut file = NamedTempFile::new()?;
+        file.write_all(FILE_SIGNATURE)?;
+        file.write_all(&1_u64.to_le_bytes())?;
         file.write_all(&42_u64.to_le_bytes())?;
 
         let table = U64Set::open(file.path())?;
@@ -152,17 +179,48 @@ mod tests {
 
     #[test]
     fn test_open() -> Result<()> {
-        let mut file = NamedTempFile::new()?;
+        let file = NamedTempFile::new()?;
 
-        // `open()` should accept an empty file.
+        // `open()` should reject a file without a header.
+        assert!(U64Set::open(file.path()).is_err());
+
+        // `open()` should accept a header-only file with no elements.
+        std::fs::write(
+            file.path(),
+            [FILE_SIGNATURE.as_slice(), &0_u64.to_le_bytes()].concat(),
+        )?;
         assert!(U64Set::open(file.path()).is_ok());
 
-        // `open()` should accept a file with 16 bytes.
-        file.write_all(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])?;
+        // `open()` should accept a file with two elements after the header.
+        std::fs::write(
+            file.path(),
+            [
+                FILE_SIGNATURE.as_slice(),
+                &2_u64.to_le_bytes(),
+                &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+            ]
+            .concat(),
+        )?;
         assert!(U64Set::open(file.path()).is_ok());
 
-        // `open()` should not accept a file with 17 bytes.
-        file.write_all(&[0])?;
+        // `open()` should not accept a file whose size doesn't match the
+        // element count in the header.
+        std::fs::write(
+            file.path(),
+            [
+                FILE_SIGNATURE.as_slice(),
+                &2_u64.to_le_bytes(),
+                &[0, 1, 2, 3, 4, 5, 6, 7],
+            ]
+            .concat(),
+        )?;
+        assert!(U64Set::open(file.path()).is_err());
+
+        // `open()` should not accept a file with a wrong magic signature.
+        std::fs::write(
+            file.path(),
+            [b"notu64s0".as_slice(), &0_u64.to_le_bytes()].concat(),
+        )?;
         assert!(U64Set::open(file.path()).is_err());
 
         Ok(())
@@ -193,10 +251,11 @@ mod tests {
 }
 
 mod writer {
+    use super::{FILE_SIGNATURE, HEADER_SIZE};
     use anyhow::{Ok, Result};
     use ext_sort::{ExternalSorter, ExternalSorterBuilder, buffer::LimitedBufferBuilder};
     use std::fs::File;
-    use std::io::{BufWriter, Write};
+    use std::io::{BufWriter, Seek, SeekFrom, Write};
     use std::path::{Path, PathBuf};
 
     pub fn create(elements: impl Iterator<Item = u64>, workdir: &Path, out: &Path) -> Result<u64> {
@@ -212,7 +271,9 @@ mod writer {
         let sorted = sorter.sort(elements.map(std::io::Result::Ok))?;
         let file = File::create(&tmp_out)?;
         let mut writer = BufWriter::with_capacity(32768, file);
-        let mut num_unique_values = 0;
+        writer.write_all(&[0_u8; HEADER_SIZE])?;
+
+        let mut num_unique_values: u64 = 0;
         let mut last: Option<u64> = None;
         for value in sorted {
             let value = value?;
@@ -228,6 +289,12 @@ mod writer {
             writer.write_all(&last.to_le_bytes())?;
             num_unique_values += 1;
         }
+
+        // Write file header.
+        writer.seek(SeekFrom::Start(0))?;
+        writer.write_all(FILE_SIGNATURE)?; // header[0] = magic
+        writer.write_all(&num_unique_values.to_le_bytes())?; // header[1] = entries_count
+        writer.seek(SeekFrom::End(0))?;
 
         writer.flush()?;
         writer.into_inner()?.sync_all()?;


### PR DESCRIPTION
## Summary

Gives `U64Set`'s file format a proper header, matching the other tables in `src/tables` (`CoordTable`, `StringCounts`, `BlobTable`):

- byte 0..8:  magic `"u64set_0"`
- byte 8..16: entry count, u64 little-endian
- byte 16..:  the set's elements, as before (sorted ascending, deduplicated, u64 little-endian each)

`U64Set::open` now validates the magic signature and checks that the file size matches the header's entry count, instead of only checking that the file size is a multiple of 8. Documented the format in the module doc comment.

## Testing

- `cargo test` — all 172 lib tests + integration + doc tests pass
- `cargo clippy --all-targets --all-features` — no new warnings vs. main
- `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)