### PR TITLE
Re-stitch after cutting a self-intersection (fixes #537)

### DIFF
--- a/src/geometry/grid_tests.rs
+++ b/src/geometry/grid_tests.rs
@@ -34,15 +34,17 @@
 //!
 //! One further caveat, tracked as a known mismatch in [`KNOWN_MISMATCHES`]
 //! rather than a hard test failure:
-//! * **A "spike" (an exact-reversal duplicate segment) can leave a ring in
-//!   pieces that don't get re-stitched.** `LineStitcher` cuts a stitched
-//!   path at any point it revisits (self-intersection repair, same
-//!   philosophy as `build_line`'s own), which correctly drops a
-//!   zero-width spike -- but the resulting pieces, though they still share
-//!   endpoints with each other, aren't fed through a second stitching
-//!   pass, so a ring that would close cleanly once the spike is removed
-//!   (`711`, `742`, `743`) instead stays several disconnected open pieces.
-//!   See <https://github.com/alltheplaces/osm-diffs/issues/537>.
+//! * **A segment duplicated across two ways isn't deduped, and can leave a
+//!   ring in pieces.** Two ways that both contain the same segment (`711`
+//!   -- unlike a "spike", `742`/`743`'s exact-reversal case, which
+//!   `LineStitcher` does now handle) stitch into one chain, get cut at the
+//!   incidental point-touches the duplicate creates, and end up as two
+//!   duplicate 2-point pieces plus the real path -- after which every
+//!   node the duplicate touches looks like a genuine degree-3 junction
+//!   (one edge from each duplicate copy, one from the real path), which
+//!   correctly blocks further merging in the general case but is wrong
+//!   here, where the "3" is an artifact of the duplicate rather than a
+//!   real fork. See <https://github.com/alltheplaces/osm-diffs/issues/541>.
 //!
 //! A fixture with no valid `default`/`fix`/`location` at all has no oracle
 //! to check against and is likewise recorded in [`KNOWN_MISMATCHES`].
@@ -301,10 +303,10 @@ fn areas_match(actual: &Geometry<f64>, expected: &MultiPolygon<f64>) -> bool {
 /// here (rather than skipped silently) so a fix shows up as a now-
 /// unexpectedly-passing test, prompting its removal from this list.
 const KNOWN_MISMATCHES: &[u32] = &[
-    // A "spike" (exact-reversal duplicate segment) leaves a ring in
-    // pieces that don't get re-stitched (see module docs' "spike"
-    // caveat). https://github.com/alltheplaces/osm-diffs/issues/537
-    711, 742, 743,
+    // A segment duplicated across two ways isn't deduped (see module
+    // docs' "duplicated across two ways" caveat).
+    // https://github.com/alltheplaces/osm-diffs/issues/541
+    711,
     // No default/fix/location entry parses to a real polygon at all --
     // nothing to check `GeometryBuilder`'s output against yet. Not a filed
     // bug: these fixtures are meant to have no lenient interpretation.

--- a/src/geometry/line_stitcher.rs
+++ b/src/geometry/line_stitcher.rs
@@ -12,6 +12,13 @@ use super::{align_to_reference_x, centroid_x, cut_at_crossings, find_crossings};
 /// [`LineStitcher::with_max_coordinates`] to override it.
 const DEFAULT_MAX_COORDINATES: usize = 2000;
 
+/// Safety cap on how many times [`LineStitcher::finish`] alternates
+/// cutting and re-stitching (see "Spikes" below) before giving up and
+/// returning whatever it has. In practice this settles in one or two
+/// rounds; the cap only guards against a pathological input that somehow
+/// never converges.
+const MAX_STITCH_CUT_ROUNDS: usize = 8;
+
 type CoordKey = (u64, u64);
 
 fn coord_key(c: Coord<f64>) -> CoordKey {
@@ -85,6 +92,23 @@ enum ChainEnd {
 /// itself might introduce (rare, but
 /// <https://github.com/georust/geo/issues/1049> shows `SimplifyVwPreserve`
 /// isn't entirely immune to it despite the name).
+///
+/// # Spikes
+/// Cutting a self-intersection can newly expose endpoints that stitch
+/// with each other. The clearest case is a "spike": two ways that share
+/// *both* endpoints but double back on one segment along the way (`A → B
+/// → C` and `C → B → D → E → A`) merge into one chain that revisits `B`
+/// (`A,B,C,B,D,E,A`). That's not a proper crossing (the doubled-back
+/// `B→C→B` is a collinear overlap, not two segments crossing at a point),
+/// but it does make `B` a self-touching vertex, and cutting there leaves
+/// three pieces: `A,B` and `B,D,E,A` — the ring the ways actually
+/// describe, just no longer stitched together — plus the degenerate
+/// `B,C,B` spike itself, which stays a separate, harmless closed 2-point
+/// loop no consumer downstream treats as real area. `finish()` re-stitches
+/// after every cutting round and only stops once a round leaves the piece
+/// count unchanged, so `A,B` and `B,D,E,A` end up merged back into the
+/// closed ring they were always meant to be. See
+/// <https://github.com/alltheplaces/osm-diffs/issues/537>.
 pub struct LineStitcher {
     lines: Vec<VecDeque<Coord<f64>>>,
     reference_x: Option<f64>,
@@ -188,47 +212,38 @@ impl LineStitcher {
             return None;
         }
 
-        // Static degree per node: how many way-ends (across everything
-        // added) touch it. Computed once, up front, so a junction found
-        // late doesn't have to "undo" an earlier greedy merge.
-        let mut degree: HashMap<CoordKey, usize> = HashMap::new();
-        for line in &self.lines {
-            *degree.entry(coord_key(line[0])).or_insert(0) += 1;
-            *degree.entry(coord_key(*line.back().unwrap())).or_insert(0) += 1;
-        }
+        let mut current = stitch_round(std::mem::take(&mut self.lines));
 
-        let mut chains: Vec<Option<VecDeque<Coord<f64>>>> = Vec::new();
-        let mut endpoint_index: HashMap<CoordKey, (usize, ChainEnd)> = HashMap::new();
-        for line in std::mem::take(&mut self.lines) {
-            add_chain(&mut chains, &mut endpoint_index, &degree, line);
-        }
-
-        let mut stitched: Vec<VecDeque<Coord<f64>>> = chains.into_iter().flatten().collect();
-
-        let total: usize = stitched.iter().map(|c| c.len()).sum();
+        // Simplify before the first self-intersection check below, so a
+        // self-intersection simplification itself introduces also gets
+        // caught (see struct docs).
+        let total: usize = current.iter().map(|c| c.len()).sum();
         if total > self.max_coordinates {
-            self.lines = stitched;
+            self.lines = current;
             self.total_coords = total;
             self.compact();
-            stitched = std::mem::take(&mut self.lines);
+            current = std::mem::take(&mut self.lines);
         }
 
-        let mut pieces: Vec<LineString<f64>> = Vec::new();
-        for chain in stitched {
-            if chain.len() < 2 {
-                continue;
+        // Cut, then re-stitch whatever that cut newly exposed, until a
+        // round leaves the piece count unchanged (see struct docs,
+        // "Spikes"). For ordinary input (no self-intersection) `changed`
+        // is `false` on the very first round, so this costs nothing beyond
+        // today's single cut pass.
+        for _ in 0..MAX_STITCH_CUT_ROUNDS {
+            let (pieces, changed) = cut_round(current);
+            current = pieces;
+            if !changed {
+                break;
             }
-            let ls = LineString::new(chain.into_iter().collect());
-            if !ls.is_valid() {
-                continue; // e.g. a degenerate all-duplicate-point loop
-            }
-            let crossings = find_crossings(&ls);
-            if crossings.is_empty() {
-                pieces.push(ls);
-            } else {
-                pieces.extend(cut_at_crossings(&ls, crossings));
-            }
+            current = stitch_round(current);
         }
+
+        let pieces: Vec<LineString<f64>> = current
+            .into_iter()
+            .filter(|chain| chain.len() >= 2)
+            .map(|chain| LineString::new(chain.into_iter().collect()))
+            .collect();
 
         match pieces.len() {
             0 => None,
@@ -236,6 +251,61 @@ impl LineStitcher {
             _ => Some(Geometry::from(MultiLineString::new(pieces))),
         }
     }
+}
+
+/// One round of stitching: computes per-node degree fresh from `lines`'
+/// current endpoints, then merges through every degree-2 junction (see
+/// struct docs). A chain that's already a closed loop is left as-is — it
+/// never tries to extend through its own closing node.
+fn stitch_round(lines: Vec<VecDeque<Coord<f64>>>) -> Vec<VecDeque<Coord<f64>>> {
+    // Static degree per node: how many way-ends (across everything in
+    // `lines`) touch it. Computed once, up front, so a junction found
+    // late doesn't have to "undo" an earlier greedy merge.
+    let mut degree: HashMap<CoordKey, usize> = HashMap::new();
+    for line in &lines {
+        *degree.entry(coord_key(line[0])).or_insert(0) += 1;
+        *degree.entry(coord_key(*line.back().unwrap())).or_insert(0) += 1;
+    }
+
+    let mut chains: Vec<Option<VecDeque<Coord<f64>>>> = Vec::new();
+    let mut endpoint_index: HashMap<CoordKey, (usize, ChainEnd)> = HashMap::new();
+    for line in lines {
+        add_chain(&mut chains, &mut endpoint_index, &degree, line);
+    }
+    chains.into_iter().flatten().collect()
+}
+
+/// One round of self-intersection repair: the same repair `build_line`
+/// uses, applied to each of `chains` independently -- validate, then cut
+/// at every self-crossing. Returns the resulting pieces, along with
+/// whether their count differs from `chains.len()`: a proxy for "this
+/// round changed something", which `finish()` uses to decide whether
+/// another stitching round might find newly-exposed endpoints to merge
+/// (see struct docs, "Spikes").
+fn cut_round(chains: Vec<VecDeque<Coord<f64>>>) -> (Vec<VecDeque<Coord<f64>>>, bool) {
+    let before = chains.len();
+    let mut pieces: Vec<VecDeque<Coord<f64>>> = Vec::new();
+    for chain in chains {
+        if chain.len() < 2 {
+            continue;
+        }
+        let ls = LineString::new(chain.into_iter().collect());
+        if !ls.is_valid() {
+            continue; // e.g. a degenerate all-duplicate-point loop
+        }
+        let crossings = find_crossings(&ls);
+        if crossings.is_empty() {
+            pieces.push(ls.0.into_iter().collect());
+        } else {
+            pieces.extend(
+                cut_at_crossings(&ls, crossings)
+                    .into_iter()
+                    .map(|cut| cut.0.into_iter().collect()),
+            );
+        }
+    }
+    let changed = pieces.len() != before;
+    (pieces, changed)
 }
 
 fn add_chain(
@@ -501,6 +571,37 @@ mod tests {
                 }
             }
             other => panic!("expected MultiLineString, got {other:?}"),
+        }
+    }
+
+    /// https://github.com/alltheplaces/osm-diffs/issues/537, mirroring
+    /// osm-testdata grid fixture `7/742`: two ways sharing both endpoints
+    /// but doubling back on one segment (`A→B→C` and `C→B→D→E→A`) stitch
+    /// into a chain that revisits `B`. Cutting that "spike" away should
+    /// leave the two *other* pieces free to re-stitch into the closed
+    /// ring they actually describe, not stuck as separate open paths.
+    #[test]
+    fn spike_is_cut_and_the_remaining_pieces_restitch_into_a_ring() {
+        let mut a = LineStitcher::new();
+        a.add(&ls(&[(0.0, 0.0), (0.0, 1.0), (0.0, 2.0)])); // A, B, C
+        a.add(&ls(&[
+            (0.0, 2.0), // C
+            (0.0, 1.0), // B (doubles back)
+            (1.0, 1.0), // D
+            (1.0, 0.0), // E
+            (0.0, 0.0), // A
+        ]));
+        match a.finish() {
+            Some(Geometry::MultiLineString(m)) => {
+                let has_closed_ring =
+                    m.0.iter()
+                        .any(|l| l.0.len() >= 4 && l.0.first() == l.0.last());
+                assert!(
+                    has_closed_ring,
+                    "expected a closed ring among the pieces, got {m:?}"
+                );
+            }
+            other => panic!("expected the spike cut away from a re-stitched ring, got {other:?}"),
         }
     }
 


### PR DESCRIPTION
## What

Fixes #537: cutting a self-intersection can newly expose endpoints that stitch with each other. The clearest case is a "spike": two ways sharing both endpoints but doubling back on one segment (`A→B→C` and `C→B→D→E→A`) merge into a chain that revisits `B` (`A,B,C,B,D,E,A`). That's a collinear overlap, not a proper crossing, but it does make `B` a self-touching vertex; cutting there leaves three pieces -- `A,B` and `B,D,E,A` (the ring the ways actually describe, just no longer stitched together) plus the degenerate `B,C,B` spike itself -- and `finish()` previously stopped right there, never noticing `A,B` and `B,D,E,A` still share endpoints.

## How

`finish()` now alternates cutting and re-stitching (`stitch_round`/`cut_round`, extracted from the previous single-pass body) until a round leaves the piece count unchanged, capped at `MAX_STITCH_CUT_ROUNDS` as a safety net against any pathological non-converging input. For ordinary non-self-intersecting input the first cut round changes nothing, so this costs zero extra work beyond today's single pass.

## Grid fixture impact

Fixes 2 of the 3 `grid_tests.rs` `KNOWN_MISMATCHES` cases in #537's bucket (`742`, `743`). The third (`711`) turned out, on tracing through it, to be a different bug entirely: not a spike but a segment *duplicated across two ways in the same direction*, which cutting turns into two duplicate 2-point pieces that give every node they touch an artificial degree of 3 -- indistinguishable, to the stitcher, from a real three-way junction, so it correctly (if unhelpfully) refuses to merge through it. Re-filed as #541, since it needs segment-level deduplication (analogous to #532's ring-level `ring_key`, but for `LineStitcher`) rather than anything the re-stitch loop can fix.

## Testing

- New `LineStitcher` test reproduces the spike scenario directly, mirroring grid fixture `742`.
- `cargo test` (full suite) -- green.
- `cargo clippy`, `cargo fmt`, `cargo doc` -- clean.