### PR TITLE
ci: make clippy step gate on warnings and lint tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
       run: |
         cargo llvm-cov test --cobertura --locked --verbose --output-path cobertura.xml
     - name: Look for common mistakes
-      run: cargo clippy --locked
+      run: cargo clippy --locked --all-targets -- -D warnings
     - name: Upload test coverage to Coveralls
       with:
         fail-on-error: false  # not critical when coveralls.io is down


### PR DESCRIPTION
'cargo clippy --locked' exits 0 even when clippy reports warnings — only
compiler errors fail the step — so this step has effectively been
advisory-only. Without `--all-targets` it also never lints code under
`tests/`.

Verified locally that `cargo clippy --locked --all-targets -- -D warnings`
currently passes clean on this codebase.

Part of #576.