### PR TITLE
Support --version / -V on the command-line tool

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use rustls::{ClientConfig, RootCertStore};
 use webpki_roots::TLS_SERVER_ROOTS;
 
 #[derive(Parser)]
-#[command(name = "diffed-places-pipeline")]
+#[command(name = "diffed-places-pipeline", version)]
 struct Cli {
     #[command(subcommand)]
     command: Option<Commands>,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -35,3 +35,14 @@ fn test_no_subcommand() {
         .failure()
         .stderr(predicates::str::contains("no subcommand given"));
 }
+
+#[test]
+fn test_version_flag() {
+    // Asserts against CARGO_PKG_VERSION (rather than a hardcoded string) so
+    // this doesn't need updating every time cut-release.sh bumps the version.
+    Command::new(cargo_bin!("osm-diffs"))
+        .arg("--version")
+        .assert()
+        .success()
+        .stdout(predicates::str::contains(env!("CARGO_PKG_VERSION")));
+}


### PR DESCRIPTION
Follow-up from the release-process work (#562 and the discussion before it).

Adds \`version\` to the \`Cli\` struct's \`#[command(...)]\` attribute, so clap derives a \`--version\`/\`-V\` flag from \`Cargo.toml\`'s package version at compile time (\`CARGO_PKG_VERSION\`). Only needs clap's \`derive\` + \`std\` features, already enabled -- no new dependency features.

Confirmed the baseline first: both \`--help\` and \`--version\` currently fail identically with \`error: unexpected argument found\`, since this project deliberately runs with a minimal clap feature set (\`default-features = false, features = ["derive", "std"]\`). \`--help\` needs clap's separate \`help\`/\`usage\` features and stays unsupported here -- out of scope, only \`--version\` was asked for.

This becomes more useful once \`Cargo.toml\`'s version is kept authoritative by \`scripts/cut-release.sh\` (#562) -- \`--version\` will then reflect the real release version -- and sets up embedding that version into the pipeline's output data later.

Adds an integration test asserting \`--version\` succeeds and its output contains \`CARGO_PKG_VERSION\` (not a hardcoded string, so it won't need updating on every release).

## Testing
Full \`cargo test\`, \`cargo fmt --check\`, and \`cargo clippy --locked\` all clean. Manually ran the built binary with \`--version\` and \`-V\` to confirm actual output (\`diffed-places-pipeline 0.6.0\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)