### PR TITLE
ci: cache the Cargo registry to speed up dependency fetches

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,14 @@ jobs:
       uses: taiki-e/install-action@6c6fd71fe4fb72c3697d269963d0e15df8adedad # v2.85.10
       with:
         tool: cargo-llvm-cov
+    - name: Cache Cargo registry
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+        key: cargo-registry-${{ hashFiles('Cargo.lock') }}
+        restore-keys: cargo-registry-
     - name: Fetch Rust dependencies
       run: cargo fetch --locked
     - name: Check formatting


### PR DESCRIPTION
sccache caches compilation artifacts but not downloaded crate sources,
so `cargo fetch` re-downloads the full dependency graph (arrow, parquet,
tokio, aws-lc-rs, etc.) on every run. Cache `~/.cargo/registry` and
`~/.cargo/git`, keyed on `Cargo.lock`, to avoid that.

Part of #576.