### PR TITLE
Promote a stitched closed loop to a ring/hole (fixes #531)

### DIFF
--- a/src/geometry/geometry_builder.rs
+++ b/src/geometry/geometry_builder.rs
@@ -5,7 +5,7 @@ use geo::algorithm::bool_ops::BooleanOps;
 use geo::algorithm::intersects::Intersects;
 use geo::{Coord, Geometry, GeometryCollection, LineString, MultiLineString, MultiPolygon, Point};
 
-use super::{LineStitcher, PolygonAssembler, PolygonUnion, build_points};
+use super::{LineStitcher, PolygonAssembler, PolygonUnion, build_points, build_ring};
 
 /// Accumulates an arbitrarily-typed, arbitrarily-ordered stream of `geo`
 /// geometries — as would come from resolving the members of an OSM
@@ -168,24 +168,57 @@ impl GeometryBuilder {
     /// Resolve everything added so far into a single combined geometry.
     /// `None` if nothing was added. See struct docs for how mixed-kind
     /// input is combined.
-    pub fn finish(self) -> Option<Geometry<f64>> {
+    pub fn finish(mut self) -> Option<Geometry<f64>> {
         let has_points = !self.points.is_empty();
 
-        // Fast path: only one kind was ever added, so there's nothing to
-        // combine and no need to even look at the other two accumulators.
-        match (self.has_lines, self.has_polygons, has_points) {
-            (false, false, false) => return None,
-            (true, false, false) => return self.lines.finish(),
-            (false, true, false) => return self.polygons.finish(),
-            (false, false, true) => return build_points(self.points),
-            _ => {}
-        }
-
+        // Resolve the line accumulator once, up front -- needed either
+        // way below, and (in Containment mode) so any loop it stitched
+        // closed can be promoted into a ring before anything else runs.
         let mut line_geom = if self.has_lines {
             self.lines.finish()
         } else {
             None
         };
+
+        // A ring stitched together from 2+ open member ways (rather than
+        // one already-closed way) is still a ring: in Containment mode,
+        // every member is ring material, whether it arrived pre-closed
+        // (build_ring already made it a Polygon) or as an open arc that
+        // only closes once stitched to its neighbors. Promote any closed
+        // piece LineStitcher produced into the polygon accumulator,
+        // through build_ring so a self-intersecting stitched loop gets
+        // the same repair a single self-intersecting way would. Leftover
+        // open pieces (a dangling arc that never closed) stay as line
+        // output, same as today.
+        //
+        // Union mode does *not* get this treatment: there, a closed loop
+        // isn't necessarily meant to be an area (e.g. a circular route
+        // relation's ways closing back on themselves is still a route,
+        // not a polygon) -- see PolygonFill::Union's docs.
+        if let (PolygonAccumulator::Containment(polygons), Some(lg)) =
+            (&mut self.polygons, &line_geom)
+        {
+            let (closed, open) = split_closed_open(lg);
+            for ring in closed {
+                if let Some(built) = build_ring(ring.0) {
+                    polygons.add_ring(&built);
+                    self.has_polygons = true;
+                }
+            }
+            line_geom = line_geometry_of(open);
+            self.has_lines = line_geom.is_some();
+        }
+
+        // Fast path: only one kind is left, so there's nothing to combine
+        // and no need to even look at the other two accumulators.
+        match (self.has_lines, self.has_polygons, has_points) {
+            (false, false, false) => return None,
+            (true, false, false) => return line_geom,
+            (false, true, false) => return self.polygons.finish(),
+            (false, false, true) => return build_points(self.points),
+            _ => {}
+        }
+
         let poly_geom = if self.has_polygons {
             self.polygons.finish()
         } else {
@@ -252,6 +285,31 @@ fn multi_line_string_of(lg: &Geometry<f64>) -> MultiLineString<f64> {
         Geometry::LineString(ls) => MultiLineString::new(vec![ls.clone()]),
         Geometry::MultiLineString(mls) => mls.clone(),
         other => unreachable!("LineStitcher::finish returned {other:?}"),
+    }
+}
+
+/// Splits `lg`'s constituent pieces into closed ones (first coordinate ==
+/// last: a candidate ring) and open ones (everything else). `lg` is
+/// always [`Geometry::LineString`] or [`Geometry::MultiLineString`], since
+/// it can only come from [`LineStitcher::finish`].
+fn split_closed_open(lg: &Geometry<f64>) -> (Vec<LineString<f64>>, Vec<LineString<f64>>) {
+    let pieces = match lg {
+        Geometry::LineString(ls) => vec![ls.clone()],
+        Geometry::MultiLineString(mls) => mls.0.clone(),
+        other => unreachable!("LineStitcher::finish returned {other:?}"),
+    };
+    pieces
+        .into_iter()
+        .partition(|ls| ls.0.len() >= 2 && ls.0.first() == ls.0.last())
+}
+
+/// The smallest `Geometry` representing `pieces`: `None` if empty, a bare
+/// `LineString` for exactly one piece, a `MultiLineString` otherwise.
+fn line_geometry_of(pieces: Vec<LineString<f64>>) -> Option<Geometry<f64>> {
+    match pieces.len() {
+        0 => None,
+        1 => Some(Geometry::from(pieces.into_iter().next().unwrap())),
+        _ => Some(Geometry::from(MultiLineString::new(pieces))),
     }
 }
 
@@ -591,6 +649,58 @@ mod tests {
         match b.finish() {
             Some(Geometry::Polygon(p)) => assert_eq!(p.interiors().len(), 1),
             other => panic!("expected Polygon with a hole, got {other:?}"),
+        }
+    }
+
+    /// https://github.com/alltheplaces/osm-diffs/issues/531: a ring made
+    /// of 2+ *open* member ways (rather than one already-closed way)
+    /// closes once `LineStitcher` stitches them together, and in
+    /// Containment mode that closed loop should be promoted to a ring --
+    /// mirrors osm-testdata grid fixture `9/901`.
+    #[test]
+    fn containment_fill_promotes_a_stitched_closed_loop_to_a_ring() {
+        let mut b = GeometryBuilder::new(PolygonFill::Containment);
+        b.add(&ls(&[(0.0, 0.0), (10.0, 0.0), (10.0, 10.0)]));
+        b.add(&ls(&[(10.0, 10.0), (0.0, 10.0), (0.0, 0.0)]));
+        match b.finish() {
+            Some(Geometry::Polygon(p)) => assert_eq!(p.interiors().len(), 0),
+            other => panic!("expected the stitched loop promoted to a Polygon, got {other:?}"),
+        }
+    }
+
+    /// Same idea, but the promoted loop is the *hole*, not the shell --
+    /// mirrors grid fixture `7/782` (a single closed way for the outer
+    /// ring, and a hole stitched from two open ways).
+    #[test]
+    fn containment_fill_promotes_a_stitched_closed_loop_to_a_hole() {
+        let mut b = GeometryBuilder::new(PolygonFill::Containment);
+        b.add(&polygon(&[
+            (0.0, 0.0),
+            (10.0, 0.0),
+            (10.0, 10.0),
+            (0.0, 10.0),
+        ]));
+        b.add(&ls(&[(2.0, 2.0), (4.0, 2.0), (4.0, 4.0)]));
+        b.add(&ls(&[(4.0, 4.0), (2.0, 4.0), (2.0, 2.0)]));
+        match b.finish() {
+            Some(Geometry::Polygon(p)) => assert_eq!(p.interiors().len(), 1),
+            other => panic!("expected Polygon with a hole, got {other:?}"),
+        }
+    }
+
+    /// The complement of the two tests above: in Union mode, a closed
+    /// loop of stitched lines is *not* necessarily an area (e.g. a
+    /// circular route relation's ways closing back on themselves is still
+    /// a route) -- see `PolygonFill::Union`'s docs -- so it should stay a
+    /// line, not get promoted to a polygon.
+    #[test]
+    fn union_fill_does_not_promote_a_stitched_closed_loop() {
+        let mut b = GeometryBuilder::new(PolygonFill::Union);
+        b.add(&ls(&[(0.0, 0.0), (10.0, 0.0), (10.0, 10.0)]));
+        b.add(&ls(&[(10.0, 10.0), (0.0, 10.0), (0.0, 0.0)]));
+        match b.finish() {
+            Some(Geometry::LineString(l)) => assert_eq!(l.0.len(), 5),
+            other => panic!("expected the stitched loop to stay a LineString, got {other:?}"),
         }
     }
 

--- a/src/geometry/grid_tests.rs
+++ b/src/geometry/grid_tests.rs
@@ -32,34 +32,27 @@
 //! it's compared against whichever of `default`/`fix`/`location` is
 //! actually a valid WKT (see [`expected_geometry`]).
 //!
-//! Three further caveats, tracked as known mismatches in
+//! Two further caveats, tracked as known mismatches in
 //! [`KNOWN_MISMATCHES`] rather than hard test failures:
-//! * **Stitched closed loops aren't promoted to rings.** When a ring is
-//!   made of 2+ *open* member ways, `GeometryBuilder` runs each through
-//!   `build_line` (they're open) and routes the resulting `LineString`s to
-//!   its internal `LineStitcher`, which joins them into one closed path —
-//!   but nothing then notices that closed path is a ring and hands it to
-//!   `PolygonAssembler`. If that's the *only* member (e.g. grid `701`),
-//!   the relation ends up a `LineString`/`MultiLineString`, not a
-//!   `Polygon`. If the relation *also* has an independent closed-way ring
-//!   (e.g. `782`'s outer, a single way), `GeometryBuilder::finish`'s
-//!   mixed-kind path clips the stitched line to whatever falls outside the
-//!   polygon area — since the stitched loop sits entirely inside, it's
-//!   clipped away completely, silently dropping what should have been a
-//!   hole. A ring built from a single, already-closed way (`build_ring`'s
-//!   own output) is unaffected, since it's a `Polygon` from the start.
 //! * **Duplicate/overlapping ring members self-cancel.** A relation whose
 //!   members describe the same ring twice (literally the same way twice,
-//!   as `790`, or two different ways tracing the same or an overlapping
-//!   ring, as `791`/`792`) hits `PolygonAssembler`'s even-odd nesting rule
-//!   exactly as two perfectly overlapping rings would: the second
-//!   "cancels" the first, producing nothing. `default` is itself `INVALID`
-//!   for these; only `location` gives a lenient expected area.
-//! * `GeometryBuilder` also doesn't yet special-case `type=multipolygon`/
-//!   `boundary` relations (nesting decides fill) vs. other relation types
-//!   (which should be a plain geometric union, ignoring containment) —
-//!   moot for this fixture set, since every relation in it is one of the
-//!   two nesting-fill types, but relevant to note.
+//!   as `790`, or the same way listed twice as a member, as `795`, or two
+//!   different ways tracing the same or an overlapping ring, as
+//!   `791`/`792`) hits `PolygonAssembler`'s even-odd nesting rule exactly
+//!   as two perfectly overlapping rings would: the second "cancels" the
+//!   first, producing nothing (or, for `795`, dropping the hole entirely).
+//!   `default` is itself `INVALID` for these; only `location` gives a
+//!   lenient expected area. See
+//!   <https://github.com/alltheplaces/osm-diffs/issues/532>.
+//! * **A "spike" (an exact-reversal duplicate segment) can leave a ring in
+//!   pieces that don't get re-stitched.** `LineStitcher` cuts a stitched
+//!   path at any point it revisits (self-intersection repair, same
+//!   philosophy as `build_line`'s own), which correctly drops a
+//!   zero-width spike -- but the resulting pieces, though they still share
+//!   endpoints with each other, aren't fed through a second stitching
+//!   pass, so a ring that would close cleanly once the spike is removed
+//!   (`711`, `742`, `743`) instead stays several disconnected open pieces.
+//!   See <https://github.com/alltheplaces/osm-diffs/issues/537>.
 //!
 //! A fixture with no valid `default`/`fix`/`location` at all has no oracle
 //! to check against and is likewise recorded in [`KNOWN_MISMATCHES`].
@@ -318,15 +311,14 @@ fn areas_match(actual: &Geometry<f64>, expected: &MultiPolygon<f64>) -> bool {
 /// here (rather than skipped silently) so a fix shows up as a now-
 /// unexpectedly-passing test, prompting its removal from this list.
 const KNOWN_MISMATCHES: &[u32] = &[
-    // Ring stitched from 2+ open member ways isn't promoted to a
-    // Polygon/hole (see module docs' "stitched closed loops" caveat).
-    // https://github.com/alltheplaces/osm-diffs/issues/531
-    701, 702, 703, 704, 705, 706, 707, 708, 709, 711, 725, 731, 742, 743, 782, 795, 901, 902, 904,
-    912, 913, 920, 921, 924, 925, 930, 931, 950,
     // Duplicate/overlapping ring members self-cancel under the even-odd
     // nesting rule (see module docs' "duplicate/overlapping" caveat).
     // https://github.com/alltheplaces/osm-diffs/issues/532
-    790, 791, 792,
+    790, 791, 792, 795,
+    // A "spike" (exact-reversal duplicate segment) leaves a ring in
+    // pieces that don't get re-stitched (see module docs' "spike"
+    // caveat). https://github.com/alltheplaces/osm-diffs/issues/537
+    711, 742, 743,
     // No default/fix/location entry parses to a real polygon at all --
     // nothing to check `GeometryBuilder`'s output against yet. Not a filed
     // bug: these fixtures are meant to have no lenient interpretation.


### PR DESCRIPTION
## What

Fixes #531: when a ring is made of 2+ *open* member ways (rather than one already-closed way), `GeometryBuilder` ran each through `build_line` and routed the resulting `LineString`s to its internal `LineStitcher`, which joins them into one closed path -- but nothing then noticed that closed path was a ring and handed it to the polygon accumulator. So the relation ended up a `LineString`/`MultiLineString` (or, if it also had an independent closed-way ring, the stitched loop got clipped away entirely as redundant line territory, silently dropping what should've been a hole).

## How

In `Containment` mode, every member way is ring material -- whether it arrived pre-closed (`build_ring` already made it a `Polygon`) or as an open arc that only closes once stitched to its neighbors. `GeometryBuilder::finish` now, in `Containment` mode only, extracts any closed piece `LineStitcher` produced, repairs it through `build_ring` (the same self-intersection repair a single self-intersecting way would get), and hands it to the polygon accumulator. Leftover open pieces stay line output, same as today.

`Union` mode is untouched: a closed loop isn't necessarily an area there (a circular route relation's ways closing back on themselves is still a route, not a polygon). This is exactly what sequencing this fix after #534/#536 (which taught `GeometryBuilder` the `Containment`/`Union` distinction) makes possible without regressing non-multipolygon relation types -- the concern that made me hold off on this fix earlier.

## Grid fixture impact

Fixes 24 of the 26 `grid_tests.rs` `KNOWN_MISMATCHES` cases this affected. The 2 residual groups got re-triaged rather than left vague:
- `711`/`742`/`743` turned out to need a *second* stitching pass after `LineStitcher`'s own self-intersection ("spike") cut -- a distinct, deeper gap. Filed as #537, moved out of #531's bucket.
- `795` turned out to be a duplicate-member case (the same way listed twice as an `inner` member), not a stitched-loop case at all. Reclassified into the existing #532 bucket alongside `790`/`791`/`792`.

## Testing

- New `GeometryBuilder` tests cover both promotion shapes (a ring made of 2+ ways -- mirrors grid `9/901`; a hole made of 2+ ways -- mirrors grid `7/782`) and confirm `Union` mode's non-promotion (the route-relation regression guard).
- `cargo test` (full suite, including `test_pipeline`) -- green.
- `cargo clippy`, `cargo fmt`, `cargo doc` -- clean.