### PR TITLE
Rename docs/*.md to consistent uppercase filenames

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # Documentation
 
-- [`releasing.md`](releasing.md) — how to cut a release of `osm-diffs`.
-- [`supply-chain-security.md`](supply-chain-security.md) — the concepts
+- [`RELEASING.md`](RELEASING.md) — how to cut a release of `osm-diffs`.
+- [`SUPPLY_CHAIN_SECURITY.md`](SUPPLY_CHAIN_SECURITY.md) — the concepts
   behind our release process: SBOM, CBOM, CycloneDX, build provenance,
   attestations, and immutable releases.
 - [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) — how we expect people to

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -3,7 +3,7 @@
 This document is the practical how-to for cutting a release of
 `osm-diffs`. For the concepts behind *why* the process looks like this
 (SBOM, attestations, immutable releases, ...), see
-[`supply-chain-security.md`](supply-chain-security.md).
+[`SUPPLY_CHAIN_SECURITY.md`](SUPPLY_CHAIN_SECURITY.md).
 
 ## Quick start
 
@@ -65,7 +65,7 @@ Once you run `cut-release.sh vX.Y.Z`:
    [`.github/release.yml`](../.github/release.yml)’s label rules). This
    creates the underlying git tag as a side effect, and the release is
    immutable from this point on (see
-   [`supply-chain-security.md`](supply-chain-security.md#immutable-releases)).
+   [`SUPPLY_CHAIN_SECURITY.md`](SUPPLY_CHAIN_SECURITY.md#immutable-releases)).
 5. **That tag push triggers
    [`.github/workflows/release.yml`](../.github/workflows/release.yml)**,
    entirely independently of the script:
@@ -108,7 +108,7 @@ It waits for (or, if already finished, immediately checks)
 `release.yml`’s run for that tag, then confirms both a build-provenance
 and an SBOM attestation exist for each per-architecture image — the same
 two checks described in
-[`supply-chain-security.md`](supply-chain-security.md#build-provenance-and-attestations),
+[`SUPPLY_CHAIN_SECURITY.md`](SUPPLY_CHAIN_SECURITY.md#build-provenance-and-attestations),
 done for real rather than assumed. This is exactly what was done by hand
 to confirm v0.6.9, the first release cut with `cut-release.sh` — see the
 comment trail on

--- a/docs/SUPPLY_CHAIN_SECURITY.md
+++ b/docs/SUPPLY_CHAIN_SECURITY.md
@@ -2,7 +2,7 @@
 
 This document explains the concepts behind the supply-chain security
 practices used in this project’s release process (see
-[`releasing.md`](releasing.md) for the actual, repo-specific steps). It’s
+[`RELEASING.md`](RELEASING.md) for the actual, repo-specific steps). It’s
 written for someone who can code but hasn’t necessarily done release
 engineering before.
 
@@ -71,7 +71,7 @@ feature for this (backed by [Sigstore](https://www.sigstore.dev/)), which
 signs and publishes both a build-provenance attestation and an
 SBOM attestation for our container images, so anyone who pulls the image
 can verify both what’s in it and that it was really built by our GitHub
-Actions workflow — see [`releasing.md`](releasing.md) for exactly which
+Actions workflow — see [`RELEASING.md`](RELEASING.md) for exactly which
 attestations get created and how to check them yourself.
 
 One nuance worth knowing for a multi-architecture image like ours: the

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,7 +2,7 @@
 
 Scripts used to generate some Rust sources in this repository, plus
 release-engineering scripts that aren’t part of the Rust build itself.
-See [`../docs/releasing.md`](../docs/releasing.md) for the full release
+See [`../docs/RELEASING.md`](../docs/RELEASING.md) for the full release
 process these fit into.
 
 - [`sbom/`](sbom/README.md): generates the Software Bill of Materials

--- a/scripts/sbom/README.md
+++ b/scripts/sbom/README.md
@@ -3,7 +3,7 @@
 This directory holds the scripts that generate the Software Bill of
 Materials (SBOM) — including a small Cryptographic Bill of Materials,
 CBOM — for the `osm-diffs` container image. See
-[`../../docs/supply-chain-security.md`](../../docs/supply-chain-security.md)
+[`../../docs/SUPPLY_CHAIN_SECURITY.md`](../../docs/SUPPLY_CHAIN_SECURITY.md)
 for what an SBOM/CBOM actually is and why we publish one; this document
 only covers how it’s implemented here.
 

--- a/scripts/verify-release.sh
+++ b/scripts/verify-release.sh
@@ -8,7 +8,7 @@
 #   - waits for (or, if it's already done, immediately checks) that
 #     workflow's run for the given tag to complete successfully
 #   - confirms both a build-provenance and an SBOM attestation exist for
-#     each per-architecture image (see docs/supply-chain-security.md for
+#     each per-architecture image (see docs/SUPPLY_CHAIN_SECURITY.md for
 #     what these are and why both should exist)
 #
 # Usage:


### PR DESCRIPTION
Follow-up from #591.

\`docs/releasing.md\` -> \`docs/RELEASING.md\`
\`docs/supply-chain-security.md\` -> \`docs/SUPPLY_CHAIN_SECURITY.md\`

Matches \`CODE_OF_CONDUCT.md\` and \`SECURITY.md\`, which need their exact uppercase names for GitHub to recognize them as community health files -- rather than have those two be uppercase by necessity and the other two lowercase by accident, make all of \`docs/\` consistent. \`README.md\` is unchanged (already uppercase, and is itself one of the GitHub-recognized names).

Updated every cross-reference (both the link text and the path) across \`docs/README.md\`, \`docs/RELEASING.md\`, \`docs/SUPPLY_CHAIN_SECURITY.md\`, \`scripts/README.md\`, \`scripts/verify-release.sh\`, and \`scripts/sbom/README.md\`.

## Testing
Grepped the whole repo for both old filenames after the change -- no references remain anywhere. Confirmed the anchored links (\`#immutable-releases\`, \`#build-provenance-and-attestations\`) still resolve, since the headings they point at didn't change, only the filename. \`sh -n\` on \`verify-release.sh\` (only its header comment changed) still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)