### PR TITLE
Containerfile: pin tippecanoe to a commit SHA instead of a mutable tag

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -22,6 +22,12 @@ FROM rust:1.97.1-alpine3.23 AS builder
 
 ARG BUILD_TIMESTAMP
 ARG TIPPECANOE_VERSION=2.79.0
+# Commit that the "2.79.0" tag pointed to as of 2026-08-08. Pinned by
+# commit, not by tag/branch name: git tags are mutable references that
+# can be force-moved (accidentally or maliciously) after the fact, while
+# fetching by commit SHA is content-addressed and can't silently drift.
+# Update alongside TIPPECANOE_VERSION when bumping to a newer release.
+ARG TIPPECANOE_COMMIT=68ab8dcc229f95b8b25877697d5e8d66783af503
 
 # TODO: Take cargo-cyclonedx from stable Alpine Linux (not edge)
 # once Alpine 3.24 has been released.
@@ -47,8 +53,10 @@ RUN echo "@edge https://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/ap
 
 WORKDIR /build/tippecanoe
 
-RUN git clone --depth 1 --branch ${TIPPECANOE_VERSION} \
-    https://github.com/felt/tippecanoe.git /build/tippecanoe
+RUN git init -q . && \
+    git remote add origin https://github.com/felt/tippecanoe.git && \
+    git fetch --depth 1 origin "${TIPPECANOE_COMMIT}" && \
+    git checkout -q FETCH_HEAD
 
 RUN make -j"$(nproc)" \
         PREFIX=/usr/local \


### PR DESCRIPTION
Follow-up from #548 (see [this discussion](https://github.com/alltheplaces/osm-diffs/issues/540#issuecomment-5220834415)).

`git clone --branch ${TIPPECANOE_VERSION}` fetches tippecanoe by tag name. Git tags are mutable references — they can be force-moved, accidentally or maliciously, after the fact — so a release build could silently end up compiling different code than what was reviewed when `TIPPECANOE_VERSION` was last bumped.

This pins to the exact commit SHA the `2.79.0` tag currently points to, fetched via `git fetch --depth 1 origin <sha>` + `git checkout FETCH_HEAD`. Verified this works against GitHub for a public repo, shallow fetch included. Fetching by SHA is content-addressed and can't drift — it either gets exactly that commit or fails outright, never silently substitutes something else.

`TIPPECANOE_VERSION` is unchanged (still drives the SBOM's version/purl and the human-readable label); `TIPPECANOE_COMMIT` is the new pin. Both need updating together when bumping to a newer tippecanoe release — noted in a comment at the ARG.

(Discussed with @brawer whether to also wire up Dependabot/an automated release-tracking workflow for this pin — decided to keep this PR to just the pin itself and revisit tracking separately.)

## Testing
Full `podman build` against the real Alpine builder: the pinned commit fetches correctly, tippecanoe builds and still statically links (`readelf` check passes), and the resulting container and SBOM (tippecanoe version/purl unchanged) both check out — `cyclonedx-cli validate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)