### PR TITLE
Add scripts/cut-release.sh to automate cutting a release

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -5,3 +5,7 @@ release-engineering scripts that aren't part of the Rust build itself.
 
 - [`sbom/`](sbom/README.md): generates the Software Bill of Materials
   (SBOM) for the release container image.
+- [`cut-release.sh`](cut-release.sh): cuts a new release (bumps
+  `Cargo.toml`'s version via a PR, then creates the tagged GitHub Release
+  that triggers `.github/workflows/release.yml`). Run
+  `./scripts/cut-release.sh vX.Y.Z` from an up-to-date `main`.

--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env sh
+#
+# SPDX-FileCopyrightText: 2026 Sascha Brawer <sascha@brawer.ch>
+# SPDX-License-Identifier: MIT
+#
+# Cut a new release, end to end:
+#   1. Bump Cargo.toml's version (and Cargo.lock's self-entry) on a new
+#      branch, open a PR, enable auto-merge, and wait for it to clear
+#      required checks and the merge queue.
+#   2. Once that's landed on main, create the GitHub Release there (tag +
+#      auto-generated notes, from the categories configured in
+#      .github/release.yml).
+#
+# That release tag is what triggers .github/workflows/release.yml, which
+# builds, SBOMs, and attests the container -- this script doesn't touch
+# that part at all, it only automates getting a correctly tagged, correctly
+# versioned commit onto main in the first place.
+#
+# Usage:
+#   ./scripts/cut-release.sh vX.Y.Z
+#
+# Version bump rules (SemVer, driven by the pipeline's OUTPUT SCHEMA, not
+# just code changes):
+#   major - output schema changed in a client-breaking way
+#   minor - output schema evolved in a backward-compatible way
+#   patch - bugfixes only, no schema changes
+#
+# Requirements: git, cargo, gh (authenticated -- run `gh auth login` first)
+
+set -eu
+
+REQUIRED_CHECK="Execute unit and integration tests"
+MERGE_WAIT_TIMEOUT=1500  # 25 min: ~5 min test run + merge-queue wait + slack
+MERGE_POLL_INTERVAL=15
+
+# ── argument handling ────────────────────────────────────────────────────────
+TAG="${1:?usage: cut-release.sh vX.Y.Z}"
+case "$TAG" in
+  v*.*.*) VERSION="${TAG#v}" ;;
+  *) echo "ERROR: tag must look like vX.Y.Z (got: $TAG)" >&2; exit 1 ;;
+esac
+case "$VERSION" in
+  [0-9]*.[0-9]*.[0-9]*) ;;
+  *) echo "ERROR: '$VERSION' doesn't look like X.Y.Z" >&2; exit 1 ;;
+esac
+
+# ── pre-flight checks ────────────────────────────────────────────────────────
+for cmd in git cargo gh; do
+  command -v "$cmd" >/dev/null 2>&1 || { echo "ERROR: $cmd is not installed" >&2; exit 1; }
+done
+gh auth status >/dev/null 2>&1 || { echo "ERROR: gh is not authenticated -- run 'gh auth login'" >&2; exit 1; }
+
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+if [ "$BRANCH" != "main" ]; then
+  echo "ERROR: must be run from main (currently on '$BRANCH')" >&2
+  exit 1
+fi
+if [ -n "$(git status --porcelain)" ]; then
+  echo "ERROR: working tree is not clean" >&2
+  exit 1
+fi
+
+echo "Fetching origin..."
+git fetch origin main --tags -q
+if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]; then
+  echo "ERROR: local main is not up to date with origin/main (run 'git pull')" >&2
+  exit 1
+fi
+
+if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+  echo "ERROR: tag '${TAG}' already exists" >&2
+  exit 1
+fi
+
+CURRENT_VERSION="$(awk '
+  /^\[package\]/ { in_package=1; next }
+  /^\[/           { in_package=0 }
+  in_package && /^version[[:space:]]*=/ {
+    match($0, /"[^"]*"/)
+    print substr($0, RSTART+1, RLENGTH-2)
+    exit
+  }
+' Cargo.toml)"
+HIGHEST="$(printf '%s\n%s\n' "$CURRENT_VERSION" "$VERSION" | sort -t. -k1,1n -k2,2n -k3,3n | tail -1)"
+if [ "$HIGHEST" != "$VERSION" ] || [ "$VERSION" = "$CURRENT_VERSION" ]; then
+  echo "ERROR: ${VERSION} is not newer than Cargo.toml's current version (${CURRENT_VERSION})" >&2
+  exit 1
+fi
+
+echo "Checking latest CI status on main..."
+LATEST_RUN="$(gh run list --branch main --workflow test.yml --limit 1 \
+  --json headSha,status,conclusion -q '.[0]')"
+RUN_SHA="$(echo "$LATEST_RUN" | jq -r .headSha)"
+RUN_STATUS="$(echo "$LATEST_RUN" | jq -r .status)"
+RUN_CONCLUSION="$(echo "$LATEST_RUN" | jq -r .conclusion)"
+if [ "$RUN_SHA" != "$(git rev-parse HEAD)" ] || [ "$RUN_STATUS" != "completed" ] || [ "$RUN_CONCLUSION" != "success" ]; then
+  echo "ERROR: latest '${REQUIRED_CHECK}' run on main is not a successful," >&2
+  echo "  completed run for the current main HEAD (sha=${RUN_SHA}" >&2
+  echo "  status=${RUN_STATUS} conclusion=${RUN_CONCLUSION}). Wait for CI" >&2
+  echo "  to finish, or fix main, before cutting a release." >&2
+  exit 1
+fi
+
+# ── bump the version via a PR (main is protected: no direct pushes) ─────────
+BUMP_BRANCH="release/${TAG}"
+echo "Creating branch ${BUMP_BRANCH}..."
+git checkout -b "$BUMP_BRANCH" -q
+
+awk -v new_version="$VERSION" '
+  /^\[package\]/ { print; in_package=1; next }
+  /^\[/           { in_package=0 }
+  in_package && /^version[[:space:]]*=/ {
+    print "version = \"" new_version "\""
+    next
+  }
+  { print }
+' Cargo.toml > Cargo.toml.new
+mv Cargo.toml.new Cargo.toml
+cargo check --quiet
+
+git add Cargo.toml Cargo.lock
+git commit -q -m "Bump version to ${VERSION}"
+git push -q -u origin "$BUMP_BRANCH"
+
+PR_URL="$(gh pr create \
+  --title "Bump version to ${VERSION}" \
+  --body "Version bump ahead of releasing ${TAG}. Opened by scripts/cut-release.sh." \
+  --base main)"
+echo "Opened ${PR_URL}"
+
+gh pr merge "$PR_URL" --auto --squash
+echo "Auto-merge enabled; waiting for '${REQUIRED_CHECK}' and the merge queue..."
+
+ELAPSED=0
+while :; do
+  STATE="$(gh pr view "$PR_URL" --json state -q .state)"
+  case "$STATE" in
+    MERGED)
+      echo "Merged."
+      break
+      ;;
+    CLOSED)
+      echo "ERROR: PR was closed without merging: ${PR_URL}" >&2
+      exit 1
+      ;;
+  esac
+  if [ "$ELAPSED" -ge "$MERGE_WAIT_TIMEOUT" ]; then
+    echo "ERROR: timed out after ${MERGE_WAIT_TIMEOUT}s waiting for ${PR_URL} to merge." >&2
+    echo "  Check its status manually; it may still merge on its own." >&2
+    exit 1
+  fi
+  sleep "$MERGE_POLL_INTERVAL"
+  ELAPSED=$((ELAPSED + MERGE_POLL_INTERVAL))
+done
+
+git checkout main -q
+git branch -D "$BUMP_BRANCH" -q
+
+# ── create the release (tag + auto-generated notes) at the new main HEAD ────
+echo "Creating release ${TAG}..."
+gh release create "$TAG" --target main --generate-notes
+
+echo "Done. ${TAG} is tagged and released; .github/workflows/release.yml" \
+     "is now building, SBOM-ing, and attesting the container."


### PR DESCRIPTION
Follow-up from the release-process review/discussion (see #561 and the discussion around it).

Until now, cutting a release meant manually bumping `Cargo.toml` (in practice this got skipped for the last 8 releases -- `v0.6.1` through `v0.6.8` were all cut with `Cargo.toml` still saying `0.6.0`, which is also why the SBOM's own recorded `osm-diffs` version has been stale this whole time), then going to the GitHub web UI to pick a tag, generate notes, and publish.

`cut-release.sh` automates the mechanical parts end to end:

1. Validates preconditions: on a clean, up-to-date `main`; the chosen tag doesn't already exist; the version is actually newer than `Cargo.toml`'s current one; the latest CI run on `main`'s current HEAD is a successful "Execute unit and integration tests" run.
2. Bumps `Cargo.toml`'s version (scoped to `[package]` only -- doesn't touch dependency `version = ` fields) and syncs `Cargo.lock`'s self-entry via `cargo check`.
3. Opens a PR for that bump, enables auto-merge, and **waits** for it to clear required checks and the merge queue -- `main` is protected via a ruleset (`pull_request` + `required_status_checks` + `merge_queue`), so it can't just push directly; confirmed this via `gh api repos/.../rules/branches/main`.
4. Once merged, creates the GitHub Release (tag + `--generate-notes`, using the existing `.github/release.yml` categories) at the new `main` HEAD.

That release tag is what triggers `.github/workflows/release.yml` (build, SBOM, attest) -- completely unchanged by this script.

The only manual step left is deciding the version number itself (major/minor/patch, based on whether the pipeline's output schema changed) and running the script. Everything mechanical -- the `Cargo.toml`/tag/notes consistency that kept drifting -- is now enforced by construction instead of relied on from memory. This also sets up baking the real release version into the binary later (`Cargo.toml`'s version already becomes `CARGO_PKG_VERSION` at compile time, so once that's wired into the CLI/output, it'll reflect the true release version for free).

## Testing
Verified each risky piece of logic in isolation, not the full live flow (which would create real PRs/tags/releases):
- tag-format validation against valid/invalid inputs
- the "is this version actually newer" guard, including the classic 9-vs-10 string-sort trap (`0.9.0` -> `0.10.0`)
- the `Cargo.toml` rewrite, scoped correctly to `[package]` only, on a scratch copy of the real file (dependency `version = ` fields untouched)
- `gh run list`'s JSON field names against the real repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)