### PR TITLE
docs/SUPPLY_CHAIN_SECURITY.md: shorten the SLSA L3 paragraph

### DIFF
--- a/docs/SUPPLY_CHAIN_SECURITY.md
+++ b/docs/SUPPLY_CHAIN_SECURITY.md
@@ -109,19 +109,17 @@ by event E.”
 
 We reach
 [SLSA Build Level 3](https://slsa.dev/spec/v1.2/build-track-basics#build-l3):
-provenance whose builder identity is distinct from, and independently
-verifiable from, whatever triggered the build. `release.yml` only
-triggers on a tag push and calls
-[`release-build.yml`](../.github/workflows/release-build.yml) — a
-[reusable workflow](https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows)
-that does the actual build, manifest, and attest steps. That’s what
-gets recorded as the provenance’s builder
-(`predicate.runDetails.builder.id`), not `release.yml` itself, so an
-attacker who could edit `release.yml` still couldn’t forge what gets
-signed. `verify-release.sh` checks this on every release rather than
-trusting the file layout to keep doing its job: it reads the real
-attestation and fails loudly if the recorded builder ever stops being
-`release-build.yml`.
+whatever triggers a release and whatever signs it have separate,
+independently checkable identities, so compromising `release.yml`
+alone couldn’t forge what gets signed. `release.yml` only triggers on
+a tag push; the actual building and signing happens in a separate
+reusable workflow,
+[`release-build.yml`](../.github/workflows/release-build.yml) — see
+that file and
+[`verify-release.sh`](../scripts/verify-release.sh) for the mechanism,
+and
+[alltheplaces/osm-diffs#608](https://github.com/alltheplaces/osm-diffs/pull/608)
+for this having been checked against a real release, not just assumed.
 
 We use GitHub’s native
 [artifact attestations](https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds)


### PR DESCRIPTION
The L3 paragraph had grown into an implementation walkthrough — `predicate.runDetails.builder.id`, "an attacker who could edit `release.yml`", exactly what `verify-release.sh` checks. That's real information, but this is meant to be a conceptual, high-level doc: a reader new to release engineering doesn't need the field name to get the point, and the mechanism detail was duplicating what `release-build.yml`'s own header comment and `verify-release.sh` already explain at the depth an implementer actually wants.

Cut it down to the concept — build-triggering and signing have separate, independently checkable identities — and linked out for the receipts instead: `release-build.yml` and `verify-release.sh` for the mechanism, #608 for this having been checked against a real release rather than assumed. Matches how the multi-arch nuance a few paragraphs down already links out to #589 rather than explaining inline.

**1230 → 1198 words.**

Scanned the rest of the doc for further cuts too (this was requested as "another round" of shortening), but didn't find flabby prose worth touching elsewhere — the other sections already went through this same tightening pass in #596, and forcing more cuts there risked losing clarity for no real word-count gain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)