### PR TITLE
Extract shared sorted-u64-key lookup into src/tables/sorted_u64_index.rs

### DIFF
--- a/src/tables/blob_table.rs
+++ b/src/tables/blob_table.rs
@@ -125,14 +125,10 @@ impl<'a> BlobTable<'a> {
     }
 
     pub fn lookup(&self, key: u64) -> Option<&'a [u8]> {
-        let idx = self.keys.partition_point(|&k| u64::from_le(k) < key);
-        if idx < self.keys.len() && u64::from_le(self.keys[idx]) == key {
-            let start = u64::from_le(self.starts[idx]) as usize;
-            let end = u64::from_le(self.starts[idx + 1]) as usize;
-            Some(&self.blob[start..end])
-        } else {
-            None
-        }
+        let idx = super::sorted_u64_index::search(self.keys, key)?;
+        let start = u64::from_le(self.starts[idx]) as usize;
+        let end = u64::from_le(self.starts[idx + 1]) as usize;
+        Some(&self.blob[start..end])
     }
 
     pub fn len(&self) -> usize {
@@ -200,7 +196,8 @@ impl Writer {
     }
 
     /// Appends `blob` under `key`. Keys must be written in strictly
-    /// ascending order, so that [BlobTable::lookup] can binary-search them.
+    /// ascending order, so that [BlobTable::lookup] can search them via
+    /// [super::sorted_u64_index].
     pub fn write(&mut self, key: u64, blob: &[u8]) -> Result<()> {
         if let Some(last_key) = self.last_key
             && key <= last_key

--- a/src/tables/coord_table.rs
+++ b/src/tables/coord_table.rs
@@ -50,9 +50,10 @@ const FILE_SIGNATURE: &[u8; 8] = b"coords_0";
 ///
 /// The table is built once with [CoordTable::create] and then reopened
 /// with [CoordTable::open], possibly by a different process. Keys must be
-/// unique and are looked up with [CoordTable::get] via binary search, so
-/// lookups are `O(log n)` and touch only the pages that are actually
-/// needed, rather than requiring the whole table to be resident in RAM.
+/// unique and are looked up with [CoordTable::get] via
+/// [super::sorted_u64_index], so lookups touch only the pages that are
+/// actually needed, rather than requiring the whole table to be resident
+/// in RAM.
 pub struct CoordTable<'a> {
     file: File,
     _mmap: Mmap,
@@ -151,16 +152,12 @@ impl<'a> CoordTable<'a> {
 
     /// Returns the coordinate stored for `key`, or `None` if `key` is absent.
     pub fn get(&self, key: u64) -> Option<Coord> {
-        let idx = self.keys.partition_point(|&k| u64::from_le(k) < key);
-        if idx < self.keys.len() && self.keys[idx] == key {
-            let val = u64::from_le(self.coords[idx]);
-            Some(Coord {
-                x: (((val >> 32) as i32) as f64) * 1e-7,
-                y: ((val as i32) as f64) * 1e-7,
-            })
-        } else {
-            None
-        }
+        let idx = super::sorted_u64_index::search(self.keys, key)?;
+        let val = u64::from_le(self.coords[idx]);
+        Some(Coord {
+            x: (((val >> 32) as i32) as f64) * 1e-7,
+            y: ((val as i32) as f64) * 1e-7,
+        })
     }
 
     /// Returns the number of entries in the table.

--- a/src/tables/mod.rs
+++ b/src/tables/mod.rs
@@ -14,6 +14,7 @@ mod geometry_table;
 mod graph;
 #[allow(unused)]
 mod records;
+mod sorted_u64_index;
 mod string_counts;
 mod string_pool;
 mod u64_set;

--- a/src/tables/sorted_u64_index.rs
+++ b/src/tables/sorted_u64_index.rs
@@ -1,0 +1,88 @@
+//! Search over the sorted `u64` key arrays shared by [BlobTable](crate::tables::BlobTable),
+//! [CoordTable](crate::tables::CoordTable), and [U64Set](crate::tables::U64Set).
+//!
+//! All three tables store their keys as a sorted, mmap'd, little-endian
+//! `&[u64]` slice and look them up the same way; this module holds that
+//! shared logic once instead of three times.
+//!
+//! An interpolation-search variant was prototyped here, on the theory
+//! that OSM object IDs are mostly contiguous (gaps come only from
+//! deletions) and so a position guess should converge faster than plain
+//! binary search. A benchmark against a real mmap'd file (not a
+//! heap-allocated `Vec`, which can hide the page-touch cost this was
+//! meant to avoid) didn't back that up: once the backing pages are
+//! resident, interpolation search's extra per-probe arithmetic
+//! consistently cost more than the fewer probes saved. It might still
+//! win when a table's working set doesn't fit in RAM and lookups are
+//! genuinely page-fault-bound, but that wasn't validated, so plain binary
+//! search is what's here. See
+//! <https://github.com/alltheplaces/osm-diffs/issues/620> for the
+//! benchmark and discussion.
+
+/// Returns the index of `key` in `keys`, or `None` if it is absent.
+///
+/// `keys` must be sorted in ascending order and stored as little-endian
+/// `u64`s, as they are on the mmap'd pages backing `BlobTable`,
+/// `CoordTable`, and `U64Set` — this function byte-swaps on read via
+/// [u64::from_le], so it does not require the keys to already be in
+/// native byte order.
+pub fn search(keys: &[u64], key: u64) -> Option<usize> {
+    let idx = keys.partition_point(|&k| u64::from_le(k) < key);
+    (idx < keys.len() && u64::from_le(keys[idx]) == key).then_some(idx)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn le(keys: &[u64]) -> Vec<u64> {
+        keys.iter().map(|&k| k.to_le()).collect()
+    }
+
+    #[test]
+    fn empty() {
+        assert_eq!(search(&[], 0), None);
+    }
+
+    #[test]
+    fn singleton() {
+        let keys = le(&[42]);
+        assert_eq!(search(&keys, 41), None);
+        assert_eq!(search(&keys, 42), Some(0));
+        assert_eq!(search(&keys, 43), None);
+    }
+
+    #[test]
+    fn dense_contiguous_keys() {
+        let dense: Vec<u64> = (100..100_000).collect();
+        let keys = le(&dense);
+        assert_eq!(search(&keys, 99), None);
+        assert_eq!(search(&keys, 100), Some(0));
+        assert_eq!(search(&keys, 5_000), Some(4_900));
+        assert_eq!(search(&keys, 99_999), Some(99_899));
+        assert_eq!(search(&keys, 100_000), None);
+    }
+
+    #[test]
+    fn sparse_keys_with_gaps() {
+        // Roughly OSM-like: mostly contiguous, with a few deleted IDs.
+        let sparse: Vec<u64> = (0..10_000).filter(|n| n % 7 != 0 && n % 13 != 0).collect();
+        let keys = le(&sparse);
+        for (idx, &k) in sparse.iter().enumerate() {
+            assert_eq!(search(&keys, k), Some(idx));
+        }
+        // Deleted IDs must be reported absent, not aliased to a neighbor.
+        assert_eq!(search(&keys, 7), None);
+        assert_eq!(search(&keys, 13), None);
+        assert_eq!(search(&keys, 91), None); // 7 * 13
+    }
+
+    #[test]
+    fn out_of_range_keys() {
+        let keys = le(&[10, 20, 30]);
+        assert_eq!(search(&keys, 0), None);
+        assert_eq!(search(&keys, 9), None);
+        assert_eq!(search(&keys, 31), None);
+        assert_eq!(search(&keys, u64::MAX), None);
+    }
+}

--- a/src/tables/u64_set.rs
+++ b/src/tables/u64_set.rs
@@ -5,11 +5,9 @@
 //! set of all OpenStreetMap nodes that are members of ways whose tags
 //! indicate potential conflation candidates.
 //!
-//! Containment test ([U64Set::contains]) is currently implemented as a
-//! regular binary search. To make it faster, we could use hashing or
-//! Cache-Sensitive Skip Lists. However, this would complicate the code,
-//! so let’s keep it simple as long as we don’t have an actual performance
-//! problem.
+//! Containment test ([U64Set::contains]) is implemented via
+//! [super::sorted_u64_index], shared with [crate::tables::BlobTable] and
+//! [crate::tables::CoordTable], which do the same kind of lookup.
 //!
 //! # File format
 //!
@@ -99,11 +97,7 @@ impl U64Set {
             std::slice::from_raw_parts(ptr, self.entries_count)
         };
 
-        if cfg!(target_endian = "little") {
-            slice.binary_search(&n).is_ok()
-        } else {
-            slice.binary_search_by(|x| x.swap_bytes().cmp(&n)).is_ok()
-        }
+        super::sorted_u64_index::search(slice, n).is_some()
     }
 
     /// Returns the number of elements in the set.


### PR DESCRIPTION
## What

`BlobTable::lookup`, `CoordTable::get`, and `U64Set::contains` each duplicated the same binary search over a sorted, mmap'd, little-endian `&[u64]` slice. This pulls that logic into one shared `src/tables/sorted_u64_index.rs::search`, used by all three. No behavior or performance change.

## Why

Prompted by looking into whether `CoordTable` (286.7M entries on a full planet import) would benefit from a faster lookup than binary search, given OSM node IDs are mostly contiguous. I prototyped a guarded interpolation search, but a benchmark against a real mmap'd file (not a heap `Vec`, which turned out to hide the effect) showed it was consistently ~33–35% slower than binary search once the backing pages were cache-resident — true for nearly every run. Full writeup and numbers in #620, which I'm closing as not pursued for now.

What's left from that investigation is this dedup, which stands on its own.

## Testing

- `cargo test` (unit + integration + doctests): all pass
- `cargo clippy --lib --tests --all-targets`: clean
- `cargo fmt --check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
