### PR TITLE
logging: support structured key-value fields in the JSON logger

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ geo-traits = { version = "0.3.0", default-features = false }
 geojson = "1.0.0"
 indicatif = { version = "0.18.4", default-features = false }
 librqbit = { version = "8.1.1", default-features = false, features = ["disable-upload", "rust-tls"] }
-log = { version = "0.4.32", default-features = false }
+log = { version = "0.4.32", default-features = false, features = ["kv"] }
 lru = { version = "0.18.0", default-features = false }
 lz4_flex = "0.14.0"
 memmap2 = "0.9.10"

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -8,12 +8,22 @@
 //! logged it, and its `message` can be grepped for or parsed without
 //! worrying about how a human-oriented formatter might wrap or color it.
 //!
-//! This is a first skeleton. It doesn't yet thread per-call structured
-//! fields (e.g. a relation id) through the `log` crate's key-value API --
-//! for now, such details go into the message text (see
+//! Call sites that have actual structured data to log (numbers, an id,
+//! ...) rather than just a message should attach it via the `log`
+//! crate's key-value API instead of interpolating it into the message
+//! text, e.g.:
+//!
+//! ```ignore
+//! log::info!(step = "import_atp", elapsed_seconds = 12.3; "import_atp: end");
+//! ```
+//!
+//! [`format_json`] renders those as a `"fields"` object alongside the
+//! usual `timestamp`/`level`/`target`/`message`, omitted entirely for
+//! records that don't attach any -- so plain `log::info!("some
+//! message")` call sites (most of them, as of this writing; see e.g.
 //! `pipeline::osm::assemble`, which logs failures as e.g.
-//! "relation/12345"). RUST_LOG still controls the level as usual, default
-//! `info`.
+//! "relation/12345" in the message text) keep working unchanged.
+//! RUST_LOG still controls the level as usual, default `info`.
 
 use anyhow::{Context, Result};
 use std::{fs::OpenOptions, io::Write, path::Path};
@@ -53,13 +63,94 @@ fn format_json(buf: &mut env_logger::fmt::Formatter, record: &log::Record) -> st
     let timestamp = OffsetDateTime::now_utc()
         .format(&Rfc3339)
         .unwrap_or_default();
-    let entry = serde_json::json!({
+    let mut entry = serde_json::json!({
         "timestamp": timestamp,
         "level": record.level().as_str(),
         "target": record.target(),
         "message": record.args().to_string(),
     });
+    let fields = key_values_to_json(record.key_values());
+    if !fields.is_empty() {
+        entry["fields"] = fields.into();
+    }
     writeln!(buf, "{}", entry)
+}
+
+/// Converts a `log` record's key-value pairs (attached via the `log`
+/// crate's key-value API, e.g. `log::info!(step = "import_atp"; "...")`)
+/// into a JSON object. Uses [`log::kv::Value::visit`] rather than the
+/// `kv_serde` feature: the handful of value types actually passed at
+/// call sites in this crate (`u64`, `f64`, `&str`, `bool`, and `Option`
+/// of those) are covered by [`log::kv::VisitValue`]'s primitive methods
+/// directly, without pulling in `serde` as a `log` feature just for
+/// this.
+fn key_values_to_json(source: &dyn log::kv::Source) -> serde_json::Map<String, serde_json::Value> {
+    struct Visitor(serde_json::Map<String, serde_json::Value>);
+
+    impl<'kvs> log::kv::VisitSource<'kvs> for Visitor {
+        fn visit_pair(
+            &mut self,
+            key: log::kv::Key<'kvs>,
+            value: log::kv::Value<'kvs>,
+        ) -> Result<(), log::kv::Error> {
+            self.0.insert(key.to_string(), value_to_json(&value));
+            Ok(())
+        }
+    }
+
+    let mut visitor = Visitor(serde_json::Map::new());
+    // A `Source`/`Value` only fails to visit if the visitor itself
+    // returns an error, which ours never does.
+    let _ = source.visit(&mut visitor);
+    visitor.0
+}
+
+/// Converts a single `log::kv::Value` into JSON. A value this crate
+/// never attaches (a captured error, a `Debug`-only type, ...) falls
+/// back to its text representation via `visit_any`, rather than being
+/// dropped.
+fn value_to_json(value: &log::kv::Value) -> serde_json::Value {
+    struct Visitor(serde_json::Value);
+
+    impl<'v> log::kv::VisitValue<'v> for Visitor {
+        fn visit_any(&mut self, value: log::kv::Value) -> Result<(), log::kv::Error> {
+            self.0 = value.to_string().into();
+            Ok(())
+        }
+        fn visit_null(&mut self) -> Result<(), log::kv::Error> {
+            self.0 = serde_json::Value::Null;
+            Ok(())
+        }
+        fn visit_u64(&mut self, value: u64) -> Result<(), log::kv::Error> {
+            self.0 = value.into();
+            Ok(())
+        }
+        fn visit_i64(&mut self, value: i64) -> Result<(), log::kv::Error> {
+            self.0 = value.into();
+            Ok(())
+        }
+        fn visit_f64(&mut self, value: f64) -> Result<(), log::kv::Error> {
+            // A non-finite float (NaN, +-inf) has no JSON representation;
+            // fall back to null rather than silently dropping the field
+            // or failing the whole log record.
+            self.0 = serde_json::Number::from_f64(value)
+                .map(serde_json::Value::Number)
+                .unwrap_or(serde_json::Value::Null);
+            Ok(())
+        }
+        fn visit_bool(&mut self, value: bool) -> Result<(), log::kv::Error> {
+            self.0 = value.into();
+            Ok(())
+        }
+        fn visit_borrowed_str(&mut self, value: &'v str) -> Result<(), log::kv::Error> {
+            self.0 = value.into();
+            Ok(())
+        }
+    }
+
+    let mut visitor = Visitor(serde_json::Value::Null);
+    let _ = value.visit(&mut visitor);
+    visitor.0
 }
 
 #[cfg(test)]
@@ -81,6 +172,15 @@ mod tests {
         let dir = tempfile::tempdir()?;
         init(dir.path())?;
         log::warn!("something worth noting: {}", "relation/12345");
+        log::info!(
+            step = "import_atp",
+            elapsed_seconds = 12.5,
+            attempt = 3u64,
+            ok = true;
+            "structured fields test"
+        );
+        let missing_rss_bytes: Option<u64> = None;
+        log::info!(rss_bytes = missing_rss_bytes; "optional field test");
 
         let contents = std::fs::read_to_string(dir.path().join(LOG_FILE_NAME))?;
         let records: Vec<serde_json::Value> = contents
@@ -107,6 +207,30 @@ mod tests {
             .find(|r| r["target"] == module_path!() && r["level"] == "WARN")
             .with_context(|| format!("no warn record found among: {records:?}"))?;
         assert!(warn["message"].as_str().unwrap().contains("relation/12345"));
+        assert!(
+            warn.get("fields").is_none(),
+            "a record logged without any key-value pairs shouldn't get a \"fields\" key: {warn}"
+        );
+
+        let structured = records
+            .iter()
+            .find(|r| r["message"] == "structured fields test")
+            .with_context(|| format!("no structured-fields record found among: {records:?}"))?;
+        assert_eq!(structured["fields"]["step"], "import_atp");
+        assert_eq!(structured["fields"]["elapsed_seconds"], 12.5);
+        assert_eq!(structured["fields"]["attempt"], 3);
+        assert_eq!(structured["fields"]["ok"], true);
+
+        let optional = records
+            .iter()
+            .find(|r| r["message"] == "optional field test")
+            .with_context(|| format!("no optional-field record found among: {records:?}"))?;
+        assert_eq!(
+            optional["fields"]["rss_bytes"],
+            serde_json::Value::Null,
+            "an absent Option field should serialize as an explicit null, \
+             not be silently dropped: {optional}"
+        );
 
         Ok(())
     }


### PR DESCRIPTION
Part of #621.

Enables `log`'s `kv` feature and extends `format_json` to render a
record's `key_values()` into a `"fields"` JSON object, via a small
`VisitSource`/`VisitValue` adapter. Deliberately not the `kv_serde`
feature (and the `serde` dependency on `log` that comes with it): the
value types actually needed (`u64`, `f64`, `&str`, `bool`, and `Option`
of those) are already covered by `VisitValue`'s primitive methods
directly.

Purely additive: records that don't attach any key-value pairs -- every
existing `log::info!`/`log::warn!` call site elsewhere in the crate,
unchanged -- get no `"fields"` key at all. An absent `Option` field
serializes as an explicit JSON `null` at a fixed key rather than being
omitted, which is more useful for a structured consumer (`jq`, a log
aggregator) than a variably-shaped object; both this and a
str/u64/f64/bool round-trip are covered in the extended test.

This PR is the mechanism only -- it deliberately doesn't retrofit
existing message-text call sites elsewhere in the codebase. The next PR
in this stack (#621) uses it for per-step elapsed time and switches the
pipeline's memory-snapshot logging over to it.

Ran locally: `cargo fmt --check`, `cargo build --locked`, `cargo test
--locked` (211 tests, all pass), `cargo clippy --all-targets -- -D
warnings` -- all clean.