### PR TITLE
Serialize release.yml runs with a concurrency group

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,17 @@ on:
   push:
     tags: ['v*']  # triggered by pushing a tag such as 'v0.1.2'
 
+# Serialize releases: the manifest job below overwrites the shared, mutable
+# ":latest" tag, so two tags pushed close together must not build
+# concurrently -- whichever run's manifest push happened to land last would
+# silently "win" :latest, regardless of which tag is actually newer.
+# cancel-in-progress stays false (the default) on purpose: an in-progress
+# release may be mid-push or mid-attestation, and queuing a second run is
+# safe where killing the first one mid-flight would not be.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}


### PR DESCRIPTION
Follow-up from the release-process review.

Two tags pushed close together would build fully in parallel today. The \`manifest\` job overwrites the shared, mutable \`:latest\` tag, so whichever run's manifest push happens to land last silently "wins" \`:latest\` -- a race, not a version comparison. If the older tag's build happens to take longer (runner variance, network slowness), \`:latest\` could end up pointing at the *older* release even though a newer tag was pushed afterward.

Adds a workflow-level \`concurrency\` group with a single **fixed** key (not per-tag -- \`:latest\` is shared across all releases, so the lock needs to be too). \`cancel-in-progress: false\` is the default but made explicit here on purpose: an in-progress release may be mid-push or mid-attestation, and queuing a second run is safe where killing the first one mid-flight would not be.

One thing worth knowing about the resulting behavior (not a downside of this PR, just how GitHub's queuing works): a concurrency group only keeps one pending run queued at a time -- if three tags land while a release is running, only the last of the three queued ones actually runs next; the earlier two are dropped from the queue (never cancelled if already running, just never started). Fine for a project that cuts releases rarely and manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)