### PR TITLE
Correct SLSA Build Level claim: we're at L2, not L3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,9 +200,12 @@ jobs:
           retention-days: 30
 
 
-  # If you ever refactor the GitHub workflow, make sure that the attest phase
-  # continues to run on a separate machine, decoupled from any build jobs.
-  # https://slsa.dev/spec/v1.2/build-track-basics#build-l3
+  # This job runs on its own machine, decoupled from the build jobs, so the
+  # signing credentials used here are never exposed to build steps that
+  # compile arbitrary code. That's SLSA Build Level 2 (hosted, signed
+  # provenance) -- reaching Level 3 needs build+attest moved into a
+  # reusable workflow; see docs/SUPPLY_CHAIN_SECURITY.md.
+  # https://slsa.dev/spec/v1.2/build-track-basics
   attest:
     name: Attest build provenance
     runs-on: ubuntu-24.04

--- a/docs/SUPPLY_CHAIN_SECURITY.md
+++ b/docs/SUPPLY_CHAIN_SECURITY.md
@@ -107,13 +107,20 @@ statement, tied to the exact artifact digest, saying “this was built by
 workflow W, from commit C, on GitHub-hosted infrastructure, triggered
 by event E.”
 
-We target
-[SLSA Build Level 3](https://slsa.dev/spec/v1.2/build-track-basics#build-l3):
-provenance that isn’t just signed, but generated somewhere the build
-itself can’t influence or forge. That’s why `release.yml`’s `attest`
-job runs separately from `build`/`manifest` — the signing credentials
-are never exposed to the steps that compile arbitrary code, the part an
-attacker is more likely to reach.
+We reach
+[SLSA Build Level 2](https://slsa.dev/spec/v1.2/build-track-basics#build-l2):
+provenance that’s signed by a hosted build platform (GitHub Actions),
+not just self-attested. `release.yml`’s `attest` job runs separately
+from `build`/`manifest`, so its signing credentials are never exposed
+to the steps that compile arbitrary code — good defense in depth, but
+not the same thing as
+[SLSA Build Level 3](https://slsa.dev/spec/v1.2/build-track-basics#build-l3).
+Per GitHub’s own guidance, reaching Level 3 means moving the build and
+attestation steps into a
+[reusable workflow](https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows),
+so the process that generates provenance has a distinct, independently
+verifiable identity — not just another job living in the same workflow
+file as the build steps.
 
 We use GitHub’s native
 [artifact attestations](https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds)


### PR DESCRIPTION
Audited `release.yml` against GitHub's own documented compliance bar for SLSA v1.0 Build Level 3 ([github/docs source](https://github.com/github/docs/blob/main/content/actions/how-tos/secure-your-work/use-artifact-attestations/increase-security-rating.md), [artifact attestations concepts](https://docs.github.com/en/actions/concepts/security/artifact-attestations)). Both are explicit: `actions/attest` used directly — even isolated into its own job with its own permissions, as ours is — is Build Level 2 ("hosted, signed provenance"). Reaching Level 3 specifically requires moving build *and* attestation into a reusable workflow, not just a separate job in the same workflow file.

Our `attest` job's separation (own job, own permissions, no build secrets in scope) is real defense in depth worth keeping, but it isn't the L3 property: build and attest still live in one maintainer-editable file, and `attest` never re-derives what it signs — it trusts `digest.txt`/`sbom.cdx.json` written by the (less-trusted, code-compiling) `build` job and handed over via `actions/upload-artifact`. A compromised build step could write a false digest and `attest` would sign it without noticing.

This is step one of a two-step plan:
1. **This PR** — stop claiming L3 we don't have.
2. **Follow-up** — restructure `release.yml` into a caller + reusable workflow to actually reach L3, then document that.

## Testing
Docs-only + a workflow comment change; no `release.yml` job/step behavior changed. Confirmed no stray L3 claims remain elsewhere (`grep -rn "Build Level 3" .github docs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)