### PR TITLE
Split release.yml into caller + reusable workflow: reach SLSA Build Level 3

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,0 +1,263 @@
+name: Build and attest a release
+
+# Reusable workflow, called only by release.yml. Kept as a separate workflow
+# file (rather than a job in release.yml) specifically so this process has
+# its own, distinct identity for provenance purposes: the attestations this
+# workflow signs record *this* file's path and pinned ref as the builder,
+# not release.yml's. That's what SLSA Build Level 3 requires -- see
+# "Build provenance and attestations" in docs/SUPPLY_CHAIN_SECURITY.md for
+# why, and don't fold these jobs back into release.yml.
+# https://slsa.dev/spec/v1.2/build-track-basics#build-l3
+on:
+  workflow_call:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+permissions: {}
+
+jobs:
+  verify-version:
+    name: Verify release tag matches Cargo.toml version
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Compare tag to Cargo.toml version
+        run: |
+          TAG="${{ github.ref_name }}"
+          CARGO_VERSION=$(awk '
+            /^\[package\]/ { in_package=1; next }
+            /^\[/           { in_package=0 }
+            in_package && /^version[[:space:]]*=/ {
+              match($0, /"[^"]*"/)
+              print substr($0, RSTART+1, RLENGTH-2)
+              exit
+            }
+          ' Cargo.toml)
+          EXPECTED_TAG="v${CARGO_VERSION}"
+          if [ "$TAG" != "$EXPECTED_TAG" ]; then
+            echo "::error::Git tag '${TAG}' does not match Cargo.toml's package version '${CARGO_VERSION}' (expected tag '${EXPECTED_TAG}'). Bump and commit Cargo.toml's version before tagging a release, or fix the tag." >&2
+            exit 1
+          fi
+          echo "OK: tag ${TAG} matches Cargo.toml version ${CARGO_VERSION}"
+
+  build:
+    name: Build architecture-specific images
+    runs-on: ${{ matrix.runner }}
+    needs: [verify-version]
+    # Observed ~11-16 min per arch as of 2026-08; generous headroom over that,
+    # well short of the 360 min default, so a hang fails fast instead of
+    # burning runner-minutes for hours.
+    timeout-minutes: 30
+
+    strategy:
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            platform: linux/amd64
+            arch: amd64
+          - runner: ubuntu-24.04-arm
+            platform: linux/arm64
+            arch: arm64
+
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Install Podman
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install podman
+
+      - name: Log in to Container Registry
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | podman login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
+
+      - name: Get commit timestamp
+        id: commit-info
+        run: |
+          TIMESTAMP=$(git log -1 --format=%cI ${{ github.sha }})
+          echo "timestamp=$TIMESTAMP" >> $GITHUB_OUTPUT
+
+      - name: Build image
+        id: build
+        run: |
+          IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest-${{ matrix.arch }}
+          TIMESTAMP=${{ steps.commit-info.outputs.timestamp }}
+          mkdir artifacts
+          podman build \
+            --build-arg BUILD_TIMESTAMP="${TIMESTAMP}" \
+            --build-arg IMAGE_NAME="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}" \
+            --build-arg VCS_REF="${{ github.sha }}" \
+            --build-arg VCS_URL="${{ github.server_url }}/${{ github.repository }}" \
+            --file ./Containerfile \
+            --platform ${{ matrix.platform }} \
+            --squash \
+            --tag ${IMAGE} \
+            --timestamp $(date -d "${TIMESTAMP}" +%s) \
+            --volume $(pwd)/artifacts:/artifacts \
+            .
+          podman inspect --format '{{.Digest}}' ${IMAGE} >artifacts/digest.txt
+          echo Built container "${IMAGE}@$(cat artifacts/digest.txt)"
+
+      - name: Patch image digest into SBOM
+        id: patch-sbom
+        run: |
+          # generate-sbom.sh (run inside Containerfile, above) can't know the
+          # image digest -- it doesn't exist until the build above finishes.
+          # actions/attest binds the SBOM to a specific digest independently
+          # via its own subject-digest input, so this isn't required for
+          # provenance; we patch it in anyway so the SBOM is self-describing
+          # even when read outside of the attestation.
+          DIGEST=$(cat artifacts/digest.txt)
+          jq --arg digest "${DIGEST}" '.metadata.component.version = $digest' \
+            artifacts/sbom.cdx.json > artifacts/sbom.cdx.json.tmp
+          mv artifacts/sbom.cdx.json.tmp artifacts/sbom.cdx.json
+
+      - name: Push image
+        id: push
+        run: |
+          IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          DIGEST=$(cat artifacts/digest.txt)
+          podman push ${IMAGE}@${DIGEST}
+
+      - name: Upload image digest and SBOM to artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: artifacts-${{ matrix.arch }}
+          path: artifacts
+          retention-days: 30
+
+  manifest:
+    name: Build multi-architecture manifest
+    runs-on: ubuntu-24.04
+    needs: [build]
+    timeout-minutes: 10
+    permissions:
+      id-token: write
+      packages: write
+
+    steps:
+      - name: Install Podman
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install podman
+
+      - name: Log in to Container Registry
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | podman login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
+
+      - name: Download artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  #v8.0.1
+
+      - name: Pull architecture-specific images
+        run: |
+          IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          podman pull ${IMAGE}@`cat artifacts-amd64/digest.txt`
+          podman pull ${IMAGE}@`cat artifacts-arm64/digest.txt`
+
+      - name: Create and push multi-architecture manifest
+        id: manifests
+        run: |
+          IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          IMAGE_SHA=${IMAGE}:${{ github.sha }}
+          IMAGE_AMD64=${IMAGE}@`cat artifacts-amd64/digest.txt`
+          IMAGE_ARM64=${IMAGE}@`cat artifacts-arm64/digest.txt`
+          VCS_REF="${{ github.sha }}"
+          VCS_URL="${{ github.server_url }}/${{ github.repository }}"
+
+          mkdir artifacts
+          podman manifest create ${IMAGE_SHA}
+          podman manifest add ${IMAGE_SHA} ${IMAGE_AMD64}
+          podman manifest add ${IMAGE_SHA} ${IMAGE_ARM64}
+          podman tag ${IMAGE_SHA} ${IMAGE}:latest ${IMAGE}:${{ github.ref_name }}
+          podman manifest push ${IMAGE}:${{ github.ref_name }} \
+              --digestfile artifacts/digest.txt
+          podman manifest push ${IMAGE}:latest \
+              --digestfile artifacts/digest.txt
+
+      - name: Upload manifest digest to artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: artifacts-manifest
+          path: artifacts
+          retention-days: 30
+
+  attest:
+    name: Attest build provenance
+    runs-on: ubuntu-24.04
+    needs: [manifest]
+    timeout-minutes: 10
+
+    permissions:
+      artifact-metadata: write
+      attestations: write
+      id-token: write
+      packages: write
+
+    steps:
+      - name: Login to Container Registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  #v4.6.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  #v8.0.1
+
+      - name: Retrieve digests
+        id: retrieve-digests
+        run: |
+          echo amd64_digest=`cat artifacts-amd64/digest.txt` >> $GITHUB_OUTPUT
+          echo arm64_digest=`cat artifacts-arm64/digest.txt` >> $GITHUB_OUTPUT
+          echo manifest_digest=`cat artifacts-manifest/digest.txt` >> $GITHUB_OUTPUT
+
+      - name: Attest amd64 SBOM
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 #v4.2.2
+        with:
+          sbom-path: artifacts-amd64/sbom.cdx.json
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.retrieve-digests.outputs.amd64_digest }}
+          push-to-registry: true
+
+      - name: Attest arm64 SBOM
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 #v4.2.2
+        with:
+          sbom-path: artifacts-arm64/sbom.cdx.json
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.retrieve-digests.outputs.arm64_digest }}
+          push-to-registry: true
+
+      - name: Attest amd64 container
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 #v4.2.2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.retrieve-digests.outputs.amd64_digest }}
+          push-to-registry: true
+
+      - name: Attest arm64 container
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 #v4.2.2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.retrieve-digests.outputs.arm64_digest }}
+          push-to-registry: true
+
+      - name: Attest multi-architecture manifest
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 #v4.2.2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.retrieve-digests.outputs.manifest_digest }}
+          push-to-registry: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,10 +4,10 @@ on:
   push:
     tags: ['v*']  # triggered by pushing a tag such as 'v0.1.2'
 
-# Serialize releases: the manifest job below overwrites the shared, mutable
-# ":latest" tag, so two tags pushed close together must not build
-# concurrently -- whichever run's manifest push happened to land last would
-# silently "win" :latest, regardless of which tag is actually newer.
+# Serialize releases: the manifest job (in release-build.yml) overwrites the
+# shared, mutable ":latest" tag, so two tags pushed close together must not
+# build concurrently -- whichever run's manifest push happened to land last
+# would silently "win" :latest, regardless of which tag is actually newer.
 # cancel-in-progress stays false (the default) on purpose: an in-progress
 # release may be mid-push or mid-attestation, and queuing a second run is
 # safe where killing the first one mid-flight would not be.
@@ -15,260 +15,20 @@ concurrency:
   group: release
   cancel-in-progress: false
 
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
-
 permissions: {}
 
 jobs:
-  verify-version:
-    name: Verify release tag matches Cargo.toml version
-    runs-on: ubuntu-24.04
-    timeout-minutes: 5
-    permissions:
-      contents: read
-
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-
-      - name: Compare tag to Cargo.toml version
-        run: |
-          TAG="${{ github.ref_name }}"
-          CARGO_VERSION=$(awk '
-            /^\[package\]/ { in_package=1; next }
-            /^\[/           { in_package=0 }
-            in_package && /^version[[:space:]]*=/ {
-              match($0, /"[^"]*"/)
-              print substr($0, RSTART+1, RLENGTH-2)
-              exit
-            }
-          ' Cargo.toml)
-          EXPECTED_TAG="v${CARGO_VERSION}"
-          if [ "$TAG" != "$EXPECTED_TAG" ]; then
-            echo "::error::Git tag '${TAG}' does not match Cargo.toml's package version '${CARGO_VERSION}' (expected tag '${EXPECTED_TAG}'). Bump and commit Cargo.toml's version before tagging a release, or fix the tag." >&2
-            exit 1
-          fi
-          echo "OK: tag ${TAG} matches Cargo.toml version ${CARGO_VERSION}"
-
-  build:
-    name: Build architecture-specific images
-    runs-on: ${{ matrix.runner }}
-    needs: [verify-version]
-    # Observed ~11-16 min per arch as of 2026-08; generous headroom over that,
-    # well short of the 360 min default, so a hang fails fast instead of
-    # burning runner-minutes for hours.
-    timeout-minutes: 30
-
-    strategy:
-      matrix:
-        include:
-          - runner: ubuntu-24.04
-            platform: linux/amd64
-            arch: amd64
-          - runner: ubuntu-24.04-arm
-            platform: linux/arm64
-            arch: arm64
-
-    permissions:
-      contents: read
-      id-token: write
-      packages: write
-
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-
-      - name: Install Podman
-        run: |
-          sudo apt-get update
-          sudo apt-get -y install podman
-
-      - name: Log in to Container Registry
-        run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | podman login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
-
-      - name: Get commit timestamp
-        id: commit-info
-        run: |
-          TIMESTAMP=$(git log -1 --format=%cI ${{ github.sha }})
-          echo "timestamp=$TIMESTAMP" >> $GITHUB_OUTPUT
-
-      - name: Build image
-        id: build
-        run: |
-          IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest-${{ matrix.arch }}
-          TIMESTAMP=${{ steps.commit-info.outputs.timestamp }}
-          mkdir artifacts
-          podman build \
-            --build-arg BUILD_TIMESTAMP="${TIMESTAMP}" \
-            --build-arg IMAGE_NAME="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}" \
-            --build-arg VCS_REF="${{ github.sha }}" \
-            --build-arg VCS_URL="${{ github.server_url }}/${{ github.repository }}" \
-            --file ./Containerfile \
-            --platform ${{ matrix.platform }} \
-            --squash \
-            --tag ${IMAGE} \
-            --timestamp $(date -d "${TIMESTAMP}" +%s) \
-            --volume $(pwd)/artifacts:/artifacts \
-            .
-          podman inspect --format '{{.Digest}}' ${IMAGE} >artifacts/digest.txt
-          echo Built container "${IMAGE}@$(cat artifacts/digest.txt)"
-
-      - name: Patch image digest into SBOM
-        id: patch-sbom
-        run: |
-          # generate-sbom.sh (run inside Containerfile, above) can't know the
-          # image digest -- it doesn't exist until the build above finishes.
-          # actions/attest binds the SBOM to a specific digest independently
-          # via its own subject-digest input, so this isn't required for
-          # provenance; we patch it in anyway so the SBOM is self-describing
-          # even when read outside of the attestation.
-          DIGEST=$(cat artifacts/digest.txt)
-          jq --arg digest "${DIGEST}" '.metadata.component.version = $digest' \
-            artifacts/sbom.cdx.json > artifacts/sbom.cdx.json.tmp
-          mv artifacts/sbom.cdx.json.tmp artifacts/sbom.cdx.json
-
-      - name: Push image
-        id: push
-        run: |
-          IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          DIGEST=$(cat artifacts/digest.txt)
-          podman push ${IMAGE}@${DIGEST}
-
-      - name: Upload image digest and SBOM to artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
-        with:
-          name: artifacts-${{ matrix.arch }}
-          path: artifacts
-          retention-days: 30
-
-  manifest:
-    name: Build multi-architecture manifest
-    runs-on: ubuntu-24.04
-    needs: [build]
-    timeout-minutes: 10
-    permissions:
-      id-token: write
-      packages: write
-
-    steps:
-      - name: Install Podman
-        run: |
-          sudo apt-get update
-          sudo apt-get -y install podman
-
-      - name: Log in to Container Registry
-        run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | podman login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
-
-      - name: Download artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  #v8.0.1
-
-      - name: Pull architecture-specific images
-        run: |
-          IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          podman pull ${IMAGE}@`cat artifacts-amd64/digest.txt`
-          podman pull ${IMAGE}@`cat artifacts-arm64/digest.txt`
-
-      - name: Create and push multi-architecture manifest
-        id: manifests
-        run: |
-          IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          IMAGE_SHA=${IMAGE}:${{ github.sha }}
-          IMAGE_AMD64=${IMAGE}@`cat artifacts-amd64/digest.txt`
-          IMAGE_ARM64=${IMAGE}@`cat artifacts-arm64/digest.txt`
-          VCS_REF="${{ github.sha }}"
-          VCS_URL="${{ github.server_url }}/${{ github.repository }}"
-
-          mkdir artifacts
-          podman manifest create ${IMAGE_SHA}
-          podman manifest add ${IMAGE_SHA} ${IMAGE_AMD64}
-          podman manifest add ${IMAGE_SHA} ${IMAGE_ARM64}
-          podman tag ${IMAGE_SHA} ${IMAGE}:latest ${IMAGE}:${{ github.ref_name }}
-          podman manifest push ${IMAGE}:${{ github.ref_name }} \
-              --digestfile artifacts/digest.txt
-          podman manifest push ${IMAGE}:latest \
-              --digestfile artifacts/digest.txt
-
-      - name: Upload manifest digest to artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
-        with:
-          name: artifacts-manifest
-          path: artifacts
-          retention-days: 30
-
-
-  # This job runs on its own machine, decoupled from the build jobs, so the
-  # signing credentials used here are never exposed to build steps that
-  # compile arbitrary code. That's SLSA Build Level 2 (hosted, signed
-  # provenance) -- reaching Level 3 needs build+attest moved into a
-  # reusable workflow; see docs/SUPPLY_CHAIN_SECURITY.md.
-  # https://slsa.dev/spec/v1.2/build-track-basics
-  attest:
-    name: Attest build provenance
-    runs-on: ubuntu-24.04
-    needs: [manifest]
-    timeout-minutes: 10
-
+  # The actual build/manifest/attest work lives in release-build.yml, called
+  # here as a reusable workflow rather than inlined as jobs in this file.
+  # That split is what gets us SLSA Build Level 3 rather than Level 2: see
+  # release-build.yml's own header comment, and "Build provenance and
+  # attestations" in docs/SUPPLY_CHAIN_SECURITY.md, for why.
+  release:
+    name: Build, package, and attest
     permissions:
       artifact-metadata: write
       attestations: write
+      contents: read
       id-token: write
       packages: write
-
-    steps:
-      - name: Login to Container Registry
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  #v4.6.0
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Download artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  #v8.0.1
-
-      - name: Retrieve digests
-        id: retrieve-digests
-        run: |
-          echo amd64_digest=`cat artifacts-amd64/digest.txt` >> $GITHUB_OUTPUT
-          echo arm64_digest=`cat artifacts-arm64/digest.txt` >> $GITHUB_OUTPUT
-          echo manifest_digest=`cat artifacts-manifest/digest.txt` >> $GITHUB_OUTPUT
-
-      - name: Attest amd64 SBOM
-        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 #v4.2.2
-        with:
-          sbom-path: artifacts-amd64/sbom.cdx.json
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          subject-digest: ${{ steps.retrieve-digests.outputs.amd64_digest }}
-          push-to-registry: true
-
-      - name: Attest arm64 SBOM
-        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 #v4.2.2
-        with:
-          sbom-path: artifacts-arm64/sbom.cdx.json
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          subject-digest: ${{ steps.retrieve-digests.outputs.arm64_digest }}
-          push-to-registry: true
-
-      - name: Attest amd64 container
-        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 #v4.2.2
-        with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          subject-digest: ${{ steps.retrieve-digests.outputs.amd64_digest }}
-          push-to-registry: true
-
-      - name: Attest arm64 container
-        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 #v4.2.2
-        with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          subject-digest: ${{ steps.retrieve-digests.outputs.arm64_digest }}
-          push-to-registry: true
-
-      - name: Attest multi-architecture manifest
-        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 #v4.2.2
-        with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          subject-digest: ${{ steps.retrieve-digests.outputs.manifest_digest }}
-          push-to-registry: true
+    uses: ./.github/workflows/release-build.yml

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -164,6 +164,8 @@ for that walkthrough, which is what `verify-release.sh` automates.
   verification step `cut-release.sh` runs at the end (also usable
   standalone)
 - [`.github/workflows/release.yml`](../.github/workflows/release.yml) —
+  triggers on a pushed tag, calls `release-build.yml`
+- [`.github/workflows/release-build.yml`](../.github/workflows/release-build.yml) —
   build, SBOM, attest
 - [`Containerfile`](../Containerfile) — how the container gets built
 - [`.github/release.yml`](../.github/release.yml) — changelog

--- a/scripts/verify-release.sh
+++ b/scripts/verify-release.sh
@@ -10,6 +10,8 @@
 #   - confirms both a build-provenance and an SBOM attestation exist for
 #     each per-architecture image (see docs/SUPPLY_CHAIN_SECURITY.md for
 #     what these are and why both should exist)
+#   - confirms the provenance was signed by the isolated release-build.yml
+#     workflow, not release.yml itself (SLSA Build Level 3)
 #
 # Usage:
 #   ./scripts/verify-release.sh vX.Y.Z
@@ -80,10 +82,19 @@ ARM64_DIGEST="$(cat "${WORKDIR}/arm64/digest.txt")"
 # ── confirm both attestation types exist for each digest ────────────────────
 # Note: `gh attestation verify`'s default --predicate-type filter only shows
 # build provenance, hiding the SBOM attestation; query the raw API instead.
+#
+# Also confirms the provenance was signed by release-build.yml, not
+# release.yml: that's the actual, checkable evidence that build+attest ran
+# inside the isolated reusable workflow SLSA Build Level 3 requires, rather
+# than just trusting the workflow file's own claim about itself. See
+# "Build provenance and attestations" in docs/SUPPLY_CHAIN_SECURITY.md.
+EXPECTED_BUILDER_PATH=".github/workflows/release-build.yml"
+
 check_attestations() {
   arch="$1"; digest="$2"
-  types="$(gh api "repos/${REPO}/attestations/${digest}" \
-      -q '.attestations[].bundle.dsseEnvelope.payload' \
+  payloads="$(gh api "repos/${REPO}/attestations/${digest}" \
+      -q '.attestations[].bundle.dsseEnvelope.payload')"
+  types="$(echo "$payloads" \
     | while read -r p; do echo "$p" | base64 -d | jq -r .predicateType; done \
     | sort -u)"
   echo "${arch} (${digest}):"
@@ -92,6 +103,17 @@ check_attestations() {
     || { echo "ERROR: missing build-provenance attestation for ${arch}" >&2; exit 1; }
   echo "$types" | grep -qx 'https://cyclonedx.org/bom' \
     || { echo "ERROR: missing SBOM attestation for ${arch}" >&2; exit 1; }
+
+  builder_path="$(echo "$payloads" | while read -r p; do
+      decoded="$(echo "$p" | base64 -d)"
+      if [ "$(echo "$decoded" | jq -r .predicateType)" = "https://slsa.dev/provenance/v1" ]; then
+        echo "$decoded" | jq -r .predicate.buildDefinition.externalParameters.workflow.path
+      fi
+    done)"
+  [ "$builder_path" = "$EXPECTED_BUILDER_PATH" ] \
+    || { echo "ERROR: provenance for ${arch} was signed by workflow" \
+              "'${builder_path}', expected '${EXPECTED_BUILDER_PATH}'." >&2
+         exit 1; }
 }
 
 echo "Checking attestations..."


### PR DESCRIPTION
Follow-up to #601. Per GitHub's own documented compliance bar ([source](https://github.com/github/docs/blob/main/content/actions/how-tos/secure-your-work/use-artifact-attestations/increase-security-rating.md)), `actions/attest` used directly — even isolated into its own job, as we already had — is Build Level 2. Reaching Level 3 specifically requires moving build *and* attestation into a reusable workflow, so the process that generates provenance has a distinct, independently verifiable identity, rather than being just another job in the same maintainer-editable file the build steps live in.

## What changed

- **`release-build.yml`** (new): a reusable workflow (`on: workflow_call`) holding `verify-version`/`build`/`manifest`/`attest` — moved verbatim from `release.yml` (confirmed via `diff` against the old file: only the old attest-job comment was replaced by a new file-header explaining why this file has to stay separate).
- **`release.yml`**: now a thin caller — the tag-push trigger, the `release`/`:latest` concurrency group (unchanged; it governs the whole run regardless of what's inside, so the serialization guarantee against two releases racing on `:latest` still holds), and one job that calls `release-build.yml` with the union of permissions its jobs need.
- **`scripts/verify-release.sh`**: now checks this for real. It reads a real provenance attestation's `predicate.buildDefinition.externalParameters.workflow.path` and fails loudly if it isn't `.github/workflows/release-build.yml` — so every future release run re-verifies the SLSA L3 property empirically, not just by trusting that the file split does what it's supposed to.
- **`docs/RELEASING.md`**: "Where things live" now lists both files.

`docs/SUPPLY_CHAIN_SECURITY.md` is deliberately *not* updated to claim Level 3 in this PR — that's the planned last step, once this has actually been exercised by a real release and `verify-release.sh`'s new check has passed for real.

## Things I verified before relying on them

- **`github` context and `secrets.GITHUB_TOKEN` propagate automatically** to a called reusable workflow without needing `inputs`/`secrets: inherit` — confirmed against GitHub's own reference docs (`reusing-workflow-configurations.md`): *"When a reusable workflow is triggered by a caller workflow, the `github` context is always associated with the caller workflow. The called workflow is automatically granted access to `github.token` and `secrets.GITHUB_TOKEN`."*
- **Permissions only flow down, never up** — confirmed the caller job's `permissions:` block is a superset of every job's needs inside `release-build.yml` (`contents: read`, `id-token: write`, `packages: write`, `attestations: write`, `artifact-metadata: write`).
- **The recorded builder identity actually is the called workflow, not the caller** — pulled a real provenance attestation from the existing v0.6.9 release and inspected its actual JSON shape (`predicate.buildDefinition.externalParameters.workflow.path`, `predicate.runDetails.builder.id`) rather than guessing field names for the new `verify-release.sh` check.
- **`verify-release.sh`'s existing `gh run list --workflow=release.yml`/`gh run download` calls need no changes** — `release.yml` is still the top-level triggered workflow name, and jobs from a called reusable workflow share the same run ID (same run, nested job group in the Actions UI), so run-lookup and artifact download are unaffected by the split.

## Testing

- `actionlint` (workflow + shellcheck) on both new/changed workflow files: identical finding count to the pre-split file (24 pre-existing shellcheck style warnings, none new).
- `diff` of the job bodies between the old `release.yml` and new `release-build.yml`: byte-identical apart from the intentionally replaced header comment.
- Ruby's YAML parser (`YAML.load_file`) on both workflow files: valid.
- `sh -n` on the updated `verify-release.sh`: valid; no `shellcheck` findings.
- **Not yet tested**: an actual tag push through this new structure — that can only be verified by cutting a real release, which I'd suggest doing as the next one. If `verify-release.sh`'s new builder-path check fails, that means the isolation assumption above didn't hold in practice and needs debugging before we can honestly claim L3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)