### PR TITLE
sbom: use the real registry-qualified image name, not a hardcoded default

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,7 @@ jobs:
           mkdir artifacts
           podman build \
             --build-arg BUILD_TIMESTAMP="${TIMESTAMP}" \
+            --build-arg IMAGE_NAME="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}" \
             --build-arg VCS_REF="${{ github.sha }}" \
             --build-arg VCS_URL="${{ github.server_url }}/${{ github.repository }}" \
             --file ./Containerfile \

--- a/Containerfile
+++ b/Containerfile
@@ -21,6 +21,7 @@
 FROM rust:1.97.1-alpine3.23 AS builder
 
 ARG BUILD_TIMESTAMP
+ARG IMAGE_NAME=alltheplaces/osm-diffs
 ARG TIPPECANOE_VERSION=2.79.0
 
 # TODO: Take cargo-cyclonedx from stable Alpine Linux (not edge)

--- a/scripts/sbom/generate-sbom.sh
+++ b/scripts/sbom/generate-sbom.sh
@@ -38,7 +38,12 @@
 
 set -eu
 
-IMAGE_NAME="alltheplaces/osm-diffs"
+# The registry-qualified image name (e.g. "ghcr.io/alltheplaces/osm-diffs")
+# is known before the build runs, so -- unlike the image digest -- release.yml
+# can just pass it in as a build arg instead of patching it in afterwards.
+# Falls back to a plain default for local development and test-container.yml,
+# neither of which push a real, registry-qualified image.
+IMAGE_NAME="${IMAGE_NAME:-alltheplaces/osm-diffs}"
 
 # ── locate project root and jq scripts ──────────────────────────────────────
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"


### PR DESCRIPTION
Follow-up from #548 (see [this comment](https://github.com/alltheplaces/osm-diffs/issues/540#issuecomment-5220834415) and the discussion afterwards).

`generate-sbom.sh` hardcoded the SBOM's `metadata.component.name`/`bom-ref` as `"alltheplaces/osm-diffs"`. Before #548, `merge_sbom.sh` received the real, registry-qualified image reference (`ghcr.io/alltheplaces/osm-diffs`) from `release.yml`, so the shipped/attested SBOM had it right; my refactor lost that.

Unlike the image digest, the registry-qualified name is known *before* `podman build` runs, so there's no need to patch it in afterwards the way `release.yml` already does for the digest — simplest fix is to pass it in as a build arg, the same way `TIPPECANOE_VERSION` already works.

- `Containerfile`: new `ARG IMAGE_NAME=alltheplaces/osm-diffs` (default used by local dev / `test-container.yml`, neither of which push a real image).
- `release.yml`: passes `--build-arg IMAGE_NAME="${REGISTRY}/${IMAGE_NAME}"` for real release builds.
- `generate-sbom.sh`: reads `IMAGE_NAME` from the environment instead of a hardcoded constant.

Verified locally with `IMAGE_NAME` set: the generated SBOM is self-consistent (dependency-graph refs and `formulation` entries all agree with the new name) and passes `cyclonedx-cli validate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)