### PR TITLE
ci: cache apt packages (protobuf-compiler, tippecanoe)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,9 +42,13 @@ jobs:
     - name: Check out repository
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
     - name: Install protobuf compiler and tippecanoe
+      uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9  # v1.6.3
+      with:
+        packages: protobuf-compiler tippecanoe
+        # Bump this if the package list above changes, to bust the cache.
+        version: 1.0
+    - name: Print installed tool versions
       run: |
-        sudo apt-get update
-        sudo apt-get install -y protobuf-compiler tippecanoe
         protoc --version
         tippecanoe --version
     - name: Install Rust coverage tool


### PR DESCRIPTION
## What

Cache the `protobuf-compiler` and `tippecanoe` apt packages via
[`awalsh128/cache-apt-pkgs-action`](https://github.com/awalsh128/cache-apt-pkgs-action)
instead of running `apt-get update && apt-get install` on every run.

## Why

This step took ~10-30s every run (variance from `apt-get update` hitting
Ubuntu's mirrors) regardless of what changed in the PR. The action caches
the downloaded `.deb` files keyed on the package list + a version tag, and
installs straight from cache on a hit, skipping `apt-get update` and the
download.

Last item from #597.
