### PR TITLE
Group Arrow and Parquet crate updates in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,13 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      arrow:
+        patterns:
+          - "arrow*"
+      parquet:
+        patterns:
+          - "parquet*"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:


### PR DESCRIPTION
Groups the Apache Arrow crates (`arrow`, `arrow-buffer`, `arrow-schema`) and Parquet crates (`parquet`, `parquet-geospatial`) so Dependabot opens a single PR per group instead of one per crate, mirroring the existing `codeql` group for `github-actions`.

Once merged, Dependabot should close the current per-crate PRs (#565, #566, #567) and going forward send one combined PR for Arrow bumps and one for Parquet bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)