### PR TITLE
Add timeout-minutes to release and container-test workflow jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,10 @@ jobs:
   build:
     name: Build architecture-specific images
     runs-on: ${{ matrix.runner }}
+    # Observed ~11-16 min per arch as of 2026-08; generous headroom over that,
+    # well short of the 360 min default, so a hang fails fast instead of
+    # burning runner-minutes for hours.
+    timeout-minutes: 30
 
     strategy:
       matrix:
@@ -102,6 +106,7 @@ jobs:
     name: Build multi-architecture manifest
     runs-on: ubuntu-24.04
     needs: [build]
+    timeout-minutes: 10
     permissions:
       id-token: write
       packages: write
@@ -160,6 +165,7 @@ jobs:
     name: Attest build provenance
     runs-on: ubuntu-24.04
     needs: [manifest]
+    timeout-minutes: 10
 
     permissions:
       artifact-metadata: write

--- a/.github/workflows/test-container.yml
+++ b/.github/workflows/test-container.yml
@@ -21,6 +21,9 @@ jobs:
   build:
     name: Build (container)
     runs-on: ubuntu-latest
+    # Same build as release.yml's build job, which observed ~11-16 min per
+    # arch as of 2026-08; generous headroom over that.
+    timeout-minutes: 30
     permissions: {}
 
     steps:


### PR DESCRIPTION
Follow-up from the release-process review.

None of the release/container-test jobs had an explicit `timeout-minutes`, so a hang would run up to GitHub's 360-minute default before being killed.

Values picked from actual observed job durations (via \`gh run list\`/\`gh run view\` on the most recent successful runs, as of 2026-08):

| job | observed | timeout |
|---|---|---|
| release.yml `build` (per arch) | ~11-16 min | 30 min |
| release.yml `manifest` | ~27 sec | 10 min |
| release.yml `attest` | ~18 sec | 10 min |
| test-container.yml `build` | same build as above | 30 min |

All comfortably generous over observed times, but still well short of the 360-minute default if something actually hangs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)