### PR TITLE
verify-release.sh: check runDetails.builder.id, not externalParameters

### DIFF
--- a/scripts/verify-release.sh
+++ b/scripts/verify-release.sh
@@ -83,12 +83,18 @@ ARM64_DIGEST="$(cat "${WORKDIR}/arm64/digest.txt")"
 # Note: `gh attestation verify`'s default --predicate-type filter only shows
 # build provenance, hiding the SBOM attestation; query the raw API instead.
 #
-# Also confirms the provenance was signed by release-build.yml, not
-# release.yml: that's the actual, checkable evidence that build+attest ran
-# inside the isolated reusable workflow SLSA Build Level 3 requires, rather
-# than just trusting the workflow file's own claim about itself. See
-# "Build provenance and attestations" in docs/SUPPLY_CHAIN_SECURITY.md.
-EXPECTED_BUILDER_PATH=".github/workflows/release-build.yml"
+# Also confirms the provenance's *builder* (predicate.runDetails.builder.id)
+# is release-build.yml, not release.yml: that's the actual, checkable
+# evidence that build+attest ran inside the isolated reusable workflow SLSA
+# Build Level 3 requires, rather than just trusting the workflow file's own
+# claim about itself. See "Build provenance and attestations" in
+# docs/SUPPLY_CHAIN_SECURITY.md.
+#
+# Don't use predicate.buildDefinition.externalParameters.workflow.path for
+# this -- that field records the *caller* workflow (release.yml, the one
+# the tag-push event triggered), not who actually signed. Confirmed against
+# a real v0.6.10 attestation before relying on it.
+EXPECTED_BUILDER_ID="https://github.com/${REPO}/.github/workflows/release-build.yml@refs/tags/${TAG}"
 
 check_attestations() {
   arch="$1"; digest="$2"
@@ -104,15 +110,15 @@ check_attestations() {
   echo "$types" | grep -qx 'https://cyclonedx.org/bom' \
     || { echo "ERROR: missing SBOM attestation for ${arch}" >&2; exit 1; }
 
-  builder_path="$(echo "$payloads" | while read -r p; do
+  builder_id="$(echo "$payloads" | while read -r p; do
       decoded="$(echo "$p" | base64 -d)"
       if [ "$(echo "$decoded" | jq -r .predicateType)" = "https://slsa.dev/provenance/v1" ]; then
-        echo "$decoded" | jq -r .predicate.buildDefinition.externalParameters.workflow.path
+        echo "$decoded" | jq -r .predicate.runDetails.builder.id
       fi
     done)"
-  [ "$builder_path" = "$EXPECTED_BUILDER_PATH" ] \
-    || { echo "ERROR: provenance for ${arch} was signed by workflow" \
-              "'${builder_path}', expected '${EXPECTED_BUILDER_PATH}'." >&2
+  [ "$builder_id" = "$EXPECTED_BUILDER_ID" ] \
+    || { echo "ERROR: provenance for ${arch} was signed by builder" \
+              "'${builder_id}', expected '${EXPECTED_BUILDER_ID}'." >&2
          exit 1; }
 }
 


### PR DESCRIPTION
Cut v0.6.10 as the first real test of the `release-build.yml` split (#603) and the new builder check in `verify-release.sh` failed:

```
ERROR: provenance for amd64 was signed by workflow
'.github/workflows/release.yml', expected
'.github/workflows/release-build.yml'.
```

## What actually happened

Pulled the real attestation JSON for v0.6.10 to find out why. Good news: **the split itself works exactly as intended.** `predicate.runDetails.builder.id` correctly says `https://github.com/alltheplaces/osm-diffs/.github/workflows/release-build.yml@refs/tags/v0.6.10` — confirmed identical for the amd64, arm64, and manifest attestations.

The check was just reading the wrong field. `predicate.buildDefinition.externalParameters.workflow.path` records the *caller* workflow that responded to the tag-push event (`release.yml`) — that's correct and expected, it just isn't "who signed this." `predicate.runDetails.builder.id` is the actual SLSA builder identity, and that one does say `release-build.yml`.

## Also checked (per a request to look at the run's warnings)

Two warnings appear in the v0.6.10 run (`WARNING: image platform ... does not match the expected platform` in the manifest job, and `Failed to create storage record` / `artifact-metadata:write` in the attest job). Compared against the pre-split v0.6.9 run: both are byte-identical there too, including the storage-record warning's eventual self-resolving retry-then-succeed pattern. Pre-existing GitHub/podman quirks, unrelated to this migration — no action needed.

## Testing

Ran the fixed script against the real v0.6.10 release (not a synthetic/mocked test):

```
$ ./scripts/verify-release.sh v0.6.10
...
v0.6.10 verified: release.yml succeeded, and both SBOM and build-provenance attestations exist for both architectures.
```

Passes cleanly. This is real, empirical confirmation that `release.yml`/`release-build.yml` (#603) actually achieves SLSA Build Level 3 — not just that the file structure looks right.

## Next

With this confirmed, I'll follow up with the doc update to `docs/SUPPLY_CHAIN_SECURITY.md` claiming Level 3 for real (the step that was deliberately deferred in #603 until this was verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)