### PR TITLE
Log warnings/errors for skipped geometry, replace remaining print!/eprintln!

### DIFF
--- a/src/pipeline/edits.rs
+++ b/src/pipeline/edits.rs
@@ -79,8 +79,8 @@ pub fn suggest_edits(
     progress_bar.finish_with_message(format!("ATP features → {} suggested OSM edits", num_edits));
 
     let cache_stats = osm.cache_stats();
-    println!(
-        "  cache hits: {} misses: {} hit rate: {:.1}%",
+    log::info!(
+        "cache hits: {} misses: {} hit rate: {:.1}%",
         cache_stats.hits,
         cache_stats.misses,
         cache_stats.hit_rate().unwrap_or(0.0) * 100.0
@@ -142,12 +142,13 @@ fn produce_edits(
                 {
                     num_matches.fetch_add(1, Ordering::Relaxed);
                     if let Some(edit) = matcher.suggest_edit(&best_candidate) {
-                        if false {
-                            println!(
-                                "score={} place={:?} best_candidate={:?} edit={:?}",
-                                best_score, place, best_candidate, edit
-                            );
-                        }
+                        log::debug!(
+                            "score={} place={:?} best_candidate={:?} edit={:?}",
+                            best_score,
+                            place,
+                            best_candidate,
+                            edit
+                        );
                         // TODO: Dispatch to one of {shops, infrastructure, trees}.
                         out.shops.send(edit)?;
                     }

--- a/src/pipeline/osm/assemble.rs
+++ b/src/pipeline/osm/assemble.rs
@@ -280,6 +280,7 @@ fn assemble_ways<'a>(
                             build_line(coords)
                         };
                         let Some(geometry) = geometry else {
+                            log::warn!("could not build geometry for way/{}", way.id);
                             continue;
                         };
 
@@ -429,6 +430,7 @@ fn assemble_leaf_relations<'a>(
                             /* super_relations */ None,
                         )?
                         else {
+                            log::error!("could not build geometry for relation/{}", relation.id);
                             continue;
                         };
 

--- a/src/pipeline/tiles.rs
+++ b/src/pipeline/tiles.rs
@@ -34,7 +34,7 @@ pub fn render_tiles(
         if let Some(progress) = parse_progress(&line) {
             progress_bar.set_position((progress + 0.5) as u64);
         } else {
-            eprintln!("{}", line);
+            log::info!("tippecanoe: {}", line);
         }
     }
 
@@ -76,7 +76,7 @@ fn make_tippecanoe_command(
                 layer.path.display()
             ));
         } else {
-            eprintln!("dropping layer {:?}", layer);
+            log::info!("dropping empty layer {:?}", layer);
         }
     }
     cmd.arg("--output").arg(out_path);

--- a/src/pipeline/upload.rs
+++ b/src/pipeline/upload.rs
@@ -82,7 +82,7 @@ impl<'a> Drop for Upload<'a> {
 
 pub fn upload_tiles(tiles: &Path, progress: &MultiProgress) -> Result<()> {
     let Some(endpoint) = env::var("S3_ENDPOINT").ok() else {
-        eprintln!("S3_ENDPOINT not set, skipping upload");
+        log::warn!("S3_ENDPOINT not set, skipping upload");
         return Ok(());
     };
 


### PR DESCRIPTION
## Summary

Follow-up to #585, which added structured JSON logging to a file in the working directory.

**`pipeline::osm::assemble`** — log when geometry can't be built, instead of silently dropping the feature:
- `assemble_ways`: `log::warn!` when a way's geometry can't be built (degenerate/non-finite coords) -- mirrors the existing relation case.
- `assemble_leaf_relations`: `log::error!` when a leaf relation's geometry can't be built. This had no log statement at all before, even though the identical failure for super-relations already did (added in #585).

**Remaining `print!`/`eprintln!` cleanup** -- everything now funnels into `pipeline.log`:
- `edits.rs`: cache-hit-rate summary → `log::info!`; a permanently disabled `if false { println!(...) }` debug block → unconditional `log::debug!`, so it's actually reachable via `RUST_LOG=debug` instead of being dead code.
- `upload.rs`: missing `S3_ENDPOINT` (upload skipped) → `log::warn!`.
- `tiles.rs`: tippecanoe's non-progress stderr lines and dropped empty layers → `log::info!`.

`rg "print!|println!|eprintln!|eprint!" src` now returns nothing.

## Testing
- `cargo test` (full suite, including `test_pipeline` integration test) — all pass.
- `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo fmt --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)