### PR TITLE
Union non-multipolygon relations instead of nesting-based fill (fixes #533)

### DIFF
--- a/src/geometry/geometry_builder.rs
+++ b/src/geometry/geometry_builder.rs
@@ -5,7 +5,7 @@ use geo::algorithm::bool_ops::BooleanOps;
 use geo::algorithm::intersects::Intersects;
 use geo::{Coord, Geometry, GeometryCollection, LineString, MultiLineString, MultiPolygon, Point};
 
-use super::{LineStitcher, PolygonAssembler, build_points};
+use super::{LineStitcher, PolygonAssembler, PolygonUnion, build_points};
 
 /// Accumulates an arbitrarily-typed, arbitrarily-ordered stream of `geo`
 /// geometries — as would come from resolving the members of an OSM
@@ -17,8 +17,12 @@ use super::{LineStitcher, PolygonAssembler, build_points};
 ///   internal [`LineStitcher`], which stitches touching endpoints into
 ///   longer paths.
 /// * `Polygon`/`MultiPolygon` (and, degenerately, `Rect`/`Triangle`) go to
-///   an internal [`PolygonAssembler`], which resolves fill from geometric
-///   nesting.
+///   an internal polygon accumulator — either a [`PolygonAssembler`],
+///   which resolves fill from geometric nesting, or a [`PolygonUnion`],
+///   which just unions whole polygons together ignoring containment.
+///   Which one is picked at construction time via [`PolygonFill`] (see
+///   [`with_polygon_fill`](Self::with_polygon_fill)); containment is the
+///   default and the only option plain `new()` gives you.
 /// * `Point`/`MultiPoint` coordinates are simply collected; there's
 ///   nothing to stitch or nest, so no assembler is needed for them.
 /// * `GeometryCollection` is flattened: each member is added individually.
@@ -49,24 +53,83 @@ use super::{LineStitcher, PolygonAssembler, build_points};
 /// case.
 ///
 /// # Antimeridian handling
-/// Delegated entirely to the inner [`LineStitcher`] and [`PolygonAssembler`],
-/// each of which aligns everything it receives to its own first-added
-/// reference longitude. Points are not antimeridian-aligned: OSM node
-/// coordinates are never split across the dateline the way a way's
-/// vertices can be, so there's nothing to align them *to*.
+/// Delegated entirely to the inner [`LineStitcher`] and polygon
+/// accumulator, each of which aligns everything it receives to its own
+/// first-added reference longitude. Points are not antimeridian-aligned:
+/// OSM node coordinates are never split across the dateline the way a
+/// way's vertices can be, so there's nothing to align them *to*.
 pub struct GeometryBuilder {
     lines: LineStitcher,
-    polygons: PolygonAssembler,
+    polygons: PolygonAccumulator,
     points: Vec<Coord<f64>>,
     has_lines: bool,
     has_polygons: bool,
 }
 
+/// How [`GeometryBuilder`] should combine `Polygon`/`MultiPolygon`
+/// members into one shape; see
+/// [`GeometryBuilder::with_polygon_fill`]. Purely a geometric choice --
+/// callers are expected to have already decided, from whatever
+/// domain-specific knowledge applies (e.g. an OSM relation's `type` tag),
+/// which one describes their input.
+pub enum PolygonFill {
+    /// Resolve fill by geometric nesting (a member contained in another
+    /// becomes a hole) -- naturally handles arbitrary nesting depth (holes
+    /// with islands with holes, disjoint outer shells, ...) without
+    /// needing to know which member is meant to be a shell versus a hole.
+    /// Correct when every member is meant to jointly describe one area via
+    /// containment (e.g. OSM's `multipolygon`/`boundary` relations, where
+    /// declared roles are advisory and nesting is what actually decides
+    /// shell vs. hole).
+    Containment,
+    /// Union every member together, ignoring containment: a member fully
+    /// inside another contributes nothing new, rather than becoming a
+    /// hole. Correct when members simply *are* the area rather than
+    /// jointly describing it via nesting (e.g. an OSM `building` relation,
+    /// whose `outline` member is the exact union of its `part` members --
+    /// containment fill would wrongly punch the parts out as holes).
+    Union,
+}
+
+/// Which of the two polygon accumulators [`GeometryBuilder`] routes
+/// `Polygon`/`MultiPolygon` input to, per the requested [`PolygonFill`].
+enum PolygonAccumulator {
+    Containment(PolygonAssembler),
+    Union(PolygonUnion),
+}
+
+impl PolygonAccumulator {
+    fn add(&mut self, g: &Geometry<f64>) {
+        match self {
+            PolygonAccumulator::Containment(a) => a.add_ring(g),
+            PolygonAccumulator::Union(u) => u.add(g),
+        }
+    }
+
+    fn finish(self) -> Option<Geometry<f64>> {
+        match self {
+            PolygonAccumulator::Containment(a) => a.finish(),
+            PolygonAccumulator::Union(u) => u.finish(),
+        }
+    }
+}
+
 impl GeometryBuilder {
+    /// Same as [`with_polygon_fill`](Self::with_polygon_fill)`(`[`PolygonFill::Containment`]`)`.
     pub fn new() -> Self {
+        Self::with_polygon_fill(PolygonFill::Containment)
+    }
+
+    /// Like [`new`](Self::new), but lets the caller pick how
+    /// `Polygon`/`MultiPolygon` members are combined -- see [`PolygonFill`].
+    pub fn with_polygon_fill(fill: PolygonFill) -> Self {
+        let polygons = match fill {
+            PolygonFill::Containment => PolygonAccumulator::Containment(PolygonAssembler::new()),
+            PolygonFill::Union => PolygonAccumulator::Union(PolygonUnion::new()),
+        };
         Self {
             lines: LineStitcher::new(),
-            polygons: PolygonAssembler::new(),
+            polygons,
             points: Vec::new(),
             has_lines: false,
             has_polygons: false,
@@ -84,7 +147,7 @@ impl GeometryBuilder {
             }
             Geometry::Polygon(_) | Geometry::MultiPolygon(_) => {
                 self.has_polygons = true;
-                self.polygons.add_ring(g);
+                self.polygons.add(g);
             }
             Geometry::Point(p) => self.points.push(p.0),
             Geometry::MultiPoint(mp) => self.points.extend(mp.0.iter().map(|p| p.0)),
@@ -95,11 +158,11 @@ impl GeometryBuilder {
             }
             Geometry::Triangle(t) => {
                 self.has_polygons = true;
-                self.polygons.add_ring(&Geometry::from((*t).to_polygon()));
+                self.polygons.add(&Geometry::from((*t).to_polygon()));
             }
             Geometry::Rect(r) => {
                 self.has_polygons = true;
-                self.polygons.add_ring(&Geometry::from((*r).to_polygon()));
+                self.polygons.add(&Geometry::from((*r).to_polygon()));
             }
             Geometry::GeometryCollection(gc) => {
                 for geom in &gc.0 {
@@ -515,6 +578,79 @@ mod tests {
         match b.finish() {
             Some(Geometry::Polygon(p)) => assert_eq!(p.interiors().len(), 0),
             other => panic!("expected Polygon, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn with_polygon_fill_containment_nests_the_inner_polygon() {
+        let mut b = GeometryBuilder::with_polygon_fill(PolygonFill::Containment);
+        b.add(&polygon(&[
+            (0.0, 0.0),
+            (10.0, 0.0),
+            (10.0, 10.0),
+            (0.0, 10.0),
+        ]));
+        b.add(&polygon(&[(2.0, 2.0), (4.0, 2.0), (4.0, 4.0), (2.0, 4.0)]));
+        match b.finish() {
+            Some(Geometry::Polygon(p)) => assert_eq!(p.interiors().len(), 1),
+            other => panic!("expected Polygon with a hole, got {other:?}"),
+        }
+    }
+
+    /// The https://github.com/alltheplaces/osm-diffs/issues/533 scenario,
+    /// end to end through `GeometryBuilder`: an "outline" member that's
+    /// the exact union of the other members should reconstruct the full
+    /// outline under `PolygonFill::Union`, not (as `Containment` would)
+    /// come back empty.
+    #[test]
+    fn with_polygon_fill_union_reconstructs_tiling_parts() {
+        let mut b = GeometryBuilder::with_polygon_fill(PolygonFill::Union);
+        b.add(&polygon(&[
+            (0.0, 0.0),
+            (10.0, 0.0),
+            (10.0, 10.0),
+            (0.0, 10.0),
+        ])); // outline
+        b.add(&polygon(&[
+            (0.0, 0.0),
+            (5.0, 0.0),
+            (5.0, 10.0),
+            (0.0, 10.0),
+        ])); // part 1
+        b.add(&polygon(&[
+            (5.0, 0.0),
+            (10.0, 0.0),
+            (10.0, 10.0),
+            (5.0, 10.0),
+        ])); // part 2
+        match b.finish() {
+            Some(Geometry::Polygon(p)) => {
+                assert_eq!(p.interiors().len(), 0);
+                use geo::Area;
+                assert!((p.unsigned_area() - 100.0).abs() < 1e-9);
+            }
+            other => panic!("expected the reconstructed outline, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn new_matches_with_polygon_fill_containment() {
+        let mut a = GeometryBuilder::new();
+        let mut b = GeometryBuilder::with_polygon_fill(PolygonFill::Containment);
+        for builder in [&mut a, &mut b] {
+            builder.add(&polygon(&[
+                (0.0, 0.0),
+                (10.0, 0.0),
+                (10.0, 10.0),
+                (0.0, 10.0),
+            ]));
+            builder.add(&polygon(&[(2.0, 2.0), (4.0, 2.0), (4.0, 4.0), (2.0, 4.0)]));
+        }
+        for b in [a, b] {
+            match b.finish() {
+                Some(Geometry::Polygon(p)) => assert_eq!(p.interiors().len(), 1),
+                other => panic!("expected Polygon with a hole, got {other:?}"),
+            }
         }
     }
 }

--- a/src/geometry/geometry_builder.rs
+++ b/src/geometry/geometry_builder.rs
@@ -20,9 +20,8 @@ use super::{LineStitcher, PolygonAssembler, PolygonUnion, build_points};
 ///   an internal polygon accumulator — either a [`PolygonAssembler`],
 ///   which resolves fill from geometric nesting, or a [`PolygonUnion`],
 ///   which just unions whole polygons together ignoring containment.
-///   Which one is picked at construction time via [`PolygonFill`] (see
-///   [`with_polygon_fill`](Self::with_polygon_fill)); containment is the
-///   default and the only option plain `new()` gives you.
+///   Which one is picked via the [`PolygonFill`] passed to
+///   [`new`](Self::new).
 /// * `Point`/`MultiPoint` coordinates are simply collected; there's
 ///   nothing to stitch or nest, so no assembler is needed for them.
 /// * `GeometryCollection` is flattened: each member is added individually.
@@ -67,11 +66,10 @@ pub struct GeometryBuilder {
 }
 
 /// How [`GeometryBuilder`] should combine `Polygon`/`MultiPolygon`
-/// members into one shape; see
-/// [`GeometryBuilder::with_polygon_fill`]. Purely a geometric choice --
-/// callers are expected to have already decided, from whatever
-/// domain-specific knowledge applies (e.g. an OSM relation's `type` tag),
-/// which one describes their input.
+/// members into one shape; see [`GeometryBuilder::new`]. Purely a
+/// geometric choice -- callers are expected to have already decided, from
+/// whatever domain-specific knowledge applies (e.g. an OSM relation's
+/// `type` tag), which one describes their input.
 pub enum PolygonFill {
     /// Resolve fill by geometric nesting (a member contained in another
     /// becomes a hole) -- naturally handles arbitrary nesting depth (holes
@@ -115,14 +113,9 @@ impl PolygonAccumulator {
 }
 
 impl GeometryBuilder {
-    /// Same as [`with_polygon_fill`](Self::with_polygon_fill)`(`[`PolygonFill::Containment`]`)`.
-    pub fn new() -> Self {
-        Self::with_polygon_fill(PolygonFill::Containment)
-    }
-
-    /// Like [`new`](Self::new), but lets the caller pick how
-    /// `Polygon`/`MultiPolygon` members are combined -- see [`PolygonFill`].
-    pub fn with_polygon_fill(fill: PolygonFill) -> Self {
+    /// `fill` picks how `Polygon`/`MultiPolygon` members are combined --
+    /// see [`PolygonFill`].
+    pub fn new(fill: PolygonFill) -> Self {
         let polygons = match fill {
             PolygonFill::Containment => PolygonAccumulator::Containment(PolygonAssembler::new()),
             PolygonFill::Union => PolygonAccumulator::Union(PolygonUnion::new()),
@@ -293,12 +286,16 @@ mod tests {
 
     #[test]
     fn empty_returns_none() {
-        assert!(GeometryBuilder::new().finish().is_none());
+        assert!(
+            GeometryBuilder::new(PolygonFill::Containment)
+                .finish()
+                .is_none()
+        );
     }
 
     #[test]
     fn only_lines_takes_the_line_stitcher_fast_path() {
-        let mut b = GeometryBuilder::new();
+        let mut b = GeometryBuilder::new(PolygonFill::Containment);
         b.add(&ls(&[(0.0, 0.0), (1.0, 0.0)]));
         b.add(&ls(&[(1.0, 0.0), (2.0, 0.0)]));
         match b.finish() {
@@ -309,7 +306,7 @@ mod tests {
 
     #[test]
     fn only_polygons_takes_the_polygon_assembler_fast_path() {
-        let mut b = GeometryBuilder::new();
+        let mut b = GeometryBuilder::new(PolygonFill::Containment);
         b.add(&polygon(&[(0.0, 0.0), (4.0, 0.0), (4.0, 4.0), (0.0, 4.0)]));
         match b.finish() {
             Some(Geometry::Polygon(p)) => assert_eq!(p.interiors().len(), 0),
@@ -319,7 +316,7 @@ mod tests {
 
     #[test]
     fn only_points_returns_multi_point() {
-        let mut b = GeometryBuilder::new();
+        let mut b = GeometryBuilder::new(PolygonFill::Containment);
         b.add(&point(0.0, 0.0));
         b.add(&point(1.0, 1.0));
         match b.finish() {
@@ -334,7 +331,7 @@ mod tests {
             Point::new(0.0, 0.0),
             Point::new(1.0, 1.0),
         ]));
-        let mut b = GeometryBuilder::new();
+        let mut b = GeometryBuilder::new(PolygonFill::Containment);
         b.add(&mp);
         match b.finish() {
             Some(Geometry::MultiPoint(mp)) => assert_eq!(mp.len(), 2),
@@ -348,7 +345,7 @@ mod tests {
             LineString::new(vec![c(0.0, 0.0), c(1.0, 0.0)]),
             LineString::new(vec![c(5.0, 5.0), c(6.0, 5.0)]),
         ]));
-        let mut lines_only = GeometryBuilder::new();
+        let mut lines_only = GeometryBuilder::new(PolygonFill::Containment);
         lines_only.add(&mls);
         match lines_only.finish() {
             Some(Geometry::MultiLineString(m)) => assert_eq!(m.0.len(), 2),
@@ -377,7 +374,7 @@ mod tests {
                 vec![],
             ),
         ]));
-        let mut polys_only = GeometryBuilder::new();
+        let mut polys_only = GeometryBuilder::new(PolygonFill::Containment);
         polys_only.add(&mpoly);
         match polys_only.finish() {
             Some(Geometry::MultiPolygon(mp)) => assert_eq!(mp.0.len(), 2),
@@ -387,7 +384,7 @@ mod tests {
 
     #[test]
     fn disjoint_line_and_polygon_combine_into_geometry_collection() {
-        let mut b = GeometryBuilder::new();
+        let mut b = GeometryBuilder::new(PolygonFill::Containment);
         b.add(&polygon(&[(0.0, 0.0), (4.0, 0.0), (4.0, 4.0), (0.0, 4.0)]));
         b.add(&ls(&[(10.0, 10.0), (11.0, 10.0)]));
         match b.finish() {
@@ -402,7 +399,7 @@ mod tests {
 
     #[test]
     fn line_fully_inside_polygon_is_clipped_away_entirely() {
-        let mut b = GeometryBuilder::new();
+        let mut b = GeometryBuilder::new(PolygonFill::Containment);
         b.add(&polygon(&[
             (0.0, 0.0),
             (10.0, 0.0),
@@ -421,7 +418,7 @@ mod tests {
 
     #[test]
     fn line_crossing_polygon_boundary_keeps_only_its_outside_portion() {
-        let mut b = GeometryBuilder::new();
+        let mut b = GeometryBuilder::new(PolygonFill::Containment);
         b.add(&polygon(&[
             (0.0, 0.0),
             (10.0, 0.0),
@@ -468,7 +465,7 @@ mod tests {
 
     #[test]
     fn point_inside_polygon_is_omitted() {
-        let mut b = GeometryBuilder::new();
+        let mut b = GeometryBuilder::new(PolygonFill::Containment);
         b.add(&polygon(&[
             (0.0, 0.0),
             (10.0, 0.0),
@@ -484,7 +481,7 @@ mod tests {
 
     #[test]
     fn point_outside_polygon_is_kept() {
-        let mut b = GeometryBuilder::new();
+        let mut b = GeometryBuilder::new(PolygonFill::Containment);
         b.add(&polygon(&[
             (0.0, 0.0),
             (10.0, 0.0),
@@ -504,7 +501,7 @@ mod tests {
 
     #[test]
     fn point_on_line_is_omitted() {
-        let mut b = GeometryBuilder::new();
+        let mut b = GeometryBuilder::new(PolygonFill::Containment);
         b.add(&ls(&[(0.0, 0.0), (10.0, 0.0)]));
         b.add(&point(5.0, 0.0)); // sits exactly on the line
         match b.finish() {
@@ -515,7 +512,7 @@ mod tests {
 
     #[test]
     fn point_off_line_is_kept() {
-        let mut b = GeometryBuilder::new();
+        let mut b = GeometryBuilder::new(PolygonFill::Containment);
         b.add(&ls(&[(0.0, 0.0), (10.0, 0.0)]));
         b.add(&point(5.0, 5.0));
         match b.finish() {
@@ -534,7 +531,7 @@ mod tests {
             ls(&[(10.0, 10.0), (11.0, 10.0)]),
             polygon(&[(0.0, 0.0), (4.0, 0.0), (4.0, 4.0), (0.0, 4.0)]),
         ]));
-        let mut b = GeometryBuilder::new();
+        let mut b = GeometryBuilder::new(PolygonFill::Containment);
         b.add(&gc);
         match b.finish() {
             Some(Geometry::GeometryCollection(gc)) => {
@@ -548,7 +545,7 @@ mod tests {
 
     #[test]
     fn line_variant_is_routed_to_line_stitcher() {
-        let mut b = GeometryBuilder::new();
+        let mut b = GeometryBuilder::new(PolygonFill::Containment);
         b.add(&Geometry::from(Line::new(c(0.0, 0.0), c(1.0, 0.0))));
         b.add(&Geometry::from(Line::new(c(1.0, 0.0), c(2.0, 0.0))));
         match b.finish() {
@@ -559,7 +556,7 @@ mod tests {
 
     #[test]
     fn rect_variant_is_routed_to_polygon_assembler() {
-        let mut b = GeometryBuilder::new();
+        let mut b = GeometryBuilder::new(PolygonFill::Containment);
         b.add(&Geometry::from(Rect::new(c(0.0, 0.0), c(4.0, 4.0))));
         match b.finish() {
             Some(Geometry::Polygon(p)) => assert_eq!(p.interiors().len(), 0),
@@ -569,7 +566,7 @@ mod tests {
 
     #[test]
     fn triangle_variant_is_routed_to_polygon_assembler() {
-        let mut b = GeometryBuilder::new();
+        let mut b = GeometryBuilder::new(PolygonFill::Containment);
         b.add(&Geometry::from(Triangle::new(
             c(0.0, 0.0),
             c(4.0, 0.0),
@@ -582,8 +579,8 @@ mod tests {
     }
 
     #[test]
-    fn with_polygon_fill_containment_nests_the_inner_polygon() {
-        let mut b = GeometryBuilder::with_polygon_fill(PolygonFill::Containment);
+    fn containment_fill_nests_the_inner_polygon() {
+        let mut b = GeometryBuilder::new(PolygonFill::Containment);
         b.add(&polygon(&[
             (0.0, 0.0),
             (10.0, 0.0),
@@ -603,8 +600,8 @@ mod tests {
     /// outline under `PolygonFill::Union`, not (as `Containment` would)
     /// come back empty.
     #[test]
-    fn with_polygon_fill_union_reconstructs_tiling_parts() {
-        let mut b = GeometryBuilder::with_polygon_fill(PolygonFill::Union);
+    fn union_fill_reconstructs_tiling_parts() {
+        let mut b = GeometryBuilder::new(PolygonFill::Union);
         b.add(&polygon(&[
             (0.0, 0.0),
             (10.0, 0.0),
@@ -630,27 +627,6 @@ mod tests {
                 assert!((p.unsigned_area() - 100.0).abs() < 1e-9);
             }
             other => panic!("expected the reconstructed outline, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn new_matches_with_polygon_fill_containment() {
-        let mut a = GeometryBuilder::new();
-        let mut b = GeometryBuilder::with_polygon_fill(PolygonFill::Containment);
-        for builder in [&mut a, &mut b] {
-            builder.add(&polygon(&[
-                (0.0, 0.0),
-                (10.0, 0.0),
-                (10.0, 10.0),
-                (0.0, 10.0),
-            ]));
-            builder.add(&polygon(&[(2.0, 2.0), (4.0, 2.0), (4.0, 4.0), (2.0, 4.0)]));
-        }
-        for b in [a, b] {
-            match b.finish() {
-                Some(Geometry::Polygon(p)) => assert_eq!(p.interiors().len(), 1),
-                other => panic!("expected Polygon with a hole, got {other:?}"),
-            }
         }
     }
 }

--- a/src/geometry/grid_tests.rs
+++ b/src/geometry/grid_tests.rs
@@ -210,7 +210,7 @@ fn build_area(data: &GridData, from_type: &str, from_id: i64) -> Option<Geometry
         "way" => build_way_geometry(data, from_id),
         "relation" => {
             let relation = data.relations.get(&from_id)?;
-            let mut builder = GeometryBuilder::new();
+            let mut builder = GeometryBuilder::new(PolygonFill::Containment);
             for member in &relation.members {
                 if member.member_type == "way"
                     && let Some(geometry) = build_way_geometry(data, member.member_ref)

--- a/src/geometry/mod.rs
+++ b/src/geometry/mod.rs
@@ -45,10 +45,12 @@ mod geometry_builder;
 mod grid_tests;
 mod line_stitcher;
 mod polygon_assembler;
+mod polygon_union;
 
-pub use geometry_builder::GeometryBuilder;
+pub use geometry_builder::{GeometryBuilder, PolygonFill};
 pub use line_stitcher::LineStitcher;
 pub use polygon_assembler::PolygonAssembler;
+pub use polygon_union::PolygonUnion;
 
 // =======================================================================
 // build_points

--- a/src/geometry/polygon_assembler.rs
+++ b/src/geometry/polygon_assembler.rs
@@ -174,7 +174,7 @@ impl PolygonAssembler {
     }
 }
 
-fn polygon_coord_count(p: &Polygon<f64>) -> usize {
+pub(super) fn polygon_coord_count(p: &Polygon<f64>) -> usize {
     p.exterior().0.len() + p.interiors().iter().map(|r| r.0.len()).sum::<usize>()
 }
 
@@ -184,7 +184,11 @@ fn polygon_coord_count(p: &Polygon<f64>) -> usize {
 /// nothing can shrink further. Mirrors [`PolygonAssembler::compact`], but
 /// runs on whole `Polygon`s (exterior and interiors together) so it can't
 /// introduce a self-intersection between a polygon and its own holes.
-fn compact_polygons(polygons: &mut [Polygon<f64>], max_coordinates: usize, epsilon: &mut f64) {
+pub(super) fn compact_polygons(
+    polygons: &mut [Polygon<f64>],
+    max_coordinates: usize,
+    epsilon: &mut f64,
+) {
     let mut total: usize = polygons.iter().map(polygon_coord_count).sum();
     for _ in 0..40 {
         if total <= max_coordinates {

--- a/src/geometry/polygon_union.rs
+++ b/src/geometry/polygon_union.rs
@@ -1,0 +1,403 @@
+//! Assembles an arbitrarily-ordered bag of polygons into their plain
+//! geometric union, ignoring containment. See [`PolygonUnion`].
+
+use geo::algorithm::bool_ops::BooleanOps;
+use geo::orient::{Direction, Orient};
+use geo::{Geometry, MultiPolygon, Polygon};
+
+use super::centroid_x;
+use super::polygon_assembler::{compact_polygons, polygon_coord_count};
+
+/// Default cap on total coordinates a [`PolygonUnion`] will produce; see
+/// [`PolygonUnion::with_max_coordinates`] to override it. Mirrors
+/// [`super::PolygonAssembler`]'s own default.
+const DEFAULT_MAX_UNION_COORDINATES: usize = 2000;
+
+/// Assembles an arbitrarily-ordered collection of polygons — as would come
+/// from the members of an OSM relation whose members simply *are* the
+/// area, rather than jointly describing it via role-agnostic containment
+/// (e.g. a `type=building` relation, whose `outline` member is the exact
+/// union of its `part` members) — into their plain geometric union.
+///
+/// This is [`PolygonAssembler`](super::PolygonAssembler)'s complement, not
+/// a variant of it: `PolygonAssembler` resolves fill from nesting (a ring
+/// contained in another becomes a hole), which is the correct rule for
+/// `type=multipolygon`/`boundary` relations but actively wrong for
+/// anything else — a `building` relation's `part` members are meant to
+/// *add* area, not punch holes in the `outline`. `PolygonUnion` instead
+/// just unions whatever whole polygons it's given, so a member fully
+/// inside another contributes nothing new (rather than becoming a hole)
+/// and a member that only partially overlaps extends the total area, same
+/// as any other union. See
+/// [`GeometryBuilder::with_polygon_fill`](super::GeometryBuilder::with_polygon_fill)
+/// for how a caller picks between the two (this module doesn't know
+/// anything about OSM relation types itself -- that's decided by the
+/// caller, e.g. from a relation's `type` tag).
+///
+/// Unlike `PolygonAssembler`, this never flattens a polygon into loose
+/// rings: each added `Polygon`'s own holes stay attached to it (they were
+/// already resolved correctly, e.g. by a prior `build_ring` or by a
+/// recursively-assembled sub-relation), and the union folds whole
+/// polygons together via `geo`'s [`BooleanOps::union`].
+///
+/// # Antimeridian handling
+/// Same approach as `PolygonAssembler`: each polygon's rings are assumed
+/// to already be internally antimeridian-safe (e.g. via `build_ring`), and
+/// are re-aligned via [`align_polygon_to_reference_x`] to the first-added
+/// polygon's reference longitude before being folded in.
+///
+/// # Coordinate budget
+/// The running union is kept at or under `max_coordinates` (default
+/// [`DEFAULT_MAX_UNION_COORDINATES`]) by simplifying it (via `geo`'s
+/// topology-preserving `SimplifyVwPreserve`, reusing
+/// `PolygonAssembler`'s own compaction helper) whenever `add()` would
+/// otherwise push it over budget, for the same "don't hold an unbounded
+/// amount of un-simplified geometry in memory" reason `PolygonAssembler`
+/// and `LineStitcher` do this incrementally rather than only in
+/// `finish()`.
+pub struct PolygonUnion {
+    accumulated: MultiPolygon<f64>,
+    reference_x: Option<f64>,
+    max_coordinates: usize,
+    epsilon: f64,
+}
+
+impl PolygonUnion {
+    pub fn new() -> Self {
+        Self::with_max_coordinates(DEFAULT_MAX_UNION_COORDINATES)
+    }
+
+    pub fn with_max_coordinates(max_coordinates: usize) -> Self {
+        Self {
+            accumulated: MultiPolygon::new(Vec::new()),
+            reference_x: None,
+            max_coordinates,
+            epsilon: 1e-7,
+        }
+    }
+
+    /// Add a `Polygon`/`MultiPolygon` (each polygon's own holes stay
+    /// attached to it) to the running union.
+    pub fn add(&mut self, geom: &Geometry<f64>) {
+        for mut polygon in extract_polygons(geom) {
+            match self.reference_x {
+                Some(rx) => align_polygon_to_reference_x(&mut polygon, rx),
+                None => self.reference_x = Some(centroid_x(polygon.exterior())),
+            }
+            self.accumulated = self.accumulated.union(&polygon);
+        }
+
+        let total: usize = self.accumulated.0.iter().map(polygon_coord_count).sum();
+        if total > self.max_coordinates {
+            compact_polygons(
+                &mut self.accumulated.0,
+                self.max_coordinates,
+                &mut self.epsilon,
+            );
+        }
+    }
+
+    /// Resolve everything added so far into a valid geometry. `None` if
+    /// nothing was added, or the result has zero area.
+    pub fn finish(mut self) -> Option<Geometry<f64>> {
+        if self.accumulated.0.is_empty() {
+            return None;
+        }
+
+        let total: usize = self.accumulated.0.iter().map(polygon_coord_count).sum();
+        if total > self.max_coordinates {
+            compact_polygons(
+                &mut self.accumulated.0,
+                self.max_coordinates,
+                &mut self.epsilon,
+            );
+        }
+
+        let oriented: Vec<Polygon<f64>> = self
+            .accumulated
+            .0
+            .into_iter()
+            .map(|p| p.orient(Direction::Default))
+            .collect();
+
+        match oriented.len() {
+            1 => Some(Geometry::from(oriented.into_iter().next().unwrap())),
+            _ => Some(Geometry::from(MultiPolygon::new(oriented))),
+        }
+    }
+}
+
+/// Shifts every ring of `polygon` (exterior and interiors alike) by
+/// whichever multiple of 360° brings the *exterior's* centroid closest to
+/// `reference_x` -- one shift for the whole polygon, so an interior ring
+/// stays positioned relative to its own exterior rather than being
+/// independently realigned to a possibly different shift.
+fn align_polygon_to_reference_x(polygon: &mut Polygon<f64>, reference_x: f64) {
+    let cx = centroid_x(polygon.exterior());
+    let mut best_shift = 0.0_f64;
+    let mut best_dist = (cx - reference_x).abs();
+    for shift in [360.0, -360.0] {
+        let dist = (cx + shift - reference_x).abs();
+        if dist < best_dist {
+            best_dist = dist;
+            best_shift = shift;
+        }
+    }
+    if best_shift != 0.0 {
+        polygon.exterior_mut(|ring| {
+            for c in ring.0.iter_mut() {
+                c.x += best_shift;
+            }
+        });
+        for i in 0..polygon.interiors().len() {
+            polygon.interiors_mut(|rings| {
+                for c in rings[i].0.iter_mut() {
+                    c.x += best_shift;
+                }
+            });
+        }
+    }
+}
+
+/// Flattens `geom` into its constituent whole polygons, each keeping its
+/// own holes. `geom` is always `Geometry::Polygon` or
+/// `Geometry::MultiPolygon`, since it can only come from
+/// `GeometryBuilder::add`'s own routing (see that type's docs).
+fn extract_polygons(geom: &Geometry<f64>) -> Vec<Polygon<f64>> {
+    match geom {
+        Geometry::Polygon(p) => vec![p.clone()],
+        Geometry::MultiPolygon(mp) => mp.0.clone(),
+        other => {
+            debug_assert!(
+                false,
+                "PolygonUnion::add called with unsupported geometry: {other:?}"
+            );
+            Vec::new()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use geo::{LineString, coord};
+
+    fn ring(pts: &[(f64, f64)]) -> LineString<f64> {
+        let mut coords: Vec<_> = pts.iter().map(|&(x, y)| coord! {x: x, y: y}).collect();
+        if coords.first() != coords.last() {
+            coords.push(coords[0]);
+        }
+        LineString::new(coords)
+    }
+
+    fn polygon(pts: &[(f64, f64)]) -> Geometry<f64> {
+        Geometry::from(Polygon::new(ring(pts), vec![]))
+    }
+
+    #[test]
+    fn empty_returns_none() {
+        assert!(PolygonUnion::new().finish().is_none());
+    }
+
+    #[test]
+    fn single_polygon_returns_itself() {
+        let mut u = PolygonUnion::new();
+        u.add(&polygon(&[(0.0, 0.0), (4.0, 0.0), (4.0, 4.0), (0.0, 4.0)]));
+        match u.finish() {
+            Some(Geometry::Polygon(p)) => assert_eq!(p.interiors().len(), 0),
+            other => panic!("expected Polygon, got {other:?}"),
+        }
+    }
+
+    /// The scenario from
+    /// <https://github.com/alltheplaces/osm-diffs/issues/533>: an
+    /// `outline` polygon that's the exact union of several `part`
+    /// polygons should union back to the full outline, not (as
+    /// `PolygonAssembler`'s nesting rule would do) have the parts punched
+    /// out as holes.
+    #[test]
+    fn polygon_fully_inside_another_contributes_no_hole() {
+        let mut u = PolygonUnion::new();
+        u.add(&polygon(&[
+            (0.0, 0.0),
+            (10.0, 0.0),
+            (10.0, 10.0),
+            (0.0, 10.0),
+        ]));
+        u.add(&polygon(&[(2.0, 2.0), (4.0, 2.0), (4.0, 4.0), (2.0, 4.0)]));
+        match u.finish() {
+            Some(Geometry::Polygon(p)) => assert_eq!(p.interiors().len(), 0),
+            other => panic!("expected the inner polygon to vanish into the union, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parts_exactly_tiling_an_outline_reconstruct_the_outline() {
+        // Three "building part" rectangles exactly tiling one "outline"
+        // rectangle, split at x=3.3 and x=6.7 -- mirrors #533's actual
+        // scenario (an outline that's the geometric union of its parts).
+        let mut u = PolygonUnion::new();
+        u.add(&polygon(&[
+            (0.0, 0.0),
+            (10.0, 0.0),
+            (10.0, 10.0),
+            (0.0, 10.0),
+        ])); // outline
+        u.add(&polygon(&[
+            (0.0, 0.0),
+            (3.3, 0.0),
+            (3.3, 10.0),
+            (0.0, 10.0),
+        ])); // part 1
+        u.add(&polygon(&[
+            (3.3, 0.0),
+            (6.7, 0.0),
+            (6.7, 10.0),
+            (3.3, 10.0),
+        ])); // part 2
+        u.add(&polygon(&[
+            (6.7, 0.0),
+            (10.0, 0.0),
+            (10.0, 10.0),
+            (6.7, 10.0),
+        ])); // part 3
+        match u.finish() {
+            Some(Geometry::Polygon(p)) => {
+                assert_eq!(p.interiors().len(), 0);
+                use geo::Area;
+                assert!((p.unsigned_area() - 100.0).abs() < 1e-9);
+            }
+            other => panic!("expected the reconstructed outline, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn disjoint_polygons_return_multi_polygon() {
+        let mut u = PolygonUnion::new();
+        u.add(&polygon(&[(0.0, 0.0), (2.0, 0.0), (2.0, 2.0), (0.0, 2.0)]));
+        u.add(&polygon(&[
+            (10.0, 10.0),
+            (12.0, 10.0),
+            (12.0, 12.0),
+            (10.0, 12.0),
+        ]));
+        match u.finish() {
+            Some(Geometry::MultiPolygon(mp)) => assert_eq!(mp.0.len(), 2),
+            other => panic!("expected MultiPolygon, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn overlapping_polygons_merge_into_one_shape() {
+        let mut u = PolygonUnion::new();
+        u.add(&polygon(&[(0.0, 0.0), (6.0, 0.0), (6.0, 6.0), (0.0, 6.0)]));
+        u.add(&polygon(&[(3.0, 3.0), (9.0, 3.0), (9.0, 9.0), (3.0, 9.0)]));
+        match u.finish() {
+            Some(Geometry::Polygon(p)) => {
+                use geo::Area;
+                // Two 36-area squares overlapping in a 9-area square: 63 total.
+                assert!((p.unsigned_area() - 63.0).abs() < 1e-9);
+            }
+            other => panic!("expected a merged Polygon, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn multi_polygon_input_flattens_to_its_constituent_polygons() {
+        let mp = Geometry::from(MultiPolygon::new(vec![
+            Polygon::new(
+                ring(&[(0.0, 0.0), (2.0, 0.0), (2.0, 2.0), (0.0, 2.0)]),
+                vec![],
+            ),
+            Polygon::new(
+                ring(&[(10.0, 10.0), (12.0, 10.0), (12.0, 12.0), (10.0, 12.0)]),
+                vec![],
+            ),
+        ]));
+        let mut u = PolygonUnion::new();
+        u.add(&mp);
+        match u.finish() {
+            Some(Geometry::MultiPolygon(m)) => assert_eq!(m.0.len(), 2),
+            other => panic!("expected MultiPolygon, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn preexisting_holes_survive_when_disjoint_from_other_members() {
+        // A donut (outer with a hole) unioned with a disjoint square: the
+        // donut's own hole must survive, since nothing fills it back in.
+        let donut = Geometry::from(Polygon::new(
+            ring(&[(0.0, 0.0), (10.0, 0.0), (10.0, 10.0), (0.0, 10.0)]),
+            vec![ring(&[(4.0, 4.0), (6.0, 4.0), (6.0, 6.0), (4.0, 6.0)])],
+        ));
+        let mut u = PolygonUnion::new();
+        u.add(&donut);
+        u.add(&polygon(&[
+            (20.0, 20.0),
+            (22.0, 20.0),
+            (22.0, 22.0),
+            (20.0, 22.0),
+        ]));
+        match u.finish() {
+            Some(Geometry::MultiPolygon(mp)) => {
+                assert_eq!(mp.0.len(), 2);
+                assert!(mp.0.iter().any(|p| p.interiors().len() == 1));
+            }
+            other => panic!("expected MultiPolygon with the donut's hole intact, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn antimeridian_polygons_align_to_a_common_frame() {
+        let a = polygon(&[(170.0, 0.0), (190.0, 0.0), (190.0, 10.0), (170.0, 10.0)]);
+        // Same square really, but expressed the "other way around" the
+        // antimeridian, as an independently-unwrapped ring would be.
+        let b = polygon(&[(-190.0, 0.0), (-170.0, 0.0), (-170.0, 10.0), (-190.0, 10.0)]);
+
+        let mut u = PolygonUnion::new();
+        u.add(&a);
+        u.add(&b);
+        match u.finish() {
+            Some(Geometry::Polygon(p)) => {
+                use geo::Area;
+                assert!((p.unsigned_area() - 200.0).abs() < 1e-6);
+            }
+            other => panic!("expected the two squares to align and merge, got {other:?}"),
+        }
+    }
+
+    fn circle_pts(n: usize, cx: f64, cy: f64, radius: f64) -> Vec<(f64, f64)> {
+        (0..n)
+            .map(|i| {
+                let theta = i as f64 / n as f64 * std::f64::consts::TAU;
+                (cx + theta.cos() * radius, cy + theta.sin() * radius)
+            })
+            .collect()
+    }
+
+    #[test]
+    fn stays_under_budget_for_a_single_oversized_polygon() {
+        let mut u = PolygonUnion::with_max_coordinates(100);
+        u.add(&polygon(&circle_pts(500, 0.0, 0.0, 100.0)));
+        match u.finish() {
+            Some(Geometry::Polygon(p)) => assert!(p.exterior().0.len() <= 100),
+            other => panic!("expected Polygon, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn many_short_disjoint_polygons_trigger_incremental_compaction() {
+        let mut u = PolygonUnion::with_max_coordinates(300);
+        for i in 0..50 {
+            let base = (i * 1000) as f64;
+            u.add(&polygon(&circle_pts(50, base, 0.0, 10.0)));
+        }
+        let geom = u.finish().expect("should build");
+        let count = match &geom {
+            Geometry::MultiPolygon(mp) => mp.0.iter().map(polygon_coord_count).sum::<usize>(),
+            Geometry::Polygon(p) => polygon_coord_count(p),
+            other => panic!("unexpected geometry: {other:?}"),
+        };
+        assert!(count < 800, "expected substantial reduction, got {count}");
+    }
+}

--- a/src/geometry/polygon_union.rs
+++ b/src/geometry/polygon_union.rs
@@ -29,10 +29,10 @@ const DEFAULT_MAX_UNION_COORDINATES: usize = 2000;
 /// inside another contributes nothing new (rather than becoming a hole)
 /// and a member that only partially overlaps extends the total area, same
 /// as any other union. See
-/// [`GeometryBuilder::with_polygon_fill`](super::GeometryBuilder::with_polygon_fill)
-/// for how a caller picks between the two (this module doesn't know
-/// anything about OSM relation types itself -- that's decided by the
-/// caller, e.g. from a relation's `type` tag).
+/// [`GeometryBuilder::new`](super::GeometryBuilder::new) for how a caller
+/// picks between the two (this module doesn't know anything about OSM
+/// relation types itself -- that's decided by the caller, e.g. from a
+/// relation's `type` tag).
 ///
 /// Unlike `PolygonAssembler`, this never flattens a polygon into loose
 /// rings: each added `Polygon`'s own holes stay attached to it (they were

--- a/src/pipeline/osm/assemble.rs
+++ b/src/pipeline/osm/assemble.rs
@@ -876,8 +876,7 @@ fn assemble_relation_geometry<'a>(
     leaf_relations_geometry: Option<&GeometryTable<'a>>,
     super_relations_geometry: Option<&GeometryStore>,
 ) -> Result<Option<Geometry>> {
-    let mut geom_builder =
-        GeometryBuilder::with_polygon_fill(polygon_fill_for_relation_type(relation_type));
+    let mut geom_builder = GeometryBuilder::new(polygon_fill_for_relation_type(relation_type));
     for (member_type, id) in members {
         if let Some(g) = lookup_relation_member_geometry(
             member_type,

--- a/src/pipeline/osm/assemble.rs
+++ b/src/pipeline/osm/assemble.rs
@@ -1,6 +1,6 @@
 use super::{BlobReader, Prunings};
 use crate::{
-    geometry::{GeometryBuilder, build_line, build_ring},
+    geometry::{GeometryBuilder, PolygonFill, build_line, build_ring},
     make_progress_bar,
     matchers::MatchMask,
     pipeline::osm::id_tagging_schema::is_area,
@@ -48,8 +48,14 @@ pub fn assemble<'a>(
     let ways = assemble_ways(osm, prunings, &strings, progress, workdir)?;
     let leaf_relations =
         assemble_leaf_relations(osm, prunings, &strings, &ways, progress, workdir)?;
-    let super_relations =
-        assemble_super_relations(prunings, &ways, &leaf_relations, progress, workdir)?;
+    let super_relations = assemble_super_relations(
+        prunings,
+        &strings,
+        &ways,
+        &leaf_relations,
+        progress,
+        workdir,
+    )?;
     Ok(Assembly {
         strings,
         nodes,
@@ -418,7 +424,9 @@ fn assemble_leaf_relations<'a>(
                         let members = relation
                             .members()
                             .map(|(_role, member_id, member_type)| (member_type, member_id));
+                        let relation_type = relation_type_tag(relation.tags());
                         let Some(geometry) = assemble_relation_geometry(
+                            relation_type,
                             members,
                             coords,
                             &ways.ways_in_relations,
@@ -514,6 +522,7 @@ fn assemble_leaf_relations<'a>(
 
 fn assemble_super_relations(
     prunings: &Prunings,
+    strings: &StringPool,
     ways: &AssembledWays,
     leaf_relations: &AssembledLeafRelations,
     progress: &MultiProgress,
@@ -563,11 +572,13 @@ fn assemble_super_relations(
                 let fti = FeatureToIndex::decode(blob)?;
                 let rel_geometry = {
                     let feature = fti.feature.expect("feature");
+                    let relation_type = relation_type_from_feature_tags(&feature.tags, strings);
                     let rel_members = feature
                         .relation_members
                         .iter()
                         .map(|m| feature_to_osm_id(m.id));
                     assemble_relation_geometry(
+                        relation_type,
                         rel_members,
                         coords,
                         ways_geometry,
@@ -807,14 +818,66 @@ fn assemble_relation_members(
     }
 }
 
+/// The value of a relation's `type` tag, if any -- e.g. `Some("multipolygon")`
+/// for `type=multipolygon` -- read straight from a PBF block's raw
+/// `(key, value)` tag pairs (as `osm_pbf_iter::Relation::tags()` yields).
+fn relation_type_tag<'a>(tags: impl Iterator<Item = (&'a str, &'a str)>) -> Option<&'a str> {
+    tags.into_iter()
+        .find(|&(key, _)| key == "type")
+        .map(|(_, value)| value)
+}
+
+/// Same as [`relation_type_tag`], but for a relation whose tags have
+/// already been resolved into `Feature.tags`' flat `[key_id, value_id,
+/// ...]` string-pool-id pairs (as they are for a super-relation, which by
+/// the time [`assemble_super_relations`] runs has already gone through
+/// [`assemble_tags`] once, in [`assemble_leaf_relations`]).
+fn relation_type_from_feature_tags<'a>(tags: &[u32], strings: &'a StringPool) -> Option<&'a str> {
+    tags.chunks_exact(2)
+        .find(|pair| strings.get(pair[0] as usize) == "type")
+        .map(|pair| strings.get(pair[1] as usize))
+}
+
+/// OSM documents `type=multipolygon` and `type=boundary` relations as
+/// using containment (nesting) to decide shell vs. hole, irrespective of
+/// declared member roles -- see [`PolygonFill::Containment`]. Every other
+/// relation type's polygon-typed members should instead just be unioned
+/// (see [`PolygonFill::Union`]): e.g. a `type=building` relation's
+/// `outline` member is the exact union of its `part` members, and
+/// containment fill would wrongly punch the parts out as holes. Applies
+/// equally to untagged relations, since containment fill isn't correct
+/// for a relation whose members weren't authored with that convention in
+/// mind.
+///
+/// See the OSM wiki: <https://wiki.openstreetmap.org/wiki/Relation:multipolygon>
+/// ("outer" role: "the ways ... making up the required outer ring(s)
+/// delimiting the area"; "inner" role: "the ways ... making up the
+/// optional inner ring(s) delimiting the excluded holes that must be
+/// fully inside the area delimited by outer ring(s)") and
+/// <https://wiki.openstreetmap.org/wiki/Relation:boundary> ("They are
+/// defined in a similar manner as multipolygons: they must contain at
+/// least one outer way, and additional ways can be used to define
+/// enclaves or exclaves"). See also
+/// <https://github.com/alltheplaces/osm-diffs/issues/533> and
+/// <https://github.com/alltheplaces/osm-diffs/issues/534> for the bug this
+/// function fixes.
+fn polygon_fill_for_relation_type(relation_type: Option<&str>) -> PolygonFill {
+    match relation_type {
+        Some("multipolygon") | Some("boundary") => PolygonFill::Containment,
+        _ => PolygonFill::Union,
+    }
+}
+
 fn assemble_relation_geometry<'a>(
+    relation_type: Option<&str>,
     members: impl Iterator<Item = (RelationMemberType, u64)>,
     coords: &CoordTable,
     ways: &GeometryTable<'a>,
     leaf_relations_geometry: Option<&GeometryTable<'a>>,
     super_relations_geometry: Option<&GeometryStore>,
 ) -> Result<Option<Geometry>> {
-    let mut geom_builder = GeometryBuilder::new();
+    let mut geom_builder =
+        GeometryBuilder::with_polygon_fill(polygon_fill_for_relation_type(relation_type));
     for (member_type, id) in members {
         if let Some(g) = lookup_relation_member_geometry(
             member_type,


### PR DESCRIPTION
## What

Fixes #533: [relation/3258964](https://www.openstreetmap.org/relation/3258964) (`type=building`) currently gets no geometry. Its `outline`-role member way is the exact geometric union of its `part`-role members, and `PolygonAssembler`'s nesting/even-odd fill rule can't tell that apart from "outer ring containing a hole the same size as itself" -- so the parts get treated as holes and, since they exactly fill the outline, the assembled area cancels to nothing.

OSM only documents containment-based (nesting) fill for `type=multipolygon` and `type=boundary` relations -- see the wiki links in `polygon_fill_for_relation_type`'s doc comment. Every other relation type's polygon-typed members should be unioned instead, ignoring containment.

## How

Per review discussion, the `geometry` crate stays free of any OSM-specific knowledge; the tag interpretation lives entirely in `src/pipeline/osm`:

- **`src/geometry`**: `GeometryBuilder` gets a new `PolygonFill` enum (`Containment` | `Union`) and a `with_polygon_fill()` constructor. `new()` is unchanged (still `Containment`-only, today's behavior). New `PolygonUnion` accumulator (`src/geometry/polygon_union.rs`) -- `PolygonAssembler`'s complement: folds whole `Polygon`/`MultiPolygon` members together via `geo`'s `BooleanOps::union`, keeping each member's own holes intact rather than flattening into a ring soup, with the same antimeridian-alignment and coordinate-budget-compaction approach as `PolygonAssembler` (a couple of its private helpers are now `pub(super)` to share).
- **`src/pipeline/osm/assemble.rs`**: new `polygon_fill_for_relation_type()` is the only place that reads a relation's `type` tag to decide `Containment` vs `Union`. Threaded through both the leaf-relation path (raw tags via `relation_type_tag()`) and the super-relation path (resolved via `relation_type_from_feature_tags()`, which needed `assemble_super_relations()` to gain a `StringPool` parameter).

## Scope

This closes the fill-rule half of #534; that issue stays open for #531's separate (and unrelated) stitched-closed-loop gap, which this PR doesn't touch.

## Testing

- New `src/geometry/polygon_union.rs` tests, including the #533 scenario in miniature: an outline polygon reconstructed from three exactly-tiling parts.
- Three new `src/geometry/geometry_builder.rs` tests for `with_polygon_fill`.
- `cargo test` (full suite, including the `test_pipeline` integration test against real PBF data) — all green.
- `cargo clippy`, `cargo fmt` — clean.