### PR TITLE
Reuse make_feature_id() instead of inlining OSM id*10+N encoding

### DIFF
--- a/src/pipeline/osm/assemble.rs
+++ b/src/pipeline/osm/assemble.rs
@@ -164,7 +164,8 @@ fn assemble_nodes(
                     if let Primitive::Node(node) = primitive
                         && keep_nodes.contains(node.id)
                     {
-                        let mut fti = assemble_feature(10 * node.id + 1, &node.info);
+                        let feature_id = make_feature_id(RelationMemberType::Node, node.id);
+                        let mut fti = assemble_feature(feature_id, &node.info);
                         let point = geo::Point::new(node.lon, node.lat); // x = longitude, y = latitude
                         if let Some(feature) = &mut fti.feature {
                             write_point(&mut feature.geometry_wkb, &point, &WKB_WRITE_OPTIONS)?;
@@ -243,7 +244,7 @@ fn assemble_ways<'a>(
                 let block = PrimitiveBlock::parse(&data);
                 for primitive in block.primitives() {
                     if let Primitive::Way(way) = primitive {
-                        let feature_id = 10 * way.id + 2;
+                        let feature_id = make_feature_id(RelationMemberType::Way, way.id);
                         let is_interesting = prunings.keep_ways.contains(way.id);
                         let is_relation_member = prunings.relation_members.contains(feature_id);
                         if !is_interesting && !is_relation_member {
@@ -405,7 +406,7 @@ fn assemble_leaf_relations<'a>(
                 let block = PrimitiveBlock::parse(&data);
                 for primitive in block.primitives() {
                     if let Primitive::Relation(relation) = primitive {
-                        let feature_id = 10 * relation.id + 3;
+                        let feature_id = make_feature_id(RelationMemberType::Relation, relation.id);
                         let is_interesting = prunings.keep_relations.contains(relation.id);
                         let is_relation_member = prunings.relation_members.contains(feature_id);
                         if !is_interesting && !is_relation_member {
@@ -781,7 +782,10 @@ fn is_super_relation(rel: &osm_pbf_iter::Relation<'_>) -> bool {
     false
 }
 
-fn member_feature_id(member_type: RelationMemberType, id: u64) -> u64 {
+/// Encodes an OpenStreetMap object's `(member_type, id)` as a `Feature.id`
+/// — `id * 10 + 1` for nodes, `+ 2` for ways, `+ 3` for relations. Inverse
+/// of [`feature_to_osm_id`]. See `Feature.id` in `feature.proto`.
+fn make_feature_id(member_type: RelationMemberType, id: u64) -> u64 {
     match member_type {
         RelationMemberType::Node => id * 10 + 1,
         RelationMemberType::Way => id * 10 + 2,
@@ -818,7 +822,7 @@ fn assemble_relation_members(
         });
         let member = RelationMember {
             role: role_id as u32,
-            id: member_feature_id(member_type, id),
+            id: make_feature_id(member_type, id),
         };
         feature.relation_members.push(member);
     }


### PR DESCRIPTION
`assemble_nodes`, `assemble_ways`, and `assemble_leaf_relations` each computed a `Feature.id` by inlining `10 * id + N` (`N` = 1 for nodes, 2 for ways, 3 for relations), duplicating logic that already existed as `member_feature_id()` — previously only used when encoding relation members. This routes all four call sites through that one function instead, removing the duplicated arithmetic and the risk of a transcription slip (e.g. `+2` instead of `+3`).

Renamed `member_feature_id` to `make_feature_id`, since "member" no longer fits now that it also encodes a way's or relation's own `Feature.id`, not just relation members.

No behavior change — `cargo fmt`, `cargo build`, and the full `cargo test` suite (203 tests incl. the pipeline integration test) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)