### PR TITLE
docs/RELEASING.md: fix release.yml/release-build.yml split after #603

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -68,7 +68,13 @@ Once you run `cut-release.sh vX.Y.Z`:
    [`SUPPLY_CHAIN_SECURITY.md`](SUPPLY_CHAIN_SECURITY.md#immutable-releases)).
 5. **That tag push triggers
    [`.github/workflows/release.yml`](../.github/workflows/release.yml)**,
-   entirely independently of the script:
+   entirely independently of the script. `release.yml` itself is just a
+   thin caller: it hands off to
+   [`.github/workflows/release-build.yml`](../.github/workflows/release-build.yml)
+   as a reusable workflow — a separate file with its own identity is what
+   gets this to SLSA Build Level 3 rather than Level 2 (see
+   [`SUPPLY_CHAIN_SECURITY.md`](SUPPLY_CHAIN_SECURITY.md#build-provenance-and-attestations)).
+   The called workflow runs:
    - `verify-version`: re-checks the tag matches `Cargo.toml`’s version
      (a server-side safety net — this should never fail if you used the
      script, since the script only ever tags a version it just set).


### PR DESCRIPTION
## What changed

Step 5 of the "What happens automatically" walk-through still described
`verify-version`/`build`/`manifest`/`attest` as jobs living directly in
`release.yml`. Since #603 split the release pipeline into a thin caller
(`release.yml`) plus a reusable workflow (`release-build.yml`) to reach SLSA
Build Level 3, those jobs actually run in `release-build.yml`, invoked via
`workflow_call`. #603 updated the "Where things live" list but missed this
earlier section, so the two parts of the doc contradicted each other.

## Testing

Read through the rest of `docs/RELEASING.md` against the current
`release.yml`/`release-build.yml` job structure, and cross-checked the
"Known gaps" issue references (#555/#556/#588/#589) — all still open and
accurately described, no other changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)