### PR TITLE
sbom: fix invalid SPDX license id for sqlite

### DIFF
--- a/scripts/sbom/tippecanoe.jq
+++ b/scripts/sbom/tippecanoe.jq
@@ -96,7 +96,18 @@ def alpine_supplier: {name: "Alpine Linux", url: ["https://alpinelinux.org"]};
       "bom-ref": ("sqlite-" + $SQLITE_VERSION),
       purl: ("pkg:apk/alpine/sqlite@" + $SQLITE_VERSION + "?arch=" + $ARCH),
       supplier: alpine_supplier,
-      licenses: [{license: {id: "blessing"}}],
+      # SQLite isn't SPDX-licensed; upstream dedicates it to the public
+      # domain and informally calls that dedication a "blessing" (see
+      # https://www.sqlite.org/copyright.html). "blessing" itself isn't a
+      # valid SPDX license id, so it doesn't belong in a `license.id`
+      # field. Follow the same pattern used for osm-testdata-grid in
+      # pipeline.jq: a plain, declared "Public Domain" license name.
+      licenses: [{
+        license: {
+          name: "Public Domain",
+          acknowledgement: "declared"
+        }
+      }],
       evidence: {
         identity: [{
           field: "version",


### PR DESCRIPTION
Follow-up from #548.

`tippecanoe.jq` declared sqlite's license as `{license: {id: "blessing"}}`. `"blessing"` isn't a valid SPDX license identifier — it's SQLite's own informal term for its public-domain dedication (see [sqlite.org/copyright.html](https://www.sqlite.org/copyright.html)), not something a `license.id` field should contain. Strict SPDX/CycloneDX consumers may reject or misinterpret it.

Switches to the same `{name: "Public Domain", acknowledgement: "declared"}` pattern already used for `osm-testdata-grid` in `pipeline.jq`.

Verified: `generate-sbom.sh` output still passes `cyclonedx-cli validate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)