### PR TITLE
Fix flaky logging test: search for our records instead of assuming exact position/count

### DIFF
--- a/src/logging.rs
+++ b/src/logging.rs
@@ -69,6 +69,13 @@ mod tests {
     // `init()` sets the process-wide logger, which -- like `log::set_logger`
     // in general -- can only happen once per process; keep this the only
     // test in the crate that calls it.
+    //
+    // That logger then stays live for the rest of the test binary's
+    // process. `cargo test` runs tests in parallel within one process, so
+    // any other test that logs anything afterwards -- directly, or via a
+    // dependency such as ext_sort -- gets appended to this very same file.
+    // Search for our own two records by content instead of assuming we're
+    // the only lines in the file, or that they're at fixed positions.
     #[test]
     fn test_init_writes_structured_startup_record() -> Result<()> {
         let dir = tempfile::tempdir()?;
@@ -76,11 +83,16 @@ mod tests {
         log::warn!("something worth noting: {}", "relation/12345");
 
         let contents = std::fs::read_to_string(dir.path().join(LOG_FILE_NAME))?;
-        let lines: Vec<&str> = contents.lines().collect();
-        assert_eq!(lines.len(), 2, "expected startup + warn record: {lines:?}");
+        let records: Vec<serde_json::Value> = contents
+            .lines()
+            .map(serde_json::from_str)
+            .collect::<std::result::Result<_, _>>()?;
 
-        let startup: serde_json::Value = serde_json::from_str(lines[0])?;
-        assert_eq!(startup["level"], "INFO");
+        let init_module = module_path!().rsplit_once("::").unwrap().0;
+        let startup = records
+            .iter()
+            .find(|r| r["target"] == init_module && r["level"] == "INFO")
+            .with_context(|| format!("no startup record found among: {records:?}"))?;
         assert!(
             startup["message"]
                 .as_str()
@@ -90,9 +102,10 @@ mod tests {
         );
         assert!(startup["timestamp"].as_str().is_some());
 
-        let warn: serde_json::Value = serde_json::from_str(lines[1])?;
-        assert_eq!(warn["level"], "WARN");
-        assert_eq!(warn["target"], module_path!());
+        let warn = records
+            .iter()
+            .find(|r| r["target"] == module_path!() && r["level"] == "WARN")
+            .with_context(|| format!("no warn record found among: {records:?}"))?;
         assert!(warn["message"].as_str().unwrap().contains("relation/12345"));
 
         Ok(())


### PR DESCRIPTION
Found while investigating why CI was failing on #592 -- a docs-only rename that couldn't plausibly have caused a Rust test failure: https://github.com/alltheplaces/osm-diffs/actions/runs/31425095611/job/93574785212

\`test_init_writes_structured_startup_record\` calls \`init()\`, which installs the process-wide \`log::set_logger\` -- per the existing comment, that can only happen once per process, so it's the only test in the crate that calls it. But that logger then stays live for the rest of the test binary's process, and \`cargo test\` runs tests in parallel within one process: any other test that logs anything afterwards -- directly, or via a dependency such as \`ext_sort\` -- gets appended to this same file, since there's only one global logger for the whole process at that point.

The test asserted exactly 2 lines at fixed positions, which is racy: it depends on whether some other concurrently-running test happens to log something in the window between \`init()\` and the final read. That's exactly what happened in the linked run -- an \`ext_sort\` thread-pool-init log line interleaved in, and the test saw 3 lines instead of 2.

## Fix
Search the parsed records for our specific startup record (by target + level) and our specific warn record (by target + level), rather than assuming line count or position. This tolerates any number of interleaved lines from other tests while still verifying the same thing: that \`init()\` produces a correct structured startup record, and that our own \`log::warn!\` call is captured correctly.

## Testing
- \`cargo build\`, \`cargo fmt --check\`, \`cargo clippy --locked\`: all clean.
- Ran the full \`cargo test --lib\` suite 30 times in a loop (not just this test in isolation, which wouldn't exercise the interleaving at all) -- no failures.
- The fix is correct by construction regardless of whether a given run happens to reproduce the interleaving, since it no longer assumes anything about what else might be in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)