### PR TITLE
ci: cancel superseded test runs via a concurrency group

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,11 @@
 name: Tests
 
+# This workflow deliberately never triggers on tags: the push trigger below
+# is restricted to the "main" branch. Pushing a git tag is handled by
+# release.yml instead; see docs/RELEASING.md and docs/SUPPLY_CHAIN_SECURITY.md
+# for how releases work. One consequence is that github.ref, used below for
+# the concurrency group, is always a branch ref here (e.g. refs/heads/main)
+# rather than a tag ref.
 on:
   merge_group:
   push:
@@ -8,6 +14,13 @@ on:
     branches: [ "main" ]
 
 permissions: {}
+
+# Cancel a still-running run for the same PR (or branch) once a newer one
+# starts, e.g. after a force-push or an "Update branch" merge commit, so
+# superseded runs don't sit queued behind/compete with the current one.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## What

Add a `concurrency` group to `Tests` so a newer run for the same PR (or
branch/merge-queue entry) cancels a still-running older one, instead of
queuing behind or running alongside it.

## Why

Noticed on PR #598: pushing a merge commit ("Update branch") to a PR
started a second run while the first was still in progress. It just sat
`queued` behind the older run rather than being cancelled, wasting a
runner slot and delaying feedback on the actually-current commit.

Also added a comment clarifying that this workflow never triggers on tags
(the `push` trigger is restricted to `main`) — tag pushes are handled by
`release.yml` (see `docs/RELEASING.md` and
`docs/SUPPLY_CHAIN_SECURITY.md`), so `github.ref`, used in the concurrency
group key, is always a branch ref here, never a tag ref.

Independent of #597/#598 — unrelated to the build-caching work, just CI
hygiene noticed along the way.
