### PR TITLE
ci: remove redundant llvm-tools-preview install step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,8 +35,6 @@ jobs:
       run: |
         sudo apt-get install -y tippecanoe
         tippecanoe --version
-    - name: Install Rust LLVM tools preview
-      run: rustup component add llvm-tools-preview
     - name: Install Rust coverage tool
       uses: taiki-e/install-action@6c6fd71fe4fb72c3697d269963d0e15df8adedad # v2.85.10
       with:


### PR DESCRIPTION
`rust-toolchain.toml` already lists `llvm-tools` in its `components`, so
rustup provisions it automatically the first time cargo/rustc runs in
this checkout (the checkout step already runs before this one). The
explicit `rustup component add llvm-tools-preview` step was a no-op.

This PR's CI run itself is the verification: if `cargo-llvm-cov` can
still generate coverage without the explicit step, the toolchain-file
provisioning is doing its job.

Part of #576.