### PR TITLE
Add release-process and supply-chain-security documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,6 @@ yet run on a weekly basis. Once it does, the plan is to automatically
 feed edit proposals to [MapRoulette](https://maproulette.org/) where
 human users can manually check each edit before applying it to
 OpenStreetMap.
+
+See [`docs/`](docs/) for how to cut a release and the supply-chain
+security practices behind it.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,6 @@
+# Documentation
+
+- [`releasing.md`](releasing.md) — how to cut a release of `osm-diffs`.
+- [`supply-chain-security.md`](supply-chain-security.md) — the concepts
+  behind our release process: SBOM, CBOM, CycloneDX, build provenance,
+  attestations, and immutable releases.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -14,13 +14,23 @@ This document is the practical how-to for cutting a release of
 Run it from a clean, up-to-date `main` checkout. It handles everything
 else: bumping the version, opening and merging the PR for that, tagging,
 and publishing the release. See “What happens automatically” below for
-the full sequence.
+the full sequence — but read “Choosing the version number” first, it’s
+the one part of this that actually needs a careful decision, not just
+running a command.
 
 ## Choosing the version number
 
 This is the one genuine judgment call in the whole process; everything
 else is mechanical. We follow [SemVer](https://semver.org/), driven by
-the pipeline’s **output schema** — not by how much code changed:
+the pipeline’s **output schema** — not by how much code changed.
+
+This is a different question than what [SemVer](https://semver.org/)
+usually answers. Programmers normally think of SemVer in terms of API
+compatibility for code that *links against* a library. Nobody links
+against `osm-diffs`:
+downstream clients only ever consume the *data* it produces. So the
+question to ask isn’t “did the code change in a breaking way,” it’s “does
+this change what a client reading our output has to handle differently”:
 
 - **major** — the output schema changed in a way that breaks existing
   clients (a field was removed or renamed, a type changed, ...)
@@ -63,7 +73,8 @@ Once you run `cut-release.sh vX.Y.Z`:
      (a server-side safety net — this should never fail if you used the
      script, since the script only ever tags a version it just set).
    - `build` (once per architecture, amd64 and arm64): builds the
-     container via `Containerfile`, which also generates the SBOM (see
+     container via [`Containerfile`](../Containerfile), which also
+     generates the SBOM (see
      [`scripts/sbom/README.md`](../scripts/sbom/README.md)) and pushes
      each architecture’s image to `ghcr.io` by digest.
    - `manifest`: combines both architectures into a multi-arch manifest,
@@ -71,36 +82,38 @@ Once you run `cut-release.sh vX.Y.Z`:
    - `attest`: publishes signed SBOM and build-provenance attestations
      for both per-architecture images, plus a build-provenance
      attestation for the manifest list.
+6. **The script waits for that workflow to finish**, then runs
+   [`verify-release.sh`](../scripts/verify-release.sh) to confirm it
+   actually came out right — not just that it reported success, but that
+   both a build-provenance and an SBOM attestation genuinely exist for
+   both architectures (see “Verifying a release” below).
 
-Steps 1-4 usually take under 10 minutes; step 5 (the actual container
-build) takes roughly another 15-20 minutes.
+Steps 1-4 usually take under 10 minutes; steps 5-6 (the actual container
+build, plus verification) take roughly another 20-25 minutes.
 
 ## Verifying a release
 
-To double-check a release actually came out right, rather than just
-trusting that the workflow went green:
+This happens automatically as the last step of `cut-release.sh` — you
+don’t need to do anything extra. It’s implemented as a separate script,
+[`verify-release.sh`](../scripts/verify-release.sh), specifically so it
+can also be run standalone at any later time, e.g. if `cut-release.sh`
+didn’t get to finish (the machine running it crashed, the connection
+dropped, ...), or to double-check an older release:
 
 ```sh
-# Cargo.toml on main should match the tag you just cut
-git show origin/main:Cargo.toml | grep '^version'
-
-# the release.yml run for your tag should show all jobs succeeding
-gh run list --workflow=release.yml --limit 1
-
-# attestations exist for the published image (note: gh attestation
-# verify's default --predicate-type filter only shows build provenance;
-# query the raw API to see the SBOM attestation too)
-gh api "repos/alltheplaces/osm-diffs/attestations/sha256:<digest>" \
-  | jq -r '.attestations[].bundle.dsseEnvelope.payload' \
-  | while read -r p; do echo "$p" | base64 -d | jq -r .predicateType; done
-# expect: https://slsa.dev/provenance/v1 and https://cyclonedx.org/bom
+./scripts/verify-release.sh vX.Y.Z
 ```
 
-(This is exactly what was done to confirm v0.6.9, the first release cut
-with this script — see the comment trail on
+It waits for (or, if already finished, immediately checks)
+`release.yml`’s run for that tag, then confirms both a build-provenance
+and an SBOM attestation exist for each per-architecture image — the same
+two checks described in
+[`supply-chain-security.md`](supply-chain-security.md#build-provenance-and-attestations),
+done for real rather than assumed. This is exactly what was done by hand
+to confirm v0.6.9, the first release cut with `cut-release.sh` — see the
+comment trail on
 [alltheplaces/osm-diffs#562](https://github.com/alltheplaces/osm-diffs/pull/562)
-for the full walkthrough, including how to find the per-architecture
-digests via the release’s uploaded artifacts.)
+for that walkthrough, which is what `verify-release.sh` automates.
 
 ## Rules
 
@@ -136,11 +149,20 @@ digests via the release’s uploaded artifacts.)
   new patch version. The failed tag’s GitHub Release will just exist
   without a correspondingly published, attested container — that’s a
   known, accepted consequence of immutability, not a bug.
+- **`cut-release.sh` is interrupted, or times out, while waiting on
+  `release.yml`** (~20-25 min; a crashed machine, a dropped connection,
+  or a truly stuck workflow): the release itself is unaffected — it was
+  already created before this wait began. Just run
+  `./scripts/verify-release.sh vX.Y.Z` on its own once you’re ready to
+  check on it again; it picks up wherever the run currently stands.
 
 ## Where things live
 
 - [`scripts/cut-release.sh`](../scripts/cut-release.sh) — the script
   itself
+- [`scripts/verify-release.sh`](../scripts/verify-release.sh) — the
+  verification step `cut-release.sh` runs at the end (also usable
+  standalone)
 - [`.github/workflows/release.yml`](../.github/workflows/release.yml) —
   build, SBOM, attest
 - [`Containerfile`](../Containerfile) — how the container gets built

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,168 @@
+# Cutting a release
+
+This document is the practical how-to for cutting a release of
+`osm-diffs`. For the concepts behind *why* the process looks like this
+(SBOM, attestations, immutable releases, ...), see
+[`supply-chain-security.md`](supply-chain-security.md).
+
+## Quick start
+
+```sh
+./scripts/cut-release.sh vX.Y.Z
+```
+
+Run it from a clean, up-to-date `main` checkout. It handles everything
+else: bumping the version, opening and merging the PR for that, tagging,
+and publishing the release. See “What happens automatically” below for
+the full sequence.
+
+## Choosing the version number
+
+This is the one genuine judgment call in the whole process; everything
+else is mechanical. We follow [SemVer](https://semver.org/), driven by
+the pipeline’s **output schema** — not by how much code changed:
+
+- **major** — the output schema changed in a way that breaks existing
+  clients (a field was removed or renamed, a type changed, ...)
+- **minor** — the output schema evolved in a backward-compatible way
+  (e.g. a new optional field was added)
+- **patch** — bugfixes only, no schema changes
+
+A release that touches a lot of internal code but doesn’t change what
+clients read is still a patch release. A release that changes the output
+schema in a breaking way is a major release even if the code diff is
+tiny.
+
+## What happens automatically, step by step
+
+Once you run `cut-release.sh vX.Y.Z`:
+
+1. **Preconditions are checked**: you’re on a clean, up-to-date `main`;
+   `vX.Y.Z` doesn’t already exist; it’s actually newer than `Cargo.toml`’s
+   current version; the latest CI run on `main`’s current commit passed.
+   Any failure here stops immediately, before anything is pushed.
+2. **A version-bump PR is opened**: `Cargo.toml`’s version (and
+   `Cargo.lock`’s self-entry) is bumped on a new branch, and a PR titled
+   “Bump version to X.Y.Z” is opened against `main`. `main` is protected
+   (PR required, status checks required, merge queue), so this can’t be
+   pushed directly.
+3. **The script waits** for that PR to clear required checks and the
+   merge queue, and actually land on `main`. This normally takes a few
+   minutes (the required test job takes ~4-5 min; the merge queue has a
+   minimum 3 min wait).
+4. **The release is created**: a GitHub Release for `vX.Y.Z` is published
+   at the new `main` HEAD, with auto-generated notes (categorized per
+   [`.github/release.yml`](../.github/release.yml)’s label rules). This
+   creates the underlying git tag as a side effect, and the release is
+   immutable from this point on (see
+   [`supply-chain-security.md`](supply-chain-security.md#immutable-releases)).
+5. **That tag push triggers
+   [`.github/workflows/release.yml`](../.github/workflows/release.yml)**,
+   entirely independently of the script:
+   - `verify-version`: re-checks the tag matches `Cargo.toml`’s version
+     (a server-side safety net — this should never fail if you used the
+     script, since the script only ever tags a version it just set).
+   - `build` (once per architecture, amd64 and arm64): builds the
+     container via `Containerfile`, which also generates the SBOM (see
+     [`scripts/sbom/README.md`](../scripts/sbom/README.md)) and pushes
+     each architecture’s image to `ghcr.io` by digest.
+   - `manifest`: combines both architectures into a multi-arch manifest,
+     tagged both `vX.Y.Z` and `latest`.
+   - `attest`: publishes signed SBOM and build-provenance attestations
+     for both per-architecture images, plus a build-provenance
+     attestation for the manifest list.
+
+Steps 1-4 usually take under 10 minutes; step 5 (the actual container
+build) takes roughly another 15-20 minutes.
+
+## Verifying a release
+
+To double-check a release actually came out right, rather than just
+trusting that the workflow went green:
+
+```sh
+# Cargo.toml on main should match the tag you just cut
+git show origin/main:Cargo.toml | grep '^version'
+
+# the release.yml run for your tag should show all jobs succeeding
+gh run list --workflow=release.yml --limit 1
+
+# attestations exist for the published image (note: gh attestation
+# verify's default --predicate-type filter only shows build provenance;
+# query the raw API to see the SBOM attestation too)
+gh api "repos/alltheplaces/osm-diffs/attestations/sha256:<digest>" \
+  | jq -r '.attestations[].bundle.dsseEnvelope.payload' \
+  | while read -r p; do echo "$p" | base64 -d | jq -r .predicateType; done
+# expect: https://slsa.dev/provenance/v1 and https://cyclonedx.org/bom
+```
+
+(This is exactly what was done to confirm v0.6.9, the first release cut
+with this script — see the comment trail on
+[alltheplaces/osm-diffs#562](https://github.com/alltheplaces/osm-diffs/pull/562)
+for the full walkthrough, including how to find the per-architecture
+digests via the release’s uploaded artifacts.)
+
+## Rules
+
+- **Always cut releases with `cut-release.sh`.** Never push a `v*` tag by
+  hand. `release.yml` would still build and publish a container for it,
+  but you’d have skipped the version-consistency checks, and immutability
+  protections apply to tags that went through a real GitHub Release —
+  not to a bare tag pushed directly.
+- **Releases are immutable. If one’s bad, cut a new patch version and
+  leave the bad one as-is.** You can’t fix a published release in place,
+  and you can’t reuse or move its tag even if you delete it.
+- **Anyone with write access can cut a release.** There’s no separate
+  approval gate for this beyond the normal merge-queue checks — we don’t
+  have enough people for dedicated release roles.
+
+## If it goes wrong
+
+- **A precondition check fails** (dirty tree, stale `main`, tag exists,
+  version not newer, CI not green): nothing was pushed. Fix the
+  underlying issue and re-run.
+- **The bump PR fails its required checks**: auto-merge won’t complete,
+  and the script eventually times out (~25 min) with the PR still open.
+  Look at why CI failed on that PR, fix it, and either let auto-merge
+  finish or close the PR and start over.
+- **The bump PR merges, but the release itself fails to get created**
+  (rare): `main` now has the version bump, but re-running the whole
+  script will fail its “is this version newer” check, since `Cargo.toml`
+  already matches. Just run the release-creation step directly instead:
+  `gh release create vX.Y.Z --target main --generate-notes`.
+- **The tag/release gets created, but `release.yml` then fails** (e.g. a
+  build failure): the release is already immutable at this point, so
+  there’s no “redo.” Fix whatever broke the build (or `main`), and cut a
+  new patch version. The failed tag’s GitHub Release will just exist
+  without a correspondingly published, attested container — that’s a
+  known, accepted consequence of immutability, not a bug.
+
+## Where things live
+
+- [`scripts/cut-release.sh`](../scripts/cut-release.sh) — the script
+  itself
+- [`.github/workflows/release.yml`](../.github/workflows/release.yml) —
+  build, SBOM, attest
+- [`Containerfile`](../Containerfile) — how the container gets built
+- [`.github/release.yml`](../.github/release.yml) — changelog
+  categorization rules for auto-generated release notes
+- [`scripts/sbom/README.md`](../scripts/sbom/README.md) — how the SBOM
+  itself is generated
+
+## Known gaps, not yet in place
+
+- **Production deployment isn’t wired up yet.** This process ends at “a
+  correctly built, SBOM’d, attested container sits in `ghcr.io`” — what
+  happens after that, to actually run this in production, doesn’t exist
+  yet and isn’t covered here.
+- A few low-priority, deliberately-deferred items are tracked separately
+  and don’t block anything: automated freshness checks for vendored
+  dependencies
+  ([#555](https://github.com/alltheplaces/osm-diffs/issues/555)), moving
+  `cargo-cyclonedx` off Alpine’s edge repo once it’s available in stable
+  ([#556](https://github.com/alltheplaces/osm-diffs/issues/556)),
+  embedding the release version into the pipeline’s actual output data,
+  not just its logs
+  ([#588](https://github.com/alltheplaces/osm-diffs/issues/588)), and
+  watching for an emerging standard on index-level SBOMs for multi-arch
+  images ([#589](https://github.com/alltheplaces/osm-diffs/issues/589)).

--- a/docs/supply-chain-security.md
+++ b/docs/supply-chain-security.md
@@ -35,7 +35,8 @@ build-environment details (compiler and OS versions), and licenses.
 Alongside it, our SBOM includes a small **C**ryptographic **B**ill of
 **M**aterials (CBOM): the same idea, but for cryptography instead of
 dependencies — which TLS version, cipher suites, and crypto backend the
-binary uses. This matters because that’s exactly the kind of thing that
+binary uses, for example when uploading its output to S3-compatible
+storage. This matters because that’s exactly the kind of thing that
 can go stale silently: nothing about a routine dependency update would
 otherwise tell you that the set of cipher suites your binary supports has
 changed.
@@ -93,6 +94,28 @@ be deleted while the release exists. Even if the release is deleted
 outright, its tag name can never be reused for a new release. This closes
 off a whole class of supply-chain attack where a previously-trusted,
 already-verified tag gets quietly repointed at something else later.
+
+## Is this overkill for a project like this?
+
+Fair question. `osm-diffs` is open source, processes only publicly
+available data, and doesn’t handle secrets. Our actual threat model is
+modest compared to, say, a proprietary service handling user data or
+credentials — nobody stands to gain much by compromising this pipeline.
+So no, this level of supply-chain hardening isn’t strictly *necessary*
+the way it would be for many other projects.
+
+But it’s a one-time cost: once set up, it runs entirely automated, adding
+no ongoing effort to any future release. Given that, doing it properly
+is cheap insurance rather than a real trade-off against something else
+we’d otherwise be spending that effort on.
+
+It’s also a reasonable bet on where the industry is heading, not just
+where it stands today: supply-chain attacks aren’t hypothetical anymore
+(the [xz-utils backdoor](https://en.wikipedia.org/wiki/XZ_Utils_backdoor)
+being the starkest recent example), and the regulation and tooling
+responding to them — the practices this document describes among them —
+are becoming baseline expectations rather than something only
+security-sensitive projects bother with.
 
 ## Why all of this, together
 

--- a/docs/supply-chain-security.md
+++ b/docs/supply-chain-security.md
@@ -1,0 +1,106 @@
+# Supply-chain security: concepts
+
+This document explains the concepts behind the supply-chain security
+practices used in this project’s release process (see
+[`releasing.md`](releasing.md) for the actual, repo-specific steps). It’s
+written for someone who can code but hasn’t necessarily done release
+engineering before.
+
+## Bill of Materials (BOM)
+
+A Bill of Materials is a structured, machine-readable record of what went
+into producing something — similar in spirit to the list of ingredients
+on a food package. The idea is most commonly applied to software (a
+*Software* Bill of Materials, SBOM: which libraries a program depends on,
+which compiler and build tools were used, under which licenses), but
+nothing about it is specific to software. The same idea applies to any
+produced artifact: a BOM for a dataset could record which pipeline
+version, which input files, and when it was produced. This project’s SBOM
+already has a taste of that: alongside the software dependencies, it
+includes a couple of `"type": "data"` components (the vendored
+`id-tagging-schema` and `osm-testdata-grid`) that aren’t code at all, just
+data this project depends on.
+
+A BOM lets anyone — a downstream user, a security team, an auditor —
+answer questions like “does this contain a vulnerable version of library
+X?” without having to rebuild the software or read its source.
+
+## SBOM and CBOM
+
+Our **S**oftware **B**ill of **M**aterials describes the container image
+we publish: the Rust dependency graph of the `osm-diffs` binary, the
+statically linked `tippecanoe` binary and the libraries baked into it,
+build-environment details (compiler and OS versions), and licenses.
+
+Alongside it, our SBOM includes a small **C**ryptographic **B**ill of
+**M**aterials (CBOM): the same idea, but for cryptography instead of
+dependencies — which TLS version, cipher suites, and crypto backend the
+binary uses. This matters because that’s exactly the kind of thing that
+can go stale silently: nothing about a routine dependency update would
+otherwise tell you that the set of cipher suites your binary supports has
+changed.
+
+Both are generated from real, current build state, not maintained by
+hand — see [`scripts/sbom/README.md`](../scripts/sbom/README.md) for how.
+
+## CycloneDX
+
+We publish our SBOM (and CBOM) in [CycloneDX](https://cyclonedx.org/)
+format, an open, machine-readable standard for this kind of document (see
+the [CycloneDX Wikipedia article](https://en.wikipedia.org/wiki/CycloneDX)
+for background). Using a standard format, rather than inventing our own,
+means existing tools (vulnerability scanners, license auditors,
+CI validators like `cyclonedx-cli`) can consume it without needing to
+understand anything project-specific.
+
+## Build provenance and attestations
+
+Knowing what’s *in* an artifact (the SBOM) is only half the story —
+you also want to know that it was actually *built* the way you expect,
+by the CI pipeline you trust, from the source you expect, rather than
+tampered with somewhere between the build and reaching you. That’s what a
+build provenance attestation records: a cryptographically signed
+statement, tied to the exact artifact digest, that says “this was built
+by workflow W, from commit C, on GitHub-hosted infrastructure, triggered
+by event E.”
+
+We use GitHub’s native
+[artifact attestations](https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds)
+feature for this (backed by [Sigstore](https://www.sigstore.dev/)), which
+signs and publishes both a build-provenance attestation and an
+SBOM attestation for our container images, so anyone who pulls the image
+can verify both what’s in it and that it was really built by our GitHub
+Actions workflow — see [`releasing.md`](releasing.md) for exactly which
+attestations get created and how to check them yourself.
+
+One nuance worth knowing for a multi-architecture image like ours: the
+per-architecture images each get their own SBOM and provenance
+attestation (since their actual content, e.g. the compiled binaries,
+genuinely differs by architecture), while the top-level multi-arch
+manifest list gets a provenance attestation but not its own separate
+SBOM — it has no software content of its own, it’s a pure routing
+document pointing at the per-architecture images. This matches current
+mainstream practice (see the research summarized on
+[alltheplaces/osm-diffs#589](https://github.com/alltheplaces/osm-diffs/issues/589)
+for where this might evolve).
+
+## Immutable releases
+
+Attestations prove a release was built correctly *once*. Immutability
+protects that guarantee over time: once a release is published, GitHub
+locks its git tag to that exact commit — it can’t be moved, and it can’t
+be deleted while the release exists. Even if the release is deleted
+outright, its tag name can never be reused for a new release. This closes
+off a whole class of supply-chain attack where a previously-trusted,
+already-verified tag gets quietly repointed at something else later.
+
+## Why all of this, together
+
+None of these pieces alone is enough. An SBOM without provenance tells
+you what’s in an artifact but not whether to trust that it was built
+honestly. Provenance without immutability can be quietly invalidated
+later by moving the tag it refers to. Together, they form a chain a
+downstream consumer can actually verify: *this exact tag* can’t have been
+silently swapped (immutability), *this exact image* was built by our
+workflow from our source (provenance), and *this exact image* contains
+what it claims to (SBOM/CBOM).

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,11 +1,18 @@
 # Scripts
 
 Scripts used to generate some Rust sources in this repository, plus
-release-engineering scripts that aren't part of the Rust build itself.
+release-engineering scripts that aren’t part of the Rust build itself.
+See [`../docs/releasing.md`](../docs/releasing.md) for the full release
+process these fit into.
 
 - [`sbom/`](sbom/README.md): generates the Software Bill of Materials
   (SBOM) for the release container image.
 - [`cut-release.sh`](cut-release.sh): cuts a new release (bumps
-  `Cargo.toml`'s version via a PR, then creates the tagged GitHub Release
-  that triggers `.github/workflows/release.yml`). Run
-  `./scripts/cut-release.sh vX.Y.Z` from an up-to-date `main`.
+  `Cargo.toml`’s version via a PR, then creates the tagged GitHub Release
+  that triggers `.github/workflows/release.yml`, then waits for and
+  verifies the result). Run `./scripts/cut-release.sh vX.Y.Z` from an
+  up-to-date `main`.
+- [`verify-release.sh`](verify-release.sh): the verification step
+  `cut-release.sh` runs at the end — also usable standalone, e.g. to
+  double-check an older release. Run
+  `./scripts/verify-release.sh vX.Y.Z`.

--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -10,11 +10,14 @@
 #   2. Once that's landed on main, create the GitHub Release there (tag +
 #      auto-generated notes, from the categories configured in
 #      .github/release.yml).
+#   3. Wait for the resulting .github/workflows/release.yml run (build,
+#      SBOM, attest) and verify it actually came out right, via
+#      verify-release.sh.
 #
-# That release tag is what triggers .github/workflows/release.yml, which
-# builds, SBOMs, and attests the container -- this script doesn't touch
-# that part at all, it only automates getting a correctly tagged, correctly
-# versioned commit onto main in the first place.
+# Step 3 alone can take ~20-25 minutes; it's safe to Ctrl-C this script
+# once the release has been created (end of step 2) and, if you do,
+# finish verifying it later with:
+#   ./scripts/verify-release.sh vX.Y.Z
 #
 # Usage:
 #   ./scripts/cut-release.sh vX.Y.Z
@@ -28,6 +31,8 @@
 # Requirements: git, cargo, gh (authenticated -- run `gh auth login` first)
 
 set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 REQUIRED_CHECK="Execute unit and integration tests"
 MERGE_WAIT_TIMEOUT=1500  # 25 min: ~5 min test run + merge-queue wait + slack
@@ -160,5 +165,11 @@ git branch -D "$BUMP_BRANCH" -q
 echo "Creating release ${TAG}..."
 gh release create "$TAG" --target main --generate-notes
 
-echo "Done. ${TAG} is tagged and released; .github/workflows/release.yml" \
-     "is now building, SBOM-ing, and attesting the container."
+# ── wait for release.yml and verify the result ───────────────────────────────
+echo "${TAG} is tagged and released; waiting for .github/workflows/release.yml" \
+     "to build, SBOM, and attest the container, then verifying the result." \
+     "This can take ~20-25 minutes; safe to Ctrl-C and finish later with" \
+     "'./scripts/verify-release.sh ${TAG}'."
+"${SCRIPT_DIR}/verify-release.sh" "$TAG"
+
+echo "Done."

--- a/scripts/sbom/README.md
+++ b/scripts/sbom/README.md
@@ -1,32 +1,11 @@
 # SBOM generation
 
 This directory holds the scripts that generate the Software Bill of
-Materials (SBOM) for the `osm-diffs` container image.
-
-## What's an SBOM, and why do we have one?
-
-A Software Bill of Materials is a structured, machine-readable inventory of
-everything that went into building a piece of software: which libraries it
-depends on, which compiler and build tools were used, under which licenses
-the various pieces are published, and so on -- similar in spirit to the
-list of ingredients on a food package. It lets anyone (a downstream user, a
-security team, an auditor) answer questions like "does this container
-contain a vulnerable version of library X?" without having to rebuild the
-software or read its source.
-
-Alongside it, our SBOM includes a small Cryptographic Bill of Materials
-(CBOM): the same idea, but for cryptography instead of dependencies --
-which TLS version, cipher suites and crypto backend we use. See the
-`crypto/protocol/tls-1.3` entry in [`pipeline.jq`](pipeline.jq).
-
-We publish our SBOM in [CycloneDX](https://cyclonedx.org/) format, an
-open standard for this kind of document (see the
-[CycloneDX Wikipedia article](https://en.wikipedia.org/wiki/CycloneDX) for
-background). For every release, the generated SBOM gets attached to our
-container image on GitHub Container Registry as a signed
-[attestation](https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds),
-so anyone who pulls the image can verify both what's in it and that it was
-really built by our GitHub Actions workflow.
+Materials (SBOM) — including a small Cryptographic Bill of Materials,
+CBOM — for the `osm-diffs` container image. See
+[`../../docs/supply-chain-security.md`](../../docs/supply-chain-security.md)
+for what an SBOM/CBOM actually is and why we publish one; this document
+only covers how it’s implemented here.
 
 ## When and how it runs
 
@@ -36,14 +15,14 @@ built: after a git tag such as `v1.2.3` is pushed, GitHub Actions runs
 which invokes `podman build` on [`Containerfile`](../../Containerfile) to
 build the container image. As one of the last steps of that build,
 `Containerfile` runs [`generate-sbom.sh`](generate-sbom.sh), which writes a
-single `sbom.cdx.json` file into a directory that's mounted from the host
+single `sbom.cdx.json` file into a directory that’s mounted from the host
 (so we can read it without baking it into the shipped image itself).
 
 One thing `generate-sbom.sh` cannot know at that point is the digest of
-the finished container image -- that digest only exists once `podman
+the finished container image — that digest only exists once `podman
 build` has completed, which is after the SBOM was already written. So
 `release.yml` patches the digest in afterwards, with a one-line `jq`
-expression; see the comment in [`merge.jq`](merge.jq) for why that's safe.
+expression; see the comment in [`merge.jq`](merge.jq) for why that’s safe.
 
 `.github/workflows/test-container.yml` runs the same `Containerfile` build
 (without publishing anything) on every pull request that touches
@@ -61,9 +40,9 @@ tools such as `apk`, `sed`, `awk` and `grep`. It then:
    `cargo cyclonedx` currently supports).
 2. Pipes that through [`pipeline.jq`](pipeline.jq), which upgrades it to
    CycloneDX 1.7 and enriches it with build-environment metadata,
-   supplier/license info, and the vendored "data" components
-   (`id-tagging-schema`, `osm-testdata-grid`) that `cargo cyclonedx` has no
-   way to see.
+   supplier/license info, the CBOM entry, and the vendored “data”
+   components (`id-tagging-schema`, `osm-testdata-grid`) that
+   `cargo cyclonedx` has no way to see.
 3. Builds a CycloneDX fragment for the statically linked `tippecanoe`
    binary from scratch, with [`tippecanoe.jq`](tippecanoe.jq).
 4. Combines both fragments into the final, single SBOM for the container,
@@ -71,8 +50,15 @@ tools such as `apk`, `sed`, `awk` and `grep`. It then:
 
 None of the `.jq` files are invoked directly; `generate-sbom.sh` always
 passes the gathered facts to them as `--arg`/`--slurpfile` parameters, so
-none of the shell script's data ever needs to be patched into the `jq`
+none of the shell script’s data ever needs to be patched into the `jq`
 source itself.
+
+The CBOM’s cipher-suite list specifically comes from
+[`tls-1.3-cipher-suites.json`](tls-1.3-cipher-suites.json), not a
+hardcoded value in the `.jq` files — a Rust test
+(`cbom_cipher_suites_match_sbom_facts` in `src/main.rs`) checks that same
+file against the live crypto provider, so the CBOM can’t silently drift
+from what the binary actually supports.
 
 ### Running it outside of the release build
 
@@ -83,9 +69,9 @@ machine, to sanity-check its output:
 ./scripts/sbom/generate-sbom.sh /tmp/sbom.cdx.json
 ```
 
-Some of the facts it normally reads via Alpine's `apk` (the exact musl,
+Some of the facts it normally reads via Alpine’s `apk` (the exact musl,
 sqlite and zlib versions statically linked into `tippecanoe`, the Alpine
-version itself) aren't available outside of that build environment. In
+version itself) aren’t available outside of that build environment. In
 that case, the script inserts placeholder values, prints a warning, and
 marks the SBOM as `osm-diffs:sbom:devBuild` in its metadata properties.
 Such an SBOM is useful for checking structural or semantic validity (e.g.

--- a/scripts/verify-release.sh
+++ b/scripts/verify-release.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env sh
+#
+# SPDX-FileCopyrightText: 2026 Sascha Brawer <sascha@brawer.ch>
+# SPDX-License-Identifier: MIT
+#
+# Verify that a release actually came out right, not just that
+# `.github/workflows/release.yml` reported success:
+#   - waits for (or, if it's already done, immediately checks) that
+#     workflow's run for the given tag to complete successfully
+#   - confirms both a build-provenance and an SBOM attestation exist for
+#     each per-architecture image (see docs/supply-chain-security.md for
+#     what these are and why both should exist)
+#
+# Usage:
+#   ./scripts/verify-release.sh vX.Y.Z
+#
+# This is called automatically as the last step of cut-release.sh, but is
+# also safe to run standalone, any time after a tag was pushed -- e.g. if
+# cut-release.sh didn't get to finish (the machine running it crashed,
+# the connection dropped, ...), or to double-check an older release.
+#
+# Requirements: gh (authenticated -- run `gh auth login` first), jq
+
+set -eu
+
+RUN_WAIT_TIMEOUT=2700  # 45 min: ~20 min build+manifest+attest, plus slack
+RUN_POLL_INTERVAL=20
+RUN_LIST_LIMIT=50  # generous, so this still finds older releases
+
+TAG="${1:?usage: verify-release.sh vX.Y.Z}"
+
+for cmd in gh jq; do
+  command -v "$cmd" >/dev/null 2>&1 || { echo "ERROR: $cmd is not installed" >&2; exit 1; }
+done
+gh auth status >/dev/null 2>&1 || { echo "ERROR: gh is not authenticated -- run 'gh auth login'" >&2; exit 1; }
+
+REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+
+# ── wait for (or check) release.yml's run for this tag ──────────────────────
+echo "Looking for release.yml's run for ${TAG}..."
+ELAPSED=0
+RUN_ID=""
+CONCLUSION=""
+while :; do
+  RUN_JSON="$(gh run list --workflow=release.yml --limit "$RUN_LIST_LIMIT" \
+    --json databaseId,headBranch,status,conclusion \
+    -q "[.[] | select(.headBranch == \"${TAG}\")] | .[0] // empty")"
+  if [ -n "$RUN_JSON" ]; then
+    RUN_ID="$(echo "$RUN_JSON" | jq -r .databaseId)"
+    STATUS="$(echo "$RUN_JSON" | jq -r .status)"
+    CONCLUSION="$(echo "$RUN_JSON" | jq -r .conclusion)"
+    [ "$STATUS" = "completed" ] && break
+  fi
+  if [ "$ELAPSED" -ge "$RUN_WAIT_TIMEOUT" ]; then
+    echo "ERROR: timed out after ${RUN_WAIT_TIMEOUT}s waiting for release.yml" >&2
+    echo "  to finish for ${TAG}. Check its status manually and re-run this" >&2
+    echo "  script once it's done." >&2
+    exit 1
+  fi
+  sleep "$RUN_POLL_INTERVAL"
+  ELAPSED=$((ELAPSED + RUN_POLL_INTERVAL))
+done
+
+if [ "$CONCLUSION" != "success" ]; then
+  echo "ERROR: release.yml's run for ${TAG} did not succeed (conclusion=${CONCLUSION})." >&2
+  echo "  https://github.com/${REPO}/actions/runs/${RUN_ID}" >&2
+  exit 1
+fi
+echo "release.yml succeeded: https://github.com/${REPO}/actions/runs/${RUN_ID}"
+
+# ── fetch the per-architecture digests from that run's artifacts ────────────
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+gh run download "$RUN_ID" -n artifacts-amd64 -D "${WORKDIR}/amd64" >/dev/null
+gh run download "$RUN_ID" -n artifacts-arm64 -D "${WORKDIR}/arm64" >/dev/null
+AMD64_DIGEST="$(cat "${WORKDIR}/amd64/digest.txt")"
+ARM64_DIGEST="$(cat "${WORKDIR}/arm64/digest.txt")"
+
+# ── confirm both attestation types exist for each digest ────────────────────
+# Note: `gh attestation verify`'s default --predicate-type filter only shows
+# build provenance, hiding the SBOM attestation; query the raw API instead.
+check_attestations() {
+  arch="$1"; digest="$2"
+  types="$(gh api "repos/${REPO}/attestations/${digest}" \
+      -q '.attestations[].bundle.dsseEnvelope.payload' \
+    | while read -r p; do echo "$p" | base64 -d | jq -r .predicateType; done \
+    | sort -u)"
+  echo "${arch} (${digest}):"
+  echo "$types" | sed 's/^/  /'
+  echo "$types" | grep -qx 'https://slsa.dev/provenance/v1' \
+    || { echo "ERROR: missing build-provenance attestation for ${arch}" >&2; exit 1; }
+  echo "$types" | grep -qx 'https://cyclonedx.org/bom' \
+    || { echo "ERROR: missing SBOM attestation for ${arch}" >&2; exit 1; }
+}
+
+echo "Checking attestations..."
+check_attestations amd64 "$AMD64_DIGEST"
+check_attestations arm64 "$ARM64_DIGEST"
+
+echo "${TAG} verified: release.yml succeeded, and both SBOM and" \
+     "build-provenance attestations exist for both architectures."


### PR DESCRIPTION
New `docs/` directory, matching the existing "README per directory" convention already used for `scripts/` and `scripts/sbom/`.

- **`docs/README.md`**: index.
- **`docs/releasing.md`**: the practical how-to for cutting a release -- quick start, how to choose the version number (SemVer driven by output-schema compatibility, not code churn), what happens automatically step by step, how to verify a release actually came out right, rules (always use the script, releases are immutable, who's allowed to release), what to do if something goes wrong at each stage, where things live, and known gaps that are deliberately out of scope for now (no production deployment yet; links to #555/#556/#588/#589 for the rest).
- **`docs/supply-chain-security.md`**: the concepts behind all of this -- Bill of Materials (framed generally, not just "software," since a future BOM-for-output-data is plausible per #588), SBOM, CBOM, CycloneDX, build provenance/attestations (including why per-architecture images get their own SBOM but the manifest list only gets provenance, linking to the research on #589), immutable releases, and a candid section on whether any of this is overkill for a project like this.
- **`scripts/verify-release.sh`**: added per review feedback -- automates the SBOM/build-provenance attestation checks that were originally described in `docs/releasing.md` as manual copy-paste commands. Wired into `cut-release.sh` as its final step, and also standalone-invokable (e.g. if `cut-release.sh` gets interrupted, or to audit an older release later).

Also trims `scripts/sbom/README.md` down to implementation only (the `.jq` pipeline, dev-mode placeholder behavior), removing the conceptual SBOM/CBOM explanation now that it lives in `docs/supply-chain-security.md`, and adds a one-line pointer from the top-level `README.md` to `docs/`.

## Testing
- Verified every cross-referenced file path and every markdown anchor link resolves to a real file/heading.
- `scripts/verify-release.sh`: exercised all three code paths against real GitHub state, not just read through:
  - **Success path**: ran it against the real, already-published `v0.6.9` release -- correctly found the `release.yml` run, confirmed it succeeded, downloaded both per-architecture digests, and confirmed both a build-provenance (`https://slsa.dev/provenance/v1`) and an SBOM (`https://cyclonedx.org/bom`) attestation exist for each.
  - **Not-found/wait path**: confirmed the `gh run list` query correctly returns empty for a tag with no matching run (`v99.99.99`), which is what makes the script's poll loop keep waiting rather than misfiring.
  - **Failure path**: ran it against `v0.6.7`, a real historically-failed `release.yml` run (from before #558-#561 fixed the underlying issues) -- correctly detected `conclusion=failure` and exited non-zero with a link to the failed run, instead of hanging or reporting success.
  - Also `sh -n` syntax-checked both `cut-release.sh` and `verify-release.sh` after wiring them together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
