### PR TITLE
Fix clippy warnings in generated id_tagging_schema.rs

### DIFF
--- a/scripts/generate_id_tagging_schema.py
+++ b/scripts/generate_id_tagging_schema.py
@@ -255,26 +255,26 @@ def generate_rust(
             #[test]
             fn test_is_area() {
                 // If a way is not closed, it is never an area, no matter how it is tagged.
-                assert_eq!(is_area(false, [("area", "yes")].into_iter()), false);
-                assert_eq!(is_area(true, [("area", "yes")].into_iter()), true);
-                assert_eq!(is_area(true, [("area", "no")].into_iter()), false);
+                assert!(!is_area(false, [("area", "yes")].into_iter()));
+                assert!(is_area(true, [("area", "yes")].into_iter()));
+                assert!(!is_area(true, [("area", "no")].into_iter()));
 
                 // By default, a closed way is not an area, unless the tags say otherwise.
-                assert_eq!(is_area(true, [].into_iter()), false);
-                assert_eq!(is_area(true, [("foo", "bar")].into_iter()), false);
+                assert!(!is_area(true, [].into_iter()));
+                assert!(!is_area(true, [("foo", "bar")].into_iter()));
 
                 // Should handle allowlists and denylists.
-                assert_eq!(is_area(true, [("aerialway", "pylon")].into_iter()), true);
-                assert_eq!(is_area(true, [("aerialway", "pylon"), ("area", "no")].into_iter()), false);
-                assert_eq!(is_area(true, [("aerialway", "pylon"), ("area", "yes")].into_iter()), true);
-                assert_eq!(is_area(true, [("aerialway", "goods")].into_iter()), false);
-                assert_eq!(is_area(true, [("aerialway", "goods"), ("area", "no")].into_iter()), false);
-                assert_eq!(is_area(true, [("aerialway", "goods"), ("area", "yes")].into_iter()), true);
+                assert!(is_area(true, [("aerialway", "pylon")].into_iter()));
+                assert!(!is_area(true, [("aerialway", "pylon"), ("area", "no")].into_iter()));
+                assert!(is_area(true, [("aerialway", "pylon"), ("area", "yes")].into_iter()));
+                assert!(!is_area(true, [("aerialway", "goods")].into_iter()));
+                assert!(!is_area(true, [("aerialway", "goods"), ("area", "no")].into_iter()));
+                assert!(is_area(true, [("aerialway", "goods"), ("area", "yes")].into_iter()));
 
                 // Should recognize lifecycle prefixes, similar to how iD does it in its codebase.
-                assert_eq!(is_area(true, [("planned:aerialway", "pylon")].into_iter()), true);
-                assert_eq!(is_area(true, [("planned:aerialway", "goods")].into_iter()), false);
-                assert_eq!(is_area(true, [("razed:building", "yes")].into_iter()), true);
+                assert!(is_area(true, [("planned:aerialway", "pylon")].into_iter()));
+                assert!(!is_area(true, [("planned:aerialway", "goods")].into_iter()));
+                assert!(is_area(true, [("razed:building", "yes")].into_iter()));
             }
 
             #[test]

--- a/src/pipeline/osm/id_tagging_schema.rs
+++ b/src/pipeline/osm/id_tagging_schema.rs
@@ -279,44 +279,38 @@ mod tests {
     #[test]
     fn test_is_area() {
         // If a way is not closed, it is never an area, no matter how it is tagged.
-        assert_eq!(is_area(false, [("area", "yes")].into_iter()), false);
-        assert_eq!(is_area(true, [("area", "yes")].into_iter()), true);
-        assert_eq!(is_area(true, [("area", "no")].into_iter()), false);
+        assert!(!is_area(false, [("area", "yes")].into_iter()));
+        assert!(is_area(true, [("area", "yes")].into_iter()));
+        assert!(!is_area(true, [("area", "no")].into_iter()));
 
         // By default, a closed way is not an area, unless the tags say otherwise.
-        assert_eq!(is_area(true, [].into_iter()), false);
-        assert_eq!(is_area(true, [("foo", "bar")].into_iter()), false);
+        assert!(!is_area(true, [].into_iter()));
+        assert!(!is_area(true, [("foo", "bar")].into_iter()));
 
         // Should handle allowlists and denylists.
-        assert_eq!(is_area(true, [("aerialway", "pylon")].into_iter()), true);
-        assert_eq!(
-            is_area(true, [("aerialway", "pylon"), ("area", "no")].into_iter()),
-            false
-        );
-        assert_eq!(
-            is_area(true, [("aerialway", "pylon"), ("area", "yes")].into_iter()),
-            true
-        );
-        assert_eq!(is_area(true, [("aerialway", "goods")].into_iter()), false);
-        assert_eq!(
-            is_area(true, [("aerialway", "goods"), ("area", "no")].into_iter()),
-            false
-        );
-        assert_eq!(
-            is_area(true, [("aerialway", "goods"), ("area", "yes")].into_iter()),
-            true
-        );
+        assert!(is_area(true, [("aerialway", "pylon")].into_iter()));
+        assert!(!is_area(
+            true,
+            [("aerialway", "pylon"), ("area", "no")].into_iter()
+        ));
+        assert!(is_area(
+            true,
+            [("aerialway", "pylon"), ("area", "yes")].into_iter()
+        ));
+        assert!(!is_area(true, [("aerialway", "goods")].into_iter()));
+        assert!(!is_area(
+            true,
+            [("aerialway", "goods"), ("area", "no")].into_iter()
+        ));
+        assert!(is_area(
+            true,
+            [("aerialway", "goods"), ("area", "yes")].into_iter()
+        ));
 
         // Should recognize lifecycle prefixes, similar to how iD does it in its codebase.
-        assert_eq!(
-            is_area(true, [("planned:aerialway", "pylon")].into_iter()),
-            true
-        );
-        assert_eq!(
-            is_area(true, [("planned:aerialway", "goods")].into_iter()),
-            false
-        );
-        assert_eq!(is_area(true, [("razed:building", "yes")].into_iter()), true);
+        assert!(is_area(true, [("planned:aerialway", "pylon")].into_iter()));
+        assert!(!is_area(true, [("planned:aerialway", "goods")].into_iter()));
+        assert!(is_area(true, [("razed:building", "yes")].into_iter()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Follow-up to #578, which excluded `src/pipeline/osm/id_tagging_schema.rs` because it's generated by `scripts/generate_id_tagging_schema.py` — hand-editing it would just get overwritten on the next regeneration.

This fixes the generator's Rust template so the generated `test_is_area` uses `assert!(x)` / `assert!(!x)` instead of `assert_eq!(x, true/false)`, eliminating the `clippy::bool_assert_comparison` warnings.

## Changes
- `scripts/generate_id_tagging_schema.py`: updated the embedded Rust template for `test_is_area`
- `src/pipeline/osm/id_tagging_schema.rs`: regenerated by running `uv run scripts/generate_id_tagging_schema.py`

Note: running the generator also picks up whatever `id-tagging-schema` release is currently latest upstream (it bumped from v7.0.1 to v7.1.0 with no data differences). I kept the version comment pinned at v7.0.1 here to keep this PR scoped to the clippy fix; a schema version bump is a separate, unrelated concern.

## Testing
- `cargo clippy --locked --all-targets -- -D warnings` → clean (no exclusions needed anymore)
- `cargo test --locked` → 200 lib tests + 4 integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)