### PR TITLE
ci: cache target/ build dir via Swatinem/rust-cache

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,14 +38,11 @@ jobs:
       uses: taiki-e/install-action@6c6fd71fe4fb72c3697d269963d0e15df8adedad # v2.85.10
       with:
         tool: cargo-llvm-cov
-    - name: Cache Cargo registry
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-        key: cargo-registry-${{ hashFiles('Cargo.lock') }}
-        restore-keys: cargo-registry-
+    - name: Cache Cargo registry and build artifacts
+      # This cache only ever feeds this test workflow. release.yml builds
+      # release binaries from scratch on purpose, without touching this
+      # (or any other) build cache.
+      uses: Swatinem/rust-cache@63fed3e2fecf6f7b51dc6f043341b79ef82a9ae7  # v2.9.2
     - name: Fetch Rust dependencies
       run: cargo fetch --locked
     - name: Check formatting


### PR DESCRIPTION
## What

Replace the hand-rolled Cargo registry cache with
[`Swatinem/rust-cache`](https://github.com/Swatinem/rust-cache), which also
caches the `target/` build directory across runs.

## Why

sccache stats on a recent doc-only PR showed a 100% cache hit rate on
compilation, yet the job still took ~3 minutes. That's because sccache only
caches individual `rustc` invocation outputs — it doesn't let Cargo skip
anything. With no `target/` directory persisted between CI runs, Cargo has
no fingerprints to compare against: it still invokes rustc for ~2000+
compile units (fast cache hits, but not free) and always redoes the link
step, which sccache doesn't cache at all, across three separate build
profiles in the job (build, coverage-instrumented test, clippy).

Caching `target/` lets Cargo's own fingerprinting recognize "nothing
relevant changed" and skip recompilation and relinking entirely — the same
mechanism that makes local incremental rebuilds fast. `Swatinem/rust-cache`
is the standard action for this: it also caches `~/.cargo/registry` and
`~/.cargo/git`, so it subsumes the existing hand-rolled registry cache
step.

sccache stays in place as a fallback (e.g. first build, or cases where the
`target/` cache doesn't restore).

Added a comment noting this cache is test-only: `release.yml` builds
release binaries from scratch on purpose and doesn't touch it.

Part of #597
