### PR TITLE
pipeline: log a memory snapshot at the start/end of each step

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,6 @@ mod coverage;
 mod geometry;
 mod logging;
 mod matchers;
-// Not yet wired into the pipeline; see #616.
-#[allow(unused)]
 mod memstats;
 mod pipeline;
 mod places;

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -16,25 +16,51 @@ pub fn run_pipeline(http_client: &reqwest::Client, workdir: &Path) -> Result<()>
 
     geostats::init()?;
     let progress = indicatif::MultiProgress::new();
-    let atp = tokio::runtime::Builder::new_multi_thread()
+    let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
-        .build()?
-        .block_on(crate::atp::import_atp(http_client, &progress, workdir))?;
-    let coverage = crate::coverage::build_coverage(&atp, &progress, workdir)?;
-    let (osm_parquet, osm_store) = osm::import_osm(&coverage, &progress, workdir)?;
-    let _conflated = conflate::conflate(
-        &atp,
-        &coverage,
-        &osm_parquet,
-        &*osm_store,
-        &progress,
-        workdir,
-    )?;
-    let edits = edits::suggest_edits(&coverage, &atp, &osm_parquet, &progress, workdir)?;
-    let tiles = tiles::render_tiles(&edits, &progress, workdir)?;
-    upload::upload_tiles(&tiles, &progress)?;
+        .build()?;
+    let atp = run_step("import_atp", || {
+        runtime.block_on(crate::atp::import_atp(http_client, &progress, workdir))
+    })?;
+    let coverage = run_step("build_coverage", || {
+        crate::coverage::build_coverage(&atp, &progress, workdir)
+    })?;
+    let (osm_parquet, osm_store) = run_step("import_osm", || {
+        osm::import_osm(&coverage, &progress, workdir)
+    })?;
+    let _conflated = run_step("conflate", || {
+        conflate::conflate(
+            &atp,
+            &coverage,
+            &osm_parquet,
+            &*osm_store,
+            &progress,
+            workdir,
+        )
+    })?;
+    let edits = run_step("suggest_edits", || {
+        edits::suggest_edits(&coverage, &atp, &osm_parquet, &progress, workdir)
+    })?;
+    let tiles = run_step("render_tiles", || {
+        tiles::render_tiles(&edits, &progress, workdir)
+    })?;
+    run_step("upload_tiles", || upload::upload_tiles(&tiles, &progress))?;
 
     Ok(())
+}
+
+/// Runs one top-level pipeline step, logging a [`crate::memstats`]
+/// snapshot before and after it -- to help diagnose out-of-memory kills
+/// and resource misconfigurations, since each step here (import, build
+/// tables, conflate, ...) tends to be where a memory blowup would show
+/// up first. Logging happens whether the step succeeds or fails, so a
+/// step that errors out (e.g. due to an actual OOM) still gets its
+/// "end" snapshot on the way out.
+fn run_step<T>(name: &str, step: impl FnOnce() -> Result<T>) -> Result<T> {
+    log::info!("{name}: start {}", crate::memstats::snapshot());
+    let result = step();
+    log::info!("{name}: end {}", crate::memstats::snapshot());
+    result
 }
 
 /// Returns the highest (most recent) last modification time among all paths.
@@ -89,5 +115,18 @@ mod tests {
         assert_eq!(last_modified(&[f7.path(), f2.path(), f0.path()])?, t7);
 
         Ok(())
+    }
+
+    #[test]
+    fn test_run_step_returns_the_closures_value() -> Result<()> {
+        let value = run_step("test-step", || Ok(42))?;
+        assert_eq!(value, 42);
+        Ok(())
+    }
+
+    #[test]
+    fn test_run_step_propagates_the_closures_error() {
+        let result: Result<()> = run_step("test-step", || anyhow::bail!("boom"));
+        assert!(result.is_err());
     }
 }


### PR DESCRIPTION
Part of #616. Stacked on #617 -- this PR only makes sense once that one
lands; the diff here is against `add-memstats-module`, not `main`.

Wraps each of the 7 top-level steps in `run_pipeline()` with a small
`run_step()` helper that logs a `crate::memstats::snapshot()` before and
after -- on both success and failure, so a step that errors out (e.g. an
actual OOM) still gets its "end" snapshot on the way out.

Verified end-to-end against the real binary using the existing
integration test's fixtures, e.g.:

```
import_atp: start rss_peak_bytes=14680064
import_atp: end rss_peak_bytes=32817152
build_coverage: start rss_peak_bytes=32817152
build_coverage: end rss_peak_bytes=35766272
...
```

(On this macOS dev machine only `rss_peak_bytes` is populated; in the
Linux/OCI production container the `rss_*`/`cgroup_*` breakdown from
`/proc` and `/sys/fs/cgroup` would show up too.)

Ran locally: `cargo fmt --check`, `cargo build --locked`, `cargo test
--locked` (207 tests, all pass, including the pre-existing end-to-end
`test_pipeline` integration test), `cargo clippy --all-targets -- -D
warnings` -- all clean.