### PR TITLE
test-container.yml: fix shellcheck warnings reported by actionlint

### DIFF
--- a/.github/workflows/test-container.yml
+++ b/.github/workflows/test-container.yml
@@ -37,10 +37,10 @@ jobs:
       run: |
           mkdir artifacts
           podman build -t test-container  \
-              --build-arg BUILD_TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")  \
-              --volume $(pwd)/artifacts:/artifacts                          \
+              --build-arg BUILD_TIMESTAMP="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"  \
+              --volume "$(pwd)/artifacts:/artifacts"                          \
               -f Containerfile .
     - name: Validate SBOM
       run: |
-          podman run --volume $(pwd)/artifacts:/artifacts:ro cyclonedx/cyclonedx-cli \
+          podman run --volume "$(pwd)/artifacts:/artifacts:ro" cyclonedx/cyclonedx-cli \
               validate --input-file /artifacts/sbom.cdx.json --fail-on-errors


### PR DESCRIPTION
Fixes the 3 remaining `shellcheck` findings that `actionlint` reports for `.github/workflows/test-container.yml` (out of scope for #604, which was limited to `release-build.yml`, fixed separately in #612).

- **SC2046** (×3) — unquoted `$(...)` command substitutions that risk word splitting:
  - `--build-arg BUILD_TIMESTAMP=$(date ...)` and `--volume $(pwd)/...` in the "Build container" step
  - `--volume $(pwd)/...` in the "Validate SBOM" step

Verified locally:
```
$ actionlint .github/workflows/test-container.yml
$ echo $?
0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)