### PR TITLE
ci: add a coverage floor to the test run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,11 @@ jobs:
       run: cargo build --locked
     - name: Run tests
       run: |
-        cargo llvm-cov test --cobertura --locked --verbose --output-path cobertura.xml
+        # Line coverage was ~91% as of 2026-08; 88% leaves some headroom
+        # for noise while still catching real regressions. Ratchet this
+        # up over time as coverage improves.
+        cargo llvm-cov test --cobertura --locked --verbose \
+          --output-path cobertura.xml --fail-under-lines 88
     - name: Look for common mistakes
       run: cargo clippy --locked
     - name: Upload test coverage to Coveralls


### PR DESCRIPTION
Coverage is reported to Coveralls but nothing previously failed CI if it
regressed. `--fail-under-lines <MIN>` fails the build if total line
coverage drops below `MIN` percent (as opposed to `--fail-uncovered-lines`,
which caps an absolute count of uncovered lines).

Current line coverage is ~91.3% per coveralls.io; set the floor to 88%,
leaving some headroom for noise while still catching real regressions.
Worth ratcheting up over time.

Part of #576.