### PR TITLE
Support --help / -h on the command-line tool

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ arrow = { version = "59.0.0", default-features = false }
 arrow-buffer = { version = "59.1.0", default-features = false }
 arrow-schema = { version = "59.1.0", default-features = false }
 aws-lc-rs = { version = "1.17.0", default-features = false }
-clap = { version = "4.6.1", default-features = false, features = ["derive", "std"] }
+clap = { version = "4.6.1", default-features = false, features = ["derive", "help", "std", "usage"] }
 deepsize = "0.2.0"
 deepsize_derive = "0.1.2"
 env_logger = { version = "0.11.10", default-features = false }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,8 @@ use rustls::version::TLS13;
 use rustls::{ClientConfig, RootCertStore};
 use webpki_roots::TLS_SERVER_ROOTS;
 
+/// Computes diffs between AllThePlaces and OpenStreetMap data, producing
+/// edit suggestions to help keep OpenStreetMap complete and up to date.
 #[derive(Parser)]
 #[command(name = "diffed-places-pipeline", version)]
 struct Cli {
@@ -16,7 +18,9 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
+    /// Run the full pipeline: fetch inputs, compute diffs, write output.
     Run {
+        /// Directory for input, intermediate, and output files.
         #[arg(short, long, value_name = "workdir")]
         workdir: PathBuf,
     },

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -46,3 +46,13 @@ fn test_version_flag() {
         .success()
         .stdout(predicates::str::contains(env!("CARGO_PKG_VERSION")));
 }
+
+#[test]
+fn test_help_flag() {
+    Command::new(cargo_bin!("osm-diffs"))
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("run"))
+        .stdout(predicates::str::contains("--version"));
+}


### PR DESCRIPTION
Follow-up from #563.

Same story as \`--version\`: \`--help\` previously failed with \`error: unexpected argument found\`, since clap runs with a minimal feature set here (\`default-features = false\`, only \`derive\` + \`std\`). Unlike \`--version\`, though, \`--help\` genuinely needs more -- confirmed by testing incrementally:
- clap's \`help\` feature is what makes \`-h\`/\`--help\` exist at all
- \`usage\` is separately needed to fill in the actual \`Usage: ...\` line (with only \`help\` added, \`--help\` worked but printed a blank \`Usage:\` with nothing after it)

Neither feature pulls in any new dependency -- \`Cargo.lock\` is unchanged.

Also added doc comments on \`Cli\`, the \`Run\` variant, and its \`workdir\` field, since clap derives their \`--help\` descriptions from those -- without them, every entry in the Commands/Options list was blank. Now \`--help\` actually explains what the tool and its subcommand do.

One behavior worth knowing about, not a bug (confirmed by testing, not assumed): the \`Usage:\` line's program name (\`osm-diffs\`) differs from what \`--version\` reports (\`diffed-places-pipeline 0.6.0\`). That's intentional clap behavior -- the usage line reflects how the binary was actually invoked at runtime (\`argv[0]\`), while \`--version\` uses the compile-time \`name\` override.

## Testing
Full \`cargo test\` (added \`test_help_flag\` alongside the existing \`test_version_flag\`, asserting on stable substrings rather than exact output), \`cargo fmt --check\`, and \`cargo clippy --locked\` all clean. Manually ran \`--help\`, \`-h\`, and \`run --help\` to confirm actual output content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)