### PR TITLE
sbom: locate root dependency entry by ref, not array position

### DIFF
--- a/scripts/sbom/pipeline.jq
+++ b/scripts/sbom/pipeline.jq
@@ -37,16 +37,31 @@ def add_supplier:
 
 # Patch bom-ref of main application to read "osm-diffs-1.2.3"
 # instead of "path+file:///Users/sascha/src/osm-diffs#osm-diffs".
+.metadata.component."bom-ref" as $orig_root_ref |
 ( .metadata.component.name + "-" + .metadata.component.version ) as $root_ref |
 .metadata.component."bom-ref" = $root_ref |
-.dependencies[0].ref = $root_ref |
+
+# Locate the root component's entry in the dependency graph by its
+# original bom-ref, not by assuming it's .dependencies[0] -- cargo-cyclonedx
+# doesn't document any ordering guarantee for `.dependencies`.
+(
+  [.dependencies[] | select(.ref == $orig_root_ref)] | length
+) as $root_matches |
+if $root_matches != 1 then
+  error("pipeline.jq: expected exactly one dependency entry with ref "
+        + $orig_root_ref + ", found " + ($root_matches | tostring))
+else . end |
+(
+  .dependencies | map(.ref == $orig_root_ref) | index(true)
+) as $root_idx |
+.dependencies[$root_idx].ref = $root_ref |
 
 # Declare the root component's dependency on our two vendored, non-crate
 # "data" components, so the dependency graph has a single root instead of
 # three (the FOSSA NTIA validator flags orphaned components -- ones no
 # other component depends on -- as extra roots).
-.dependencies[0].dependsOn =
-  ((.dependencies[0].dependsOn // []) + ["id-tagging-schema", "osm-testdata-grid"]) |
+.dependencies[$root_idx].dependsOn =
+  ((.dependencies[$root_idx].dependsOn // []) + ["id-tagging-schema", "osm-testdata-grid"]) |
 
 .bomFormat = "CycloneDX" |
 .specVersion = "1.7" |


### PR DESCRIPTION
Follow-up from #548.

`pipeline.jq` assumed cargo-cyclonedx's root component always lands at `.dependencies[0]`. That's an observation of today's output, not a documented guarantee — a future `cargo-cyclonedx` release reordering its output would make this silently patch the wrong entry's `ref`/`dependsOn`, corrupting the dependency graph with no error.

This locates the entry by matching its original `ref` against the component's original `bom-ref` instead, and fails loudly via jq's `error()` if that doesn't resolve to exactly one match (rather than failing silently or crashing with a cryptic `null` index error).

Verified:
- `generate-sbom.sh` output is unchanged (same root ref, same `dependsOn` additions) and still passes `cyclonedx-cli validate`.
- Manually fed the new guard a synthetic input where the ref doesn't match — confirmed it fails with a clear error message and non-zero exit instead of continuing silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)