### PR TITLE
ci: only save the rust-cache target/ cache from main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,13 @@ jobs:
       # release binaries from scratch on purpose, without touching this
       # (or any other) build cache.
       uses: Swatinem/rust-cache@63fed3e2fecf6f7b51dc6f043341b79ef82a9ae7  # v2.9.2
+      with:
+        # GitHub Actions caches are scoped per ref, so PR and merge-queue
+        # runs would otherwise each save their own full (~1 GB) copy of
+        # this cache on top of main's. Only save from main; other refs
+        # still restore main's cache via the usual base-branch fallback,
+        # they just don't pay to re-save a duplicate.
+        save-if: ${{ github.ref == 'refs/heads/main' }}
     - name: Fetch Rust dependencies
       run: cargo fetch --locked
     - name: Check formatting


### PR DESCRIPTION
## What

Restrict the `Swatinem/rust-cache` step to saving only from `refs/heads/main`,
via the action's documented `save-if` input.

## Why

GitHub Actions caches are scoped per ref. Inspecting
`repos/alltheplaces/osm-diffs/actions/caches` after #598 landed showed the
same cache key saved independently from 5 different refs:

```
refs/heads/main
refs/pull/598/merge
refs/heads/gh-readonly-queue/main/pr-598-...
refs/heads/gh-readonly-queue/main/pr-599-...
refs/heads/gh-readonly-queue/main/pr-600-...
```

~1.1 GB each, ~5.4 GB total for what is functionally one cache. Combined
with ~4.1 GB of long-accumulated sccache object entries and (at the time)
~0.57 GB of dead `cargo-registry-*` entries left over from before #598, the
repo's total Actions cache usage was sitting right at the classic 10 GB
quota, which triggers automatic LRU eviction across all cache entries.

PR and merge-queue runs don't need to save their own copy: they still
restore main's cache fine via the action's base-branch fallback (same key
prefix, only the `Cargo.lock`-hash suffix can differ) — this is documented
behavior ("Caches from base branches are available to PRs"). So restricting
the save to `main` keeps the exact same restore-side speed benefit for
every other ref, it just stops writing 4+ redundant copies per day.

Also deleted the stale `cargo-registry-*` entries (dead weight since #598
replaced that mechanism) directly via the cache API — not a code change,
just housekeeping, mentioned here for the record.

Part of #597
