### PR TITLE
Add structured JSON logging to a file in the working directory

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 mod atp;
 mod coverage;
 mod geometry;
+mod logging;
 mod matchers;
 mod pipeline;
 mod places;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,100 @@
+//! Structured logging to a file in the working directory.
+//!
+//! [`init`] wires up the `log` crate's global logger (the same facade
+//! already used via `log::info!` etc. elsewhere in this crate) so that
+//! every log record is appended as one JSON object per line to
+//! `<workdir>/pipeline.log`, rather than printed as free-form text. That
+//! makes the log machine-readable: a record's `target` says which module
+//! logged it, and its `message` can be grepped for or parsed without
+//! worrying about how a human-oriented formatter might wrap or color it.
+//!
+//! This is a first skeleton. It doesn't yet thread per-call structured
+//! fields (e.g. a relation id) through the `log` crate's key-value API --
+//! for now, such details go into the message text (see
+//! `pipeline::osm::assemble`, which logs failures as e.g.
+//! "relation/12345"). RUST_LOG still controls the level as usual, default
+//! `info`.
+
+use anyhow::{Context, Result};
+use std::{fs::OpenOptions, io::Write, path::Path};
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+const LOG_FILE_NAME: &str = "pipeline.log";
+
+/// Initializes the process-wide logger to append structured (JSON-lines)
+/// records to `<workdir>/pipeline.log`. Must be called once, as early as
+/// possible during pipeline startup, before any `log::*!` call.
+pub fn init(workdir: &Path) -> Result<()> {
+    let log_path = workdir.join(LOG_FILE_NAME);
+    let file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+        .with_context(|| format!("failed to open log file {}", log_path.display()))?;
+
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
+        .format(format_json)
+        .target(env_logger::Target::Pipe(Box::new(file)))
+        .init();
+
+    log::info!(
+        "pipeline starting up, version=v{}",
+        env!("CARGO_PKG_VERSION")
+    );
+    Ok(())
+}
+
+/// An [`env_logger::Builder::format`] callback that renders a [`log::Record`]
+/// as one JSON object, followed by a newline (the "JSON lines" convention).
+fn format_json(buf: &mut env_logger::fmt::Formatter, record: &log::Record) -> std::io::Result<()> {
+    // now_utc()/Rfc3339 rather than env_logger's own timestamp support,
+    // to avoid depending on env_logger's "humantime" feature, which this
+    // crate doesn't otherwise need.
+    let timestamp = OffsetDateTime::now_utc()
+        .format(&Rfc3339)
+        .unwrap_or_default();
+    let entry = serde_json::json!({
+        "timestamp": timestamp,
+        "level": record.level().as_str(),
+        "target": record.target(),
+        "message": record.args().to_string(),
+    });
+    writeln!(buf, "{}", entry)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // `init()` sets the process-wide logger, which -- like `log::set_logger`
+    // in general -- can only happen once per process; keep this the only
+    // test in the crate that calls it.
+    #[test]
+    fn test_init_writes_structured_startup_record() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        init(dir.path())?;
+        log::warn!("something worth noting: {}", "relation/12345");
+
+        let contents = std::fs::read_to_string(dir.path().join(LOG_FILE_NAME))?;
+        let lines: Vec<&str> = contents.lines().collect();
+        assert_eq!(lines.len(), 2, "expected startup + warn record: {lines:?}");
+
+        let startup: serde_json::Value = serde_json::from_str(lines[0])?;
+        assert_eq!(startup["level"], "INFO");
+        assert!(
+            startup["message"]
+                .as_str()
+                .unwrap()
+                .contains(env!("CARGO_PKG_VERSION")),
+            "startup record should mention the binary's version: {startup}"
+        );
+        assert!(startup["timestamp"].as_str().is_some());
+
+        let warn: serde_json::Value = serde_json::from_str(lines[1])?;
+        assert_eq!(warn["level"], "WARN");
+        assert_eq!(warn["target"], module_path!());
+        assert!(warn["message"].as_str().unwrap().contains("relation/12345"));
+
+        Ok(())
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,6 @@ enum Commands {
 
 fn main() -> Result<()> {
     let args = Cli::parse();
-    env_logger::init();
     init_crypto();
 
     match &args.command {

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -12,6 +12,7 @@ pub fn run_pipeline(http_client: &reqwest::Client, workdir: &Path) -> Result<()>
     if !workdir.exists() {
         std::fs::create_dir(workdir)?;
     }
+    crate::logging::init(workdir)?;
 
     geostats::init()?;
     let progress = indicatif::MultiProgress::new();

--- a/src/pipeline/osm/assemble.rs
+++ b/src/pipeline/osm/assemble.rs
@@ -580,11 +580,7 @@ fn assemble_super_relations(
                 };
 
                 let Some(rel_geometry) = rel_geometry else {
-                    // TODO: Write to a proper log file, perhaps via rust logging framework.
-                    println!(
-                        "assemble_super_relations could not build geometry for relation/{}",
-                        rel_id
-                    );
+                    log::error!("could not build geometry for relation/{}", rel_id);
                     continue;
                 };
 


### PR DESCRIPTION
## Summary
- Add `src/logging.rs`: a skeleton for structured logging. `logging::init(workdir)` wires up the `log` crate's global logger to append one JSON object per line to `<workdir>/pipeline.log` (`timestamp`, `level`, `target`, `message`), instead of the previous `env_logger::init()` to stderr. `RUST_LOG` still controls the level (default `info`).
- At pipeline startup, log an `INFO` record with the binary's version (`CARGO_PKG_VERSION`, formatted like the release tag, e.g. `"v0.6.9"`) and a timestamp.
- In `pipeline::osm::assemble`, replace the `println!` for a relation whose geometry couldn't be built with `log::error!`, so it shows up in the log as e.g. `"could not build geometry for relation/12345"` instead of going to stdout.

This is a first skeleton: per-call structured fields (e.g. a dedicated `relation_id` key rather than embedding it in the message text) aren't wired through `log`'s key-value API yet, and the remaining `print!`/`eprintln!` call sites (`edits.rs`, `tiles.rs`, `upload.rs`) are left for a follow-up.

## Testing
- `cargo test` (full suite, including the `test_pipeline` integration test against the real binary) — all pass.
- `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo fmt --check` — clean.
- Manually ran the pipeline against the test fixtures and confirmed `pipeline.log` is created in the workdir with valid JSON lines, e.g.:
  ```json
  {"level":"INFO","message":"pipeline starting up, version=v0.6.9","target":"osm_diffs::logging","timestamp":"2026-08-10T10:22:00.643612Z"}
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)