### PR TITLE
Dedupe duplicate output pieces in LineStitcher (fixes #541)

### DIFF
--- a/src/geometry/grid_tests.rs
+++ b/src/geometry/grid_tests.rs
@@ -32,24 +32,10 @@
 //! it's compared against whichever of `default`/`fix`/`location` is
 //! actually a valid WKT (see [`expected_geometry`]).
 //!
-//! One further caveat, tracked as a known mismatch in [`KNOWN_MISMATCHES`]
-//! rather than a hard test failure:
-//! * **A segment duplicated across two ways isn't deduped, and can leave a
-//!   ring in pieces.** Two ways that both contain the same segment (`711`
-//!   -- unlike a "spike", `742`/`743`'s exact-reversal case, which
-//!   `LineStitcher` does now handle) stitch into one chain, get cut at the
-//!   incidental point-touches the duplicate creates, and end up as two
-//!   duplicate 2-point pieces plus the real path -- after which every
-//!   node the duplicate touches looks like a genuine degree-3 junction
-//!   (one edge from each duplicate copy, one from the real path), which
-//!   correctly blocks further merging in the general case but is wrong
-//!   here, where the "3" is an artifact of the duplicate rather than a
-//!   real fork. See <https://github.com/alltheplaces/osm-diffs/issues/541>.
-//!
-//! A fixture with no valid `default`/`fix`/`location` at all has no oracle
-//! to check against and is likewise recorded in [`KNOWN_MISMATCHES`].
-//! None of this is something this test suite should fail CI over today —
-//! it's the follow-up work the grid run surfaced.
+//! Every fixture that has an oracle to check against now matches it. The
+//! only entries left in [`KNOWN_MISMATCHES`] are fixtures with no valid
+//! `default`/`fix`/`location` at all -- nothing to check `GeometryBuilder`'s
+//! output against in the first place, not a bug.
 
 use std::{collections::HashMap, fs, path::PathBuf};
 
@@ -303,10 +289,6 @@ fn areas_match(actual: &Geometry<f64>, expected: &MultiPolygon<f64>) -> bool {
 /// here (rather than skipped silently) so a fix shows up as a now-
 /// unexpectedly-passing test, prompting its removal from this list.
 const KNOWN_MISMATCHES: &[u32] = &[
-    // A segment duplicated across two ways isn't deduped (see module
-    // docs' "duplicated across two ways" caveat).
-    // https://github.com/alltheplaces/osm-diffs/issues/541
-    711,
     // No default/fix/location entry parses to a real polygon at all --
     // nothing to check `GeometryBuilder`'s output against yet. Not a filed
     // bug: these fixtures are meant to have no lenient interpretation.

--- a/src/geometry/grid_tests.rs
+++ b/src/geometry/grid_tests.rs
@@ -22,7 +22,7 @@
 //! WKT by area of symmetric difference, not by string equality, since
 //! ring start point/winding direction legitimately differ.
 //!
-//! # `default` vs. `fix`/`location`, and known mismatches
+//! # `default` vs. `fix`/`location`
 //! A fixture's `default` interpretation is the strict OGC reading; `fix`
 //! and `location` (checked, in the vendored data, only ever alongside an
 //! `INVALID` default) are alternate, deliberately lenient readings — e.g.
@@ -32,10 +32,11 @@
 //! it's compared against whichever of `default`/`fix`/`location` is
 //! actually a valid WKT (see [`expected_geometry`]).
 //!
-//! Every fixture that has an oracle to check against now matches it. The
-//! only entries left in [`KNOWN_MISMATCHES`] are fixtures with no valid
-//! `default`/`fix`/`location` at all -- nothing to check `GeometryBuilder`'s
-//! output against in the first place, not a bug.
+//! Every fixture that has an oracle to check against matches it. The only
+//! ones this test doesn't hold itself accountable for are tracked in
+//! [`NO_ORACLE_FIXTURES`] — fixtures with no valid `default`/`fix`/`location`
+//! at all, so there's nothing to check `GeometryBuilder`'s output against
+//! in the first place. That's not a bug; see that constant's docs.
 
 use std::{collections::HashMap, fs, path::PathBuf};
 
@@ -282,18 +283,18 @@ fn areas_match(actual: &Geometry<f64>, expected: &MultiPolygon<f64>) -> bool {
 // The test itself
 // =======================================================================
 
-/// Grid test IDs whose `GeometryBuilder` output is known not to match its
-/// oracle yet — either because there's no valid `default`/`fix`/`location`
-/// WKT to check against at all, or because of the
-/// multipolygon-vs-general-relation gap noted in the module docs. Tracked
-/// here (rather than skipped silently) so a fix shows up as a now-
-/// unexpectedly-passing test, prompting its removal from this list.
-const KNOWN_MISMATCHES: &[u32] = &[
-    // No default/fix/location entry parses to a real polygon at all --
-    // nothing to check `GeometryBuilder`'s output against yet. Not a filed
-    // bug: these fixtures are meant to have no lenient interpretation.
-    710, 714, 715, 740, 741, 744, 745, 746, 768, 771, 773,
-];
+/// Grid test IDs with no valid `default`/`fix`/`location` WKT to check
+/// `GeometryBuilder`'s output against at all -- not a bug, just nothing to
+/// verify (these fixtures are meant to have no lenient interpretation).
+/// Tracked here (rather than skipped silently) so an upstream grid update
+/// that gives one of these a real oracle -- or a regression that makes a
+/// currently-passing fixture unverifiable -- shows up as a test change
+/// prompting a look, rather than silently altering coverage. If a genuine
+/// `GeometryBuilder` mismatch (as opposed to "no oracle") ever needs
+/// tracking here too, this list's name and doc should go back to
+/// something more general -- today, every fixture with an oracle matches
+/// it, so it doesn't need to.
+const NO_ORACLE_FIXTURES: &[u32] = &[710, 714, 715, 740, 741, 744, 745, 746, 768, 771, 773];
 
 fn grid_fixture_dirs() -> Vec<PathBuf> {
     let mut root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -335,7 +336,7 @@ fn grid_multipolygon_tests() {
             continue; // not a multipolygon test (no expected geometry)
         };
         let Some(expected_entries) = expected_geometry(areas) else {
-            if !KNOWN_MISMATCHES.contains(&test_id) {
+            if !NO_ORACLE_FIXTURES.contains(&test_id) {
                 mismatches.push(format!("{test_id}: no valid default/fix/location oracle"));
             }
             continue;
@@ -367,7 +368,7 @@ fn grid_multipolygon_tests() {
             }
         }
 
-        if !case_ok && !KNOWN_MISMATCHES.contains(&test_id) {
+        if !case_ok && !NO_ORACLE_FIXTURES.contains(&test_id) {
             mismatches.push(format!("{test_id}: {}", details.join("; ")));
         }
     }
@@ -385,25 +386,26 @@ fn grid_multipolygon_tests() {
 }
 
 #[test]
-fn known_mismatches_are_still_mismatches() {
-    // Guards against KNOWN_MISMATCHES silently going stale: if a listed
-    // test id starts passing (e.g. after a GeometryBuilder fix), it should
-    // be removed from the list rather than staying there unnoticed.
-    for &test_id in KNOWN_MISMATCHES {
+fn no_oracle_fixtures_are_still_unverifiable() {
+    // Guards against NO_ORACLE_FIXTURES silently going stale: if a listed
+    // test id gets a real oracle to check against (e.g. an upstream grid
+    // update), or now matches one, it should be removed from the list
+    // rather than staying there unnoticed.
+    for &test_id in NO_ORACLE_FIXTURES {
         let dir = grid_fixture_dirs()
             .into_iter()
             .find(|d| d.file_name().unwrap().to_str().unwrap() == test_id.to_string())
-            .unwrap_or_else(|| panic!("KNOWN_MISMATCHES has stale test id {test_id}"));
+            .unwrap_or_else(|| panic!("NO_ORACLE_FIXTURES has stale test id {test_id}"));
 
         let test_json: TestJson =
             serde_json::from_str(&fs::read_to_string(dir.join("test.json")).unwrap()).unwrap();
         let areas = test_json
             .areas
             .as_ref()
-            .unwrap_or_else(|| panic!("{test_id} in KNOWN_MISMATCHES has no areas at all"));
+            .unwrap_or_else(|| panic!("{test_id} in NO_ORACLE_FIXTURES has no areas at all"));
         let data = parse_osm(&fs::read_to_string(dir.join("data.osm")).unwrap());
 
-        let still_mismatched = match expected_geometry(areas) {
+        let still_unverifiable = match expected_geometry(areas) {
             None => true, // still no oracle to check against
             Some(entries) => entries.iter().any(|entry| {
                 let expected = parse_multipolygon_wkt(&entry.wkt);
@@ -414,8 +416,8 @@ fn known_mismatches_are_still_mismatches() {
             }),
         };
         assert!(
-            still_mismatched,
-            "{test_id} is in KNOWN_MISMATCHES but now matches its oracle; remove it from the list"
+            still_unverifiable,
+            "{test_id} is in NO_ORACLE_FIXTURES but now has an oracle it matches; remove it from the list"
         );
     }
 }

--- a/src/geometry/line_stitcher.rs
+++ b/src/geometry/line_stitcher.rs
@@ -1,7 +1,7 @@
 //! Stitches arbitrarily-ordered, arbitrarily-oriented `LineString`s into
 //! longer paths wherever their endpoints touch. See [`LineStitcher`].
 
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 
 use geo::algorithm::validation::Validation;
 use geo::{Coord, Geometry, LineString, MultiLineString, SimplifyVwPreserve};
@@ -109,6 +109,20 @@ enum ChainEnd {
 /// count unchanged, so `A,B` and `B,D,E,A` end up merged back into the
 /// closed ring they were always meant to be. See
 /// <https://github.com/alltheplaces/osm-diffs/issues/537>.
+///
+/// # Duplicate segments
+/// A segment shared verbatim by two ways in the *same* direction (as
+/// opposed to a spike's reversal) is a collinear overlap too, so it isn't
+/// a crossing either -- but if cutting elsewhere in the chain ever
+/// separates it out as its own piece, it comes out *twice*, once from
+/// each way. Left alone, both copies would count toward their shared
+/// endpoints' degree, making a node that's actually part of a simple loop
+/// look like a genuine three-way junction and blocking it from
+/// re-stitching. Every cutting round de-duplicates its own output pieces
+/// (`cut_round`, via [`line_key`]) for exactly this reason -- the same
+/// idea as [`PolygonAssembler`](super::PolygonAssembler)'s duplicate-ring
+/// guard, applied to open pieces instead of closed rings. See
+/// <https://github.com/alltheplaces/osm-diffs/issues/541>.
 pub struct LineStitcher {
     lines: Vec<VecDeque<Coord<f64>>>,
     reference_x: Option<f64>,
@@ -277,11 +291,12 @@ fn stitch_round(lines: Vec<VecDeque<Coord<f64>>>) -> Vec<VecDeque<Coord<f64>>> {
 
 /// One round of self-intersection repair: the same repair `build_line`
 /// uses, applied to each of `chains` independently -- validate, then cut
-/// at every self-crossing. Returns the resulting pieces, along with
-/// whether their count differs from `chains.len()`: a proxy for "this
-/// round changed something", which `finish()` uses to decide whether
-/// another stitching round might find newly-exposed endpoints to merge
-/// (see struct docs, "Spikes").
+/// at every self-crossing -- followed by dropping any exact-duplicate
+/// piece that cutting produced (see struct docs, "Duplicate segments").
+/// Returns the resulting pieces, along with whether their count differs
+/// from `chains.len()`: a proxy for "this round changed something", which
+/// `finish()` uses to decide whether another stitching round might find
+/// newly-exposed endpoints to merge (see struct docs, "Spikes").
 fn cut_round(chains: Vec<VecDeque<Coord<f64>>>) -> (Vec<VecDeque<Coord<f64>>>, bool) {
     let before = chains.len();
     let mut pieces: Vec<VecDeque<Coord<f64>>> = Vec::new();
@@ -304,8 +319,25 @@ fn cut_round(chains: Vec<VecDeque<Coord<f64>>>) -> (Vec<VecDeque<Coord<f64>>>, b
             );
         }
     }
+
+    let mut seen = HashSet::new();
+    pieces.retain(|piece| seen.insert(line_key(piece)));
+
     let changed = pieces.len() != before;
     (pieces, changed)
+}
+
+/// Canonicalizes a piece's coordinates so that it and its exact reverse
+/// produce the same key -- `A,B,C` and `C,B,A` are the same undirected
+/// path, however it's traced. Unlike `PolygonAssembler`'s `ring_key`, no
+/// rotation is tried: these are open pieces, or a closed one with an
+/// already-fixed start/end (e.g. a spike's remnant loop), not cyclic
+/// rings where the start point is arbitrary.
+fn line_key(points: &VecDeque<Coord<f64>>) -> Vec<(u64, u64)> {
+    let bits = |c: Coord<f64>| (c.x.to_bits(), c.y.to_bits());
+    let forward: Vec<(u64, u64)> = points.iter().copied().map(bits).collect();
+    let backward: Vec<(u64, u64)> = points.iter().rev().copied().map(bits).collect();
+    forward.min(backward)
 }
 
 fn add_chain(
@@ -602,6 +634,36 @@ mod tests {
                 );
             }
             other => panic!("expected the spike cut away from a re-stitched ring, got {other:?}"),
+        }
+    }
+
+    /// https://github.com/alltheplaces/osm-diffs/issues/541, mirroring
+    /// osm-testdata grid fixture `7/711`: two ways sharing the same
+    /// segment in the *same* direction (`A→B→C` and `B→C→D→A`) -- unlike
+    /// a spike's reversal -- should still close into the one ring they
+    /// describe, not stay fragmented because the un-deduplicated
+    /// duplicate segment makes its endpoints look like three-way
+    /// junctions.
+    #[test]
+    fn duplicate_segment_is_deduped_and_the_ring_closes() {
+        let mut a = LineStitcher::new();
+        a.add(&ls(&[(0.0, 0.0), (0.0, 1.0), (1.0, 1.0)])); // A, B, C
+        a.add(&ls(&[
+            (0.0, 1.0), // B
+            (1.0, 1.0), // C (same direction as above: B -> C)
+            (1.0, 0.0), // D
+            (0.0, 0.0), // A
+        ]));
+        match a.finish() {
+            Some(Geometry::LineString(l)) => {
+                assert_eq!(l.0.first(), l.0.last(), "expected a closed ring");
+                assert_eq!(
+                    l.0.len(),
+                    5,
+                    "expected exactly one ring, no leftover pieces"
+                );
+            }
+            other => panic!("expected a single closed ring, got {other:?}"),
         }
     }
 


### PR DESCRIPTION
## What

Fixes #541: a segment shared verbatim by two ways in the *same* direction (unlike a spike's reversal) is a collinear overlap, so `find_crossings` correctly doesn't treat it as a crossing -- but if cutting elsewhere in the chain separates it out as its own piece, it comes out *twice*, once from each way. Left alone, both copies count toward their shared endpoints' degree, making a node that's actually part of a simple loop look like a genuine three-way junction and permanently blocking it from re-stitching. #537's re-stitch loop doesn't help here: the piece count really does stabilize round over round, just not at the right pieces.

## How

`cut_round` now de-duplicates its own output pieces via a new `line_key()` -- the same idea as `PolygonAssembler`'s `ring_key` from #532, but simpler: no rotation needed since these are open pieces (or a closed one with an already-fixed start/end, like a spike's remnant), not cyclic rings, so just forward-vs-reversed comparison suffices.

## Grid fixture impact

Fixes the last `grid_tests.rs` `KNOWN_MISMATCHES` case with an actual oracle to check against (`711`). **Every grid fixture that has a lenient interpretation to compare to now matches it** -- the remaining 11 `KNOWN_MISMATCHES` entries are fixtures with no valid `default`/`fix`/`location` at all, not bugs.

## Testing

- New `LineStitcher` test reproduces `711`'s scenario directly.
- `cargo test` (full suite) -- green.
- `cargo clippy`, `cargo fmt`, `cargo doc` -- clean.