### PR TITLE
Group all cargo dependency updates into a single monthly PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,14 +3,13 @@ updates:
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
+    allow:
+      - dependency-type: "all"
     groups:
-      arrow:
+      cargo:
         patterns:
-          - "arrow*"
-      parquet:
-        patterns:
-          - "parquet*"
+          - "*"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:


### PR DESCRIPTION
Supersedes the per-crate `arrow`/`parquet` groups from #570 with a single catch-all cargo group, and switches from daily to monthly. Also opts in to indirect (transitive) dependency updates via `allow: dependency-type: all` — Dependabot only updates direct `Cargo.toml` dependencies by default.

Rationale: our test suite catches regressions from dependency bumps, so there's little value in reviewing each individual update's changelog. Consolidating into one monthly cargo PR (instead of one per crate/group) cuts down on review noise significantly, while indirect updates make sure transitive dependencies with security fixes etc. aren't missed.

Once merged, Dependabot should close the currently open cargo PR (#571) and going forward send one combined cargo PR per month, covering direct and indirect dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)