### PR TITLE
Add centroid_s2_cell_id spatial sort key to FeatureToIndex

### DIFF
--- a/src/pipeline/osm/assemble.rs
+++ b/src/pipeline/osm/assemble.rs
@@ -170,7 +170,7 @@ fn assemble_nodes(
                         if let Some(feature) = &mut fti.feature {
                             write_point(&mut feature.geometry_wkb, &point, &WKB_WRITE_OPTIONS)?;
                         }
-                        assemble_geometry(&Geometry::Point(point), &mut fti.s2_cell_id);
+                        assemble_geometry(&Geometry::Point(point), &mut fti);
                         if assemble_tags(node.tags.iter().cloned(), strings, &mut fti) {
                             feature_tx.send(fti.encode_to_vec())?;
                         }
@@ -303,7 +303,7 @@ fn assemble_ways<'a>(
                         }
 
                         if is_interesting && assemble_tags(way.tags(), strings, &mut fti) {
-                            assemble_geometry(&geometry, &mut fti.s2_cell_id);
+                            assemble_geometry(&geometry, &mut fti);
                             feature_tx.send(fti.encode_to_vec())?;
                         }
                     }
@@ -469,7 +469,7 @@ fn assemble_leaf_relations<'a>(
                         }
 
                         if is_interesting && got_tags {
-                            assemble_geometry(&geometry, &mut fti.s2_cell_id);
+                            assemble_geometry(&geometry, &mut fti);
                             feature_tx.send(fti.encode_to_vec())?;
                         }
                     }
@@ -613,12 +613,10 @@ fn assemble_super_relations(
                 // the parents.
                 geometry_store.insert(rel_id, &rel_geometry)?;
 
-                // Modify fti: Store rel_geometry, s2 cells.
-                // TODO: Also store the s2 cell of the centroid (for sort key), once
-                // we look at that part of the TODO in a later change.
+                // Modify fti: store rel_geometry, s2 cells, and the centroid sort key.
                 let feature = fti.feature.as_mut().expect("feature");
                 write_geometry(&mut feature.geometry_wkb, &rel_geometry, &WKB_WRITE_OPTIONS)?;
-                assemble_geometry(&rel_geometry, &mut fti.s2_cell_id);
+                assemble_geometry(&rel_geometry, &mut fti);
                 feature_tx.send(fti.encode_to_vec())?;
             }
             drop(feature_tx);
@@ -669,7 +667,16 @@ fn assemble_feature(id: u64, info: &Option<osm_pbf_iter::info::Info<'_>>) -> Fea
 // as it may seem; when looking for OpenStreetMap features near an AllThePlaces
 // feature, we construct an S2 cap (search circle) for several hundred meters
 // to a few kilometers depending on the tags in ATP.
-fn assemble_geometry(g: &Geometry, s2_cell_ids: &mut Vec<u64>) {
+//
+// Also sets `fti.centroid_s2_cell_id`, the spatial sort key, from the same
+// centroid computation used below for geometry kinds that don't already
+// compute one of their own (Point, MultiPoint, LineString, ...) -- so
+// callers get both in one pass over the geometry.
+fn assemble_geometry(g: &Geometry, fti: &mut FeatureToIndex) {
+    let centroid = g.centroid();
+    fti.centroid_s2_cell_id = centroid.map_or(0, |c| s2_cell_id_for_point(&c).0);
+
+    let s2_cell_ids = &mut fti.coverage_s2_cell_id;
     s2_cell_ids.clear();
     match g {
         Geometry::Point(p) => {
@@ -722,7 +729,7 @@ fn assemble_geometry(g: &Geometry, s2_cell_ids: &mut Vec<u64>) {
         }
 
         _ => {
-            if let Some(centroid) = g.centroid() {
+            if let Some(centroid) = centroid {
                 s2_cell_ids.reserve(1);
                 s2_cell_ids.push(s2_cell_id_for_point(&centroid).0);
             };

--- a/src/tables/feature.proto
+++ b/src/tables/feature.proto
@@ -43,7 +43,7 @@ message FeatureToIndex {
 
     // A set of S2 cell IDs that cover the geometry of the indexed feature,
     // for approximate spatial matching. Unlike `centroid_s2_cell_id`, this
-    // isn't a single point and isn't meant for sorting.
+    // isn't necessarily a single point and isn't meant for sorting.
     repeated uint64 coverage_s2_cell_id = 4;
 
     // Here would be a good place to store supplemental information

--- a/src/tables/feature.proto
+++ b/src/tables/feature.proto
@@ -24,17 +24,27 @@ message RelationMember {
   uint64 id = 2;
 }
 
-// An OpenStreetMap feature to be indexed.
+// An OpenStreetMap feature to be indexed. This is an internal, ephemeral
+// data structure: it only ever lives in files under the pipeline's scratch
+// working directory, and is never sent over the wire or stored long-term.
+// Field numbers are free to be renumbered as the message evolves.
 message FeatureToIndex {
+    // S2 cell ID of the feature geometry's centroid. Numerically sorting by
+    // this key clusters spatially nearby features together, since S2 cell
+    // IDs are ordered along a Hilbert curve.
+    fixed64 centroid_s2_cell_id = 1;
+
     // The OpenStreetMap feature to index.
-    Feature feature = 1;
+    Feature feature = 2;
 
     // A bitmask to quickly skip over features that cannot possibly match
     // the query feature. See matchers::MatchMask.
-    uint32 match_mask = 2;
+    uint32 match_mask = 3;
 
-    // A set of S2 cell IDs that cover the geometry of the indexed feature.
-    repeated uint64 s2_cell_id = 3;
+    // A set of S2 cell IDs that cover the geometry of the indexed feature,
+    // for approximate spatial matching. Unlike `centroid_s2_cell_id`, this
+    // isn't a single point and isn't meant for sorting.
+    repeated uint64 coverage_s2_cell_id = 4;
 
     // Here would be a good place to store supplemental information
     // that is needed to find the closest match in OpenStreetMap


### PR DESCRIPTION
## What

Adds `fixed64 centroid_s2_cell_id` to `FeatureToIndex`: the S2 cell ID of the feature geometry's centroid. Sorting numerically by this key clusters spatially nearby features together, since S2 cell IDs are ordered along a Hilbert curve — this is the sort key we'll use to spatially sort the index.

## Details

- `FeatureToIndex` is purely internal/ephemeral (only ever lives under the pipeline's scratch working directory, never sent over the wire or stored long-term), so all fields were renumbered starting from 1 instead of appending the new field at the end.
- `assemble_geometry()` now takes `&mut FeatureToIndex` instead of `&mut Vec<u64>`, and derives `centroid_s2_cell_id` from the same centroid computation already needed for some geometry kinds — so all four call sites (nodes, ways, leaf relations, super relations) get both the new sort key and the existing coverage cell IDs in a single pass, no redundant centroid computation. This also resolves the `TODO: also store the s2 cell of the centroid` left in the super-relations path.
- Renamed the existing `repeated uint64 s2_cell_id` field to `coverage_s2_cell_id`: next to `centroid_s2_cell_id`, the old name no longer said what it actually holds — an approximate covering set of cells for spatial matching, not a single sort key.

## Testing

- `cargo test --lib`: 217 passed.
- `cargo fmt --check` / `cargo clippy --all-targets`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)