### PR TITLE
ci: cap test job at 20 minutes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ jobs:
   build:
     name: Execute unit and integration tests
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions: {}
 
     env:


### PR DESCRIPTION
Without `timeout-minutes`, a hang defaults to GitHub's 6-hour cap instead
of failing fast. `test-container.yml` already sets a timeout; `test.yml`
was missing one. 20 minutes is a generous baseline given current build
times; can be tightened later if we get a better sense of typical
duration.

Part of #576.