### PR TITLE
docs/README.md: reflect SUPPLY_CHAIN_SECURITY.md's broader scope

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,8 +2,9 @@
 
 - [`RELEASING.md`](RELEASING.md) — how to cut a release of `osm-diffs`.
 - [`SUPPLY_CHAIN_SECURITY.md`](SUPPLY_CHAIN_SECURITY.md) — the concepts
-  behind our release process: SBOM, CBOM, CycloneDX, build provenance,
-  attestations, and immutable releases.
+  behind our release process: containers, multi-architecture images,
+  SBOM/CBOM, CycloneDX, build provenance and attestations, and
+  immutable releases.
 - [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) — how we expect people to
   treat each other in this project.
 - [`SECURITY.md`](SECURITY.md) — how to report a security vulnerability.


### PR DESCRIPTION
SUPPLY_CHAIN_SECURITY.md grew container and multi-architecture-image sections (#595, #596) since this index blurb was last written. Updated the topic list to match, in the same order as the doc's own headings (containers → multi-architecture images → SBOM/CBOM → CycloneDX → build provenance and attestations → immutable releases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)