### PR TITLE
docs/SUPPLY_CHAIN_SECURITY.md: add Minimal containers section, name SLSA Build L3

### DIFF
--- a/docs/SUPPLY_CHAIN_SECURITY.md
+++ b/docs/SUPPLY_CHAIN_SECURITY.md
@@ -40,6 +40,22 @@ changed.
 Both are generated from real, current build state, not maintained by
 hand — see [`scripts/sbom/README.md`](../scripts/sbom/README.md) for how.
 
+## Minimal containers
+
+`Containerfile` builds in two stages, and only the second one ships:
+`FROM scratch`, containing nothing but the `osm-diffs` and `tippecanoe`
+binaries. The entire build toolchain (Rust, a C compiler, `apk`, `git`,
+...) stays behind in the discarded first stage. Both binaries are
+statically linked against musl (Alpine’s C library) rather than
+dynamically against glibc, so there isn’t even a shared C library in the
+final image — let alone a shell or a package manager. The process also
+runs as an unprivileged user, not `root`. If someone found a way to run
+arbitrary code inside this container, there’s nothing there to run: no
+`/bin/sh`, nothing to fetch a second-stage payload with, and no root
+privileges to do more damage with even so. This is the same idea behind
+[Distroless](https://github.com/GoogleContainerTools/distroless) images,
+not something specific to `osm-diffs`.
+
 ## CycloneDX
 
 We publish our SBOM (and CBOM) in [CycloneDX](https://cyclonedx.org/)
@@ -60,6 +76,14 @@ build provenance attestation records: a cryptographically signed
 statement, tied to the exact artifact digest, that says “this was built
 by workflow W, from commit C, on GitHub-hosted infrastructure, triggered
 by event E.”
+
+This specifically targets
+[SLSA Build Level 3](https://slsa.dev/spec/v1.2/build-track-basics#build-l3):
+provenance that isn’t just signed, but generated somewhere the build
+itself can’t influence or forge. That’s why `release.yml`’s `attest` job
+runs as a separate job from `build`/`manifest` — the credentials used to
+sign the provenance are never exposed to the steps that actually compile
+arbitrary code, which is the part an attacker is more likely to reach.
 
 We use GitHub’s native
 [artifact attestations](https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds)

--- a/docs/SUPPLY_CHAIN_SECURITY.md
+++ b/docs/SUPPLY_CHAIN_SECURITY.md
@@ -15,10 +15,18 @@ to run — binaries, libraries, configuration — into a single, portable
 unit that behaves the same way regardless of the machine underneath it.
 It’s much lighter weight than a full virtual machine, since it shares
 the host machine’s kernel instead of running its own, while still
-keeping what’s inside isolated from everything else on that host. We
-publish `osm-diffs` as an [OCI](https://opencontainers.org/) image — the
-open, vendor-neutral standard most container tooling implements today —
-to GitHub’s container registry.
+keeping what’s inside isolated from everything else on that host.
+
+We publish `osm-diffs` as an [OCI](https://opencontainers.org/) image —
+the open, vendor-neutral standard most container tooling implements
+today — to a
+[container registry](https://www.redhat.com/en/topics/cloud-native-apps/what-is-a-container-registry)
+(GitHub’s, specifically): a place to store and distribute container
+images, the same way a package registry does for libraries.
+[`Containerfile`](../Containerfile) is the
+[recipe that builds our image](https://github.com/containers/container-libs/blob/main/common/docs/Containerfile.5.md):
+a plain-text file listing the steps to assemble it, one instruction per
+line.
 
 ## Minimal containers
 
@@ -37,6 +45,24 @@ arbitrary code inside this container, there’s nothing there to run: no
 privileges to do more damage with even so — see
 [this explanation of container attack-surface reduction](https://www.minimus.io/post/container-image-attack-surface-reduction)
 for more background on why that matters.
+
+## Multi-architecture containers
+
+Our container image is published for both `amd64` and `arm64`. The main
+reason: this is meant to run as a weekly batch job in a datacenter, but
+if something goes wrong, a developer should be able to just pull the
+image and run it locally to debug — including on an Apple Silicon Mac,
+without hunting down an old Intel machine first. ARM is also more
+power-efficient than x86 and gaining ground in datacenter infrastructure
+for that reason; publishing both architectures now makes an eventual
+production move easier, if that ever happens.
+
+Mechanically, a multi-architecture image is just an
+[image index](https://github.com/opencontainers/image-spec/blob/main/image-index.md)
+(also called a manifest list): a small document that points to one
+architecture-specific image per platform. Pulling the image by its tag
+automatically fetches the right one for your machine — you never have to
+pick `amd64` or `arm64` yourself.
 
 ## Bill of Materials (BOM)
 

--- a/docs/SUPPLY_CHAIN_SECURITY.md
+++ b/docs/SUPPLY_CHAIN_SECURITY.md
@@ -17,7 +17,8 @@ It’s much lighter weight than a full virtual machine, since it shares
 the host machine’s kernel instead of running its own, while still
 keeping what’s inside isolated from everything else on that host.
 
-We publish `osm-diffs` as an [OCI](https://opencontainers.org/) image —
+We publish `osm-diffs` as an
+[OCI image](https://opencontainers.org/) —
 the open, vendor-neutral standard most container tooling implements
 today — to a
 [container registry](https://www.redhat.com/en/topics/cloud-native-apps/what-is-a-container-registry)

--- a/docs/SUPPLY_CHAIN_SECURITY.md
+++ b/docs/SUPPLY_CHAIN_SECURITY.md
@@ -56,9 +56,9 @@ shell or a package manager. The process also
 runs as an unprivileged user, not `root`. If someone found a way to run
 arbitrary code inside this container, there’s nothing there to run: no
 `/bin/sh`, nothing to fetch a second-stage payload with, and no root
-privileges to do more damage with even so. This is the same idea behind
-[Distroless](https://github.com/GoogleContainerTools/distroless) images,
-not something specific to `osm-diffs`.
+privileges to do more damage with even so — see
+[this explanation of container attack-surface reduction](https://www.minimus.io/post/container-image-attack-surface-reduction)
+for more background on why that matters.
 
 ## CycloneDX
 

--- a/docs/SUPPLY_CHAIN_SECURITY.md
+++ b/docs/SUPPLY_CHAIN_SECURITY.md
@@ -8,6 +8,36 @@ engineering before. None of it is original to `osm-diffs` — everything
 described here is standard practice; this document just explains it in
 one place.
 
+## Containers
+
+A container packages an application together with everything it needs
+to run — binaries, libraries, configuration — into a single, portable
+unit that behaves the same way regardless of the machine underneath it.
+It’s much lighter weight than a full virtual machine, since it shares
+the host machine’s kernel instead of running its own, while still
+keeping what’s inside isolated from everything else on that host. We
+publish `osm-diffs` as an [OCI](https://opencontainers.org/) image — the
+open, vendor-neutral standard most container tooling implements today —
+to GitHub’s container registry.
+
+## Minimal containers
+
+`Containerfile` builds in two stages, and only the second one ships:
+`FROM scratch`, containing nothing but the `osm-diffs` and `tippecanoe`
+binaries. The entire build toolchain (Rust, a C compiler, `apk`, `git`,
+...) stays behind in the discarded first stage. Both binaries are
+statically linked against [musl](https://en.wikipedia.org/wiki/Musl),
+Alpine’s lightweight, security-focused C library
+([musl.libc.org explains why](https://musl.libc.org/about.html)), so
+there isn’t even a shared C library in the final image, let alone a
+shell or a package manager. The process also
+runs as an unprivileged user, not `root`. If someone found a way to run
+arbitrary code inside this container, there’s nothing there to run: no
+`/bin/sh`, nothing to fetch a second-stage payload with, and no root
+privileges to do more damage with even so — see
+[this explanation of container attack-surface reduction](https://www.minimus.io/post/container-image-attack-surface-reduction)
+for more background on why that matters.
+
 ## Bill of Materials (BOM)
 
 A Bill of Materials is a structured, machine-readable record of what went
@@ -41,24 +71,6 @@ changed.
 
 Both are generated from real, current build state, not maintained by
 hand — see [`scripts/sbom/README.md`](../scripts/sbom/README.md) for how.
-
-## Minimal containers
-
-`Containerfile` builds in two stages, and only the second one ships:
-`FROM scratch`, containing nothing but the `osm-diffs` and `tippecanoe`
-binaries. The entire build toolchain (Rust, a C compiler, `apk`, `git`,
-...) stays behind in the discarded first stage. Both binaries are
-statically linked against [musl](https://en.wikipedia.org/wiki/Musl),
-Alpine’s lightweight, security-focused C library
-([musl.libc.org explains why](https://musl.libc.org/about.html)), so
-there isn’t even a shared C library in the final image, let alone a
-shell or a package manager. The process also
-runs as an unprivileged user, not `root`. If someone found a way to run
-arbitrary code inside this container, there’s nothing there to run: no
-`/bin/sh`, nothing to fetch a second-stage payload with, and no root
-privileges to do more damage with even so — see
-[this explanation of container attack-surface reduction](https://www.minimus.io/post/container-image-attack-surface-reduction)
-for more background on why that matters.
 
 ## CycloneDX
 

--- a/docs/SUPPLY_CHAIN_SECURITY.md
+++ b/docs/SUPPLY_CHAIN_SECURITY.md
@@ -4,7 +4,9 @@ This document explains the concepts behind the supply-chain security
 practices used in this project’s release process (see
 [`RELEASING.md`](RELEASING.md) for the actual, repo-specific steps). It’s
 written for someone who can code but hasn’t necessarily done release
-engineering before.
+engineering before. None of it is original to `osm-diffs` — everything
+described here is standard practice; this document just explains it in
+one place.
 
 ## Bill of Materials (BOM)
 
@@ -46,9 +48,11 @@ hand — see [`scripts/sbom/README.md`](../scripts/sbom/README.md) for how.
 `FROM scratch`, containing nothing but the `osm-diffs` and `tippecanoe`
 binaries. The entire build toolchain (Rust, a C compiler, `apk`, `git`,
 ...) stays behind in the discarded first stage. Both binaries are
-statically linked against musl (Alpine’s C library) rather than
-dynamically against glibc, so there isn’t even a shared C library in the
-final image — let alone a shell or a package manager. The process also
+statically linked against [musl](https://en.wikipedia.org/wiki/Musl),
+Alpine’s lightweight, security-focused C library
+([musl.libc.org explains why](https://musl.libc.org/about.html)), so
+there isn’t even a shared C library in the final image, let alone a
+shell or a package manager. The process also
 runs as an unprivileged user, not `root`. If someone found a way to run
 arbitrary code inside this container, there’s nothing there to run: no
 `/bin/sh`, nothing to fetch a second-stage payload with, and no root
@@ -77,7 +81,7 @@ statement, tied to the exact artifact digest, that says “this was built
 by workflow W, from commit C, on GitHub-hosted infrastructure, triggered
 by event E.”
 
-This specifically targets
+We target
 [SLSA Build Level 3](https://slsa.dev/spec/v1.2/build-track-basics#build-l3):
 provenance that isn’t just signed, but generated somewhere the build
 itself can’t influence or forge. That’s why `release.yml`’s `attest` job


### PR DESCRIPTION
Adds concepts the docs didn't cover yet, all visible in the code but never explained -- `docs/SUPPLY_CHAIN_SECURITY.md` now reads roughly in this order:

- **Containers** / **Minimal containers** / **Multi-architecture containers** -- new, placed at the front (before "Bill of Materials"), since later sections already presuppose the reader knows what a container is. Covers: what a container is generally (vs. a VM); that we publish an OCI image to a container registry, built from `Containerfile`; why the shipped image is `FROM scratch` with nothing but two statically-linked (musl, not glibc) binaries, no shell, no package manager, running unprivileged -- and why that matters even with code execution; and why/how the image is published for both `amd64` and `arm64` (local debugging on Apple Silicon without needing an old Intel machine; ARM's growing datacenter footprint; mechanically just an OCI image index pointing at per-platform images).
- **SLSA Build Level 3**, named explicitly in "Build provenance and attestations": the one thing that actually earns it is the `attest` job running separately from `build`/`manifest`, so signing credentials are never exposed to the steps that compile arbitrary code.
- **"Is this overkill for a project like this?"**, moved to the very end as the closing thought -- addresses the threat-model question honestly (modest, for an open-source project handling only public data) and the "why bother anyway" question (one-time, fully automated cost; also a bet on where the industry is heading, citing the 2024 xz-utils backdoor).

Every technical claim and background link was checked directly, not asserted from memory -- including several corrections made during review: swapped a misleading Distroless link (we use `scratch`, not any distroless base image) for a verified attack-surface-reduction source after the first replacement also turned out to be the wrong kind of page; corrected the musl-vs-glibc framing after checking musl.libc.org's own design rationale, then dropped the static/dynamic-linking angle entirely per feedback; and deliberately avoided both "Docker" (we use OCI images, built with podman) and "Linux containers" (our own image, built `FROM scratch`, has no Linux userspace inside it) as terms throughout.

Kept every addition short per the "nobody reads long docs" goal -- a few sentences per concept, not new essays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
