### PR TITLE
ci: Fix git commit hash for Swatinem/rust-cache

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
       # This cache only ever feeds this test workflow. release.yml builds
       # release binaries from scratch on purpose, without touching this
       # (or any other) build cache.
-      uses: Swatinem/rust-cache@63fed3e2fecf6f7b51dc6f043341b79ef82a9ae7  # v2.9.2
+      uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
       with:
         # GitHub Actions caches are scoped per ref, so PR and merge-queue
         # runs would otherwise each save their own full (~1 GB) copy of


### PR DESCRIPTION
Before this change, the commit hash did not match the version tag.