### PR TITLE
Add Documentation category to auto-generated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -11,6 +11,9 @@ changelog:
     - title: 🔗 Dependencies
       labels:
         - dependencies
+    - title: 📚 Documentation
+      labels:
+        - documentation
     - title: 🚧 Maintenance
       labels:
         - '*'
@@ -18,4 +21,5 @@ changelog:
         labels:
           - bug
           - dependencies
+          - documentation
           - enhancement


### PR DESCRIPTION
## Summary
- Add a 📚 Documentation section to `.github/release.yml`, grouping PRs labeled `documentation`.
- Exclude the `documentation` label from the catch-all 🚧 Maintenance bucket so those PRs aren't listed twice.

We already use a `documentation` label on issues/PRs but it wasn't yet reflected in the release notes categorization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)