### PR TITLE
Capture and log AllThePlaces run provenance metadata

### DIFF
--- a/src/atp/fetch.rs
+++ b/src/atp/fetch.rs
@@ -148,11 +148,12 @@ async fn download_atp(
     Ok(metadata)
 }
 
-/// Queries `history_url` (`history.json`) and returns the metadata for the
-/// most recent run that's both complete and passes a basic sanity check
-/// (see [`MIN_SPIDERS`] and friends), as long as it isn't older than
-/// [`MAX_STALENESS`]. `history.json` entries are assumed to be listed
-/// oldest-first, as AllThePlaces does today, so we scan from the end.
+/// Queries `history_url` (`history.json`) and returns the metadata for
+/// whichever entry has the latest `start_time` among those that are both
+/// complete and pass a basic sanity check (see [`MIN_SPIDERS`] and
+/// friends), as long as it isn't older than [`MAX_STALENESS`]. Examines
+/// every entry rather than assuming `history.json` lists them in any
+/// particular order.
 async fn fetch_latest_run(client: &Client, history_url: &str) -> Result<AtpMetadata> {
     let response = client
         .get(history_url)
@@ -167,29 +168,18 @@ async fn fetch_latest_run(client: &Client, history_url: &str) -> Result<AtpMetad
         .as_array()
         .ok_or_else(|| anyhow!("{} did not return a JSON array", history_url))?;
 
-    let now = UtcDateTime::now();
     let mut rejected: Vec<String> = Vec::new();
-    for entry in entries.iter().rev() {
+    let mut newest: Option<AtpMetadata> = None;
+    for entry in entries {
         match parse_run(entry, history_url) {
             std::result::Result::Ok(metadata) => {
-                let age: SignedDuration = now - metadata.end_time;
-                if age <= MAX_STALENESS {
-                    return Ok(metadata);
+                let is_newer = match &newest {
+                    None => true,
+                    Some(current) => metadata.start_time > current.start_time,
+                };
+                if is_newer {
+                    newest = Some(metadata);
                 }
-                // Entries are chronological, so anything further back
-                // can only be even older -- no point scanning further.
-                return Err(anyhow!(
-                    "newest usable AllThePlaces run ({}) ended {} days ago, past the {}-week \
-                     staleness limit; newer entries were rejected because: {}",
-                    metadata.run_id,
-                    age.whole_days(),
-                    MAX_STALENESS.whole_weeks(),
-                    if rejected.is_empty() {
-                        "(none newer)".to_string()
-                    } else {
-                        rejected.join("; ")
-                    }
-                ));
             }
             Err(reason) => {
                 log::warn!("Skipping AllThePlaces run entry: {reason}");
@@ -197,11 +187,31 @@ async fn fetch_latest_run(client: &Client, history_url: &str) -> Result<AtpMetad
             }
         }
     }
+
+    let Some(metadata) = newest else {
+        return Err(anyhow!(
+            "No usable AllThePlaces run found in {}: {}",
+            history_url,
+            if rejected.is_empty() {
+                "history.json has no entries".to_string()
+            } else {
+                rejected.join("; ")
+            }
+        ));
+    };
+
+    let age: SignedDuration = UtcDateTime::now() - metadata.end_time;
+    if age <= MAX_STALENESS {
+        return Ok(metadata);
+    }
     Err(anyhow!(
-        "No usable AllThePlaces run found in {}: {}",
-        history_url,
+        "newest usable AllThePlaces run ({}) ended {} days ago, past the {}-week staleness \
+         limit; other rejected entries: {}",
+        metadata.run_id,
+        age.whole_days(),
+        MAX_STALENESS.whole_weeks(),
         if rejected.is_empty() {
-            "history.json has no entries".to_string()
+            "(none)".to_string()
         } else {
             rejected.join("; ")
         }
@@ -379,6 +389,30 @@ mod tests {
         assert_eq!(result.output_url, "https://example.org/last.zip");
         assert_eq!(result.history_url, history_url);
         mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_fetch_latest_run_picks_max_start_time_regardless_of_array_order() {
+        // Don't just trust history.json to list entries oldest-first:
+        // put the more recent one first and make sure it still wins.
+        let mut server = Server::new_async().await;
+        server
+            .mock("GET", "/")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                json!([
+                    fresh_entry("2026-03-18-13-32-34", "https://example.org/newer.zip", 2),
+                    fresh_entry("2017-12-14-02-01-04", "https://example.org/older.zip", 240),
+                ])
+                .to_string(),
+            )
+            .create_async()
+            .await;
+        let client = test_client(&server);
+        let result = fetch_latest_run(&client, &server.url()).await.unwrap();
+        assert_eq!(result.run_id, "2026-03-18-13-32-34");
+        assert_eq!(result.output_url, "https://example.org/newer.zip");
     }
 
     #[tokio::test]

--- a/src/atp/fetch.rs
+++ b/src/atp/fetch.rs
@@ -3,29 +3,111 @@ use anyhow::{Context, Ok, Result, anyhow};
 use futures_util::StreamExt;
 use indicatif::MultiProgress;
 use reqwest::Client;
-use serde_json::json;
+use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
+use time::{SignedDuration, UtcDateTime, format_description::well_known::Rfc3339};
 use tokio::{fs::File, io::AsyncWriteExt};
 
 pub const ATP_RUN_HISTORY_URL: &str = "https://data.alltheplaces.xyz/runs/history.json";
+
+/// Minimum plausible stats for an AllThePlaces run (see [`AtpMetadata`]).
+/// Below these, we treat the run as broken or incomplete and fall back to
+/// an older one instead of trusting it. Deliberately loose: real runs are
+/// far above these numbers (~3,500 spiders / ~3.8M lines / ~800MB as of
+/// mid-2026) -- this only needs to catch a catastrophically broken run,
+/// not flag routine week-to-week fluctuation.
+const MIN_SPIDERS: u64 = 1_000;
+const MIN_TOTAL_LINES: u64 = 500_000;
+const MIN_SIZE_BYTES: u64 = 50_000_000;
+
+/// How far back we're willing to fall back -- skipping incomplete or
+/// suspiciously small runs -- before giving up and refusing to run the
+/// pipeline on stale input.
+const MAX_STALENESS: SignedDuration = SignedDuration::weeks(6);
+
+/// Provenance metadata about a single AllThePlaces run, read from
+/// `history.json` (see [`ATP_RUN_HISTORY_URL`]). Lets us embed the
+/// provenance of our input data into our output files, the same way
+/// `PbfHeader` (see `src/pipeline/osm/mod.rs`) does for OpenStreetMap
+/// planet dumps.
+///
+/// All fields are required: `history.json` is only supposed to list
+/// finished runs, and we treat an entry that's missing any of these -- or
+/// whose stats look broken, see [`MIN_SPIDERS`] and friends -- the same
+/// as an absent entry, falling back to an older run rather than working
+/// from partial or suspect data. See [`fetch_latest_run`].
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct AtpMetadata {
+    /// AllThePlaces' own identifier for this run, e.g. "2026-03-04-15-16-17".
+    pub run_id: String,
+
+    /// URL of the `output.zip` we downloaded for this run.
+    pub output_url: String,
+
+    /// URL of the run-history endpoint we queried to discover the run.
+    pub history_url: String,
+
+    /// When AllThePlaces started running the spiders for this run.
+    #[serde(with = "rfc3339")]
+    pub start_time: UtcDateTime,
+
+    /// When AllThePlaces finished running the spiders for this run.
+    #[serde(with = "rfc3339")]
+    pub end_time: UtcDateTime,
+
+    /// Number of spiders (individual data sources) included in this run.
+    pub spiders: u64,
+
+    /// Number of GeoJSON feature lines across all spiders in this run,
+    /// as reported by AllThePlaces itself.
+    pub total_lines: u64,
+
+    /// Size, in bytes, of `output.zip` as reported by AllThePlaces.
+    pub size_bytes: u64,
+}
+
+/// (De)serializes [`UtcDateTime`] as RFC 3339 strings, e.g.
+/// "2026-03-04T15:16:17Z". `time`'s own `serde` feature would do this for
+/// us, but isn't enabled in this crate; this is small enough not to be
+/// worth the extra dependency surface.
+mod rfc3339 {
+    use serde::{Deserialize, Deserializer, Serializer, de::Error as _, ser::Error as _};
+    use time::{UtcDateTime, format_description::well_known::Rfc3339};
+
+    pub fn serialize<S: Serializer>(t: &UtcDateTime, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(&t.format(&Rfc3339).map_err(S::Error::custom)?)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<UtcDateTime, D::Error> {
+        let text = String::deserialize(d)?;
+        UtcDateTime::parse(&text, &Rfc3339).map_err(D::Error::custom)
+    }
+}
 
 pub async fn fetch_atp(
     url: &str,
     client: &Client,
     progress: &MultiProgress,
     workdir: &Path,
-) -> Result<PathBuf> {
+) -> Result<(PathBuf, AtpMetadata)> {
     let out_path: PathBuf = workdir.join("alltheplaces.zip");
+    let meta_json_path = workdir.join("alltheplaces.meta.json");
     if out_path.exists() {
-        return Ok(out_path);
+        let metadata = read_meta_json(&meta_json_path).await.with_context(|| {
+            format!(
+                "{} exists, but its metadata could not be read from {}",
+                out_path.display(),
+                meta_json_path.display()
+            )
+        })?;
+        return Ok((out_path, metadata));
     }
 
     let tmp_path = workdir.join("alltheplaces.zip.tmp");
-    let meta_json_path = workdir.join("alltheplaces.meta.json");
-    download_atp(url, client, progress, &tmp_path, &meta_json_path).await?;
+    let metadata = download_atp(url, client, progress, &tmp_path, &meta_json_path).await?;
     std::fs::rename(&tmp_path, &out_path)?; // atomic file system operation
-    Ok(out_path)
+    Ok((out_path, metadata))
 }
 
 async fn download_atp(
@@ -34,20 +116,20 @@ async fn download_atp(
     progress: &MultiProgress,
     dest: &Path,
     meta_json_dest: &Path,
-) -> Result<()> {
+) -> Result<AtpMetadata> {
     let mut file = File::create(dest)
         .await
         .with_context(|| format!("Failed to create file {}", dest.display()))?;
 
-    let (run_id, url) = fetch_latest_build(client, url).await?;
+    let metadata = fetch_latest_run(client, url).await?;
     let response = client
-        .get(&url)
+        .get(&metadata.output_url)
         .timeout(Duration::from_secs(120))
         .send()
         .await
-        .with_context(|| format!("Failed to GET {url}"))?
+        .with_context(|| format!("Failed to GET {}", metadata.output_url))?
         .error_for_status()
-        .with_context(|| format!("Server returned error for {url}"))?;
+        .with_context(|| format!("Server returned error for {}", metadata.output_url))?;
     let content_length = response.content_length();
     let mut stream = response.bytes_stream();
     let bar = make_download_bar(progress, "atp.fetch     ", content_length);
@@ -61,55 +143,138 @@ async fn download_atp(
     file.flush()
         .await
         .with_context(|| format!("Failed to flush {}", dest.display()))?;
-    write_meta_json(&run_id, &url, meta_json_dest).await?;
+    write_meta_json(&metadata, meta_json_dest).await?;
     bar.finish();
-    Ok(())
+    Ok(metadata)
 }
 
-async fn fetch_latest_build(client: &Client, url: &str) -> Result<(String, String)> {
+/// Queries `history_url` (`history.json`) and returns the metadata for the
+/// most recent run that's both complete and passes a basic sanity check
+/// (see [`MIN_SPIDERS`] and friends), as long as it isn't older than
+/// [`MAX_STALENESS`]. `history.json` entries are assumed to be listed
+/// oldest-first, as AllThePlaces does today, so we scan from the end.
+async fn fetch_latest_run(client: &Client, history_url: &str) -> Result<AtpMetadata> {
     let response = client
-        .get(url)
+        .get(history_url)
         .timeout(Duration::from_secs(120))
         .send()
         .await
-        .with_context(|| format!("Failed to GET {url}"))?
+        .with_context(|| format!("Failed to GET {history_url}"))?
         .error_for_status()
-        .with_context(|| format!("Server returned error for {url}"))?;
+        .with_context(|| format!("Server returned error for {history_url}"))?;
     let json: serde_json::Value = response.json().await?;
-    let last_entry = json
+    let entries = json
         .as_array()
-        .and_then(|arr| arr.last())
-        .ok_or(anyhow!("Could not find last element of {}", url))?;
-    let run_id = last_entry
-        .get("run_id")
-        .and_then(|v| v.as_str())
-        .ok_or(anyhow!(
-            "Could not find 'run_id' in last element of {}",
-            url
-        ))?;
-    let build_url = last_entry
-        .get("output_url")
-        .and_then(|v| v.as_str())
-        .ok_or(anyhow!(
-            "Could not find 'output_url' in last element of {}",
-            url
-        ))?;
-    Ok((String::from(run_id), String::from(build_url)))
+        .ok_or_else(|| anyhow!("{} did not return a JSON array", history_url))?;
+
+    let now = UtcDateTime::now();
+    let mut rejected: Vec<String> = Vec::new();
+    for entry in entries.iter().rev() {
+        match parse_run(entry, history_url) {
+            std::result::Result::Ok(metadata) => {
+                let age: SignedDuration = now - metadata.end_time;
+                if age <= MAX_STALENESS {
+                    return Ok(metadata);
+                }
+                // Entries are chronological, so anything further back
+                // can only be even older -- no point scanning further.
+                return Err(anyhow!(
+                    "newest usable AllThePlaces run ({}) ended {} days ago, past the {}-week \
+                     staleness limit; newer entries were rejected because: {}",
+                    metadata.run_id,
+                    age.whole_days(),
+                    MAX_STALENESS.whole_weeks(),
+                    if rejected.is_empty() {
+                        "(none newer)".to_string()
+                    } else {
+                        rejected.join("; ")
+                    }
+                ));
+            }
+            Err(reason) => {
+                log::warn!("Skipping AllThePlaces run entry: {reason}");
+                rejected.push(reason.to_string());
+            }
+        }
+    }
+    Err(anyhow!(
+        "No usable AllThePlaces run found in {}: {}",
+        history_url,
+        if rejected.is_empty() {
+            "history.json has no entries".to_string()
+        } else {
+            rejected.join("; ")
+        }
+    ))
 }
 
-async fn write_meta_json(run_id: &str, url: &str, dest: &Path) -> Result<()> {
+/// Parses and sanity-checks a single `history.json` entry. Returns an
+/// explanatory error on any field that's missing, malformed, or
+/// suspiciously small; callers collect these across several rejected
+/// entries into one combined error message.
+fn parse_run(entry: &serde_json::Value, history_url: &str) -> Result<AtpMetadata> {
+    let str_field = |key: &str| -> Result<String> {
+        entry
+            .get(key)
+            .and_then(|v| v.as_str())
+            .map(String::from)
+            .ok_or_else(|| anyhow!("missing '{key}'"))
+    };
+    let u64_field = |key: &str| -> Result<u64> {
+        entry
+            .get(key)
+            .and_then(|v| v.as_u64())
+            .ok_or_else(|| anyhow!("missing '{key}'"))
+    };
+    let timestamp_field = |key: &str| -> Result<UtcDateTime> {
+        let s = str_field(key)?;
+        UtcDateTime::parse(&s, &Rfc3339).map_err(|e| anyhow!("invalid '{key}' {s:?}: {e}"))
+    };
+
+    let run_id = str_field("run_id")?;
+    let output_url = str_field("output_url")?;
+    let start_time = timestamp_field("start_time")?;
+    let end_time = timestamp_field("end_time")?;
+    let spiders = u64_field("spiders")?;
+    let total_lines = u64_field("total_lines")?;
+    let size_bytes = u64_field("size_bytes")?;
+
+    if spiders < MIN_SPIDERS || total_lines < MIN_TOTAL_LINES || size_bytes < MIN_SIZE_BYTES {
+        return Err(anyhow!(
+            "run {run_id} looks broken (spiders={spiders}, total_lines={total_lines}, \
+             size_bytes={size_bytes})"
+        ));
+    }
+
+    Ok(AtpMetadata {
+        run_id,
+        output_url,
+        history_url: history_url.to_string(),
+        start_time,
+        end_time,
+        spiders,
+        total_lines,
+        size_bytes,
+    })
+}
+
+async fn write_meta_json(metadata: &AtpMetadata, dest: &Path) -> Result<()> {
     let mut file = File::create(dest)
         .await
         .with_context(|| format!("Failed to create {}", dest.display()))?;
-    let data = json!({
-        "run_id": run_id,
-        "url": url,
-    });
-    file.write_all(data.to_string().as_bytes()).await?;
+    let data = serde_json::to_string(metadata)?;
+    file.write_all(data.as_bytes()).await?;
     file.flush()
         .await
         .with_context(|| format!("Failed to flush {}", dest.display()))?;
     Ok(())
+}
+
+async fn read_meta_json(path: &Path) -> Result<AtpMetadata> {
+    let data = tokio::fs::read_to_string(path)
+        .await
+        .with_context(|| format!("Failed to read {}", path.display()))?;
+    serde_json::from_str(&data).with_context(|| format!("Failed to parse {}", path.display()))
 }
 
 #[cfg(test)]
@@ -117,15 +282,30 @@ mod tests {
     use super::*;
     use indicatif::ProgressDrawTarget;
     use mockito::Server;
+    use serde_json::json;
     use tempfile::TempDir;
+
+    /// A run entry, `hours_ago` hours old, that passes every check.
+    fn fresh_entry(run_id: &str, output_url: &str, hours_ago: i64) -> serde_json::Value {
+        let end_time = UtcDateTime::now() - SignedDuration::hours(hours_ago);
+        let start_time = end_time - SignedDuration::hours(3);
+        json!({
+            "run_id": run_id,
+            "output_url": output_url,
+            "start_time": start_time.format(&Rfc3339).unwrap(),
+            "end_time": end_time.format(&Rfc3339).unwrap(),
+            "spiders": MIN_SPIDERS + 1,
+            "total_lines": MIN_TOTAL_LINES + 1,
+            "size_bytes": MIN_SIZE_BYTES + 1,
+        })
+    }
 
     #[tokio::test]
     async fn test_fetch_atp() -> Result<()> {
         let mut server = Server::new_async().await;
         let server_url = server.url();
-        let mock_history_payload = json!([
-            {"run_id": "2026-03-04-15-16-17", "output_url": format!("{}/atp_data", server_url)}
-        ]);
+        let output_url = format!("{}/atp_data", server_url);
+        let mock_history_payload = json!([fresh_entry("2026-03-04-15-16-17", &output_url, 2)]);
         let mock_history_url = format!("{}/history", server_url);
         let mock_history = server
             .mock("GET", "/history")
@@ -144,51 +324,142 @@ mod tests {
         let client = test_client(&server);
         let progress = MultiProgress::with_draw_target(ProgressDrawTarget::hidden());
         let workdir = TempDir::new()?;
-        let path = fetch_atp(&mock_history_url, &client, &progress, workdir.path()).await?;
+        let (path, metadata) =
+            fetch_atp(&mock_history_url, &client, &progress, workdir.path()).await?;
         mock_history.assert_async().await;
         mock_atp_data.assert_async().await;
 
         assert!(path.exists());
         assert_eq!(tokio::fs::read(&path).await?, b"data");
+        assert_eq!(metadata.run_id, "2026-03-04-15-16-17");
+        assert_eq!(metadata.output_url, output_url);
+        assert_eq!(metadata.history_url, mock_history_url);
+        assert_eq!(metadata.spiders, MIN_SPIDERS + 1);
+        assert_eq!(metadata.total_lines, MIN_TOTAL_LINES + 1);
+        assert_eq!(metadata.size_bytes, MIN_SIZE_BYTES + 1);
 
+        // The metadata must also have been persisted to disk, so it can
+        // be recovered on a later run without re-hitting the network
+        // (see the `out_path.exists()` branch of `fetch_atp`).
         let meta_json_path = workdir.path().join("alltheplaces.meta.json");
         let meta_json_str = tokio::fs::read_to_string(meta_json_path).await?;
-        let meta_json: serde_json::Value = serde_json::from_str(&meta_json_str)?;
-        assert_eq!(
-            meta_json,
-            json!({
-            "run_id": "2026-03-04-15-16-17",
-            "url": format!("{}/atp_data", server_url)
-                })
-        );
+        let persisted: AtpMetadata = serde_json::from_str(&meta_json_str)?;
+        assert_eq!(persisted, metadata);
+
+        // Fetching again must not hit the network a second time, and
+        // must return the metadata read back from disk.
+        let (path2, metadata2) =
+            fetch_atp(&mock_history_url, &client, &progress, workdir.path()).await?;
+        assert_eq!(path2, path);
+        assert_eq!(metadata2, metadata);
 
         Ok(())
     }
 
     #[tokio::test]
-    async fn test_fetch_latest_build() {
+    async fn test_fetch_latest_run() {
         let mut server = Server::new_async().await;
         let mock = server
             .mock("GET", "/")
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(
-                r#"[
-                    {"run_id": "2017-12-14-02-01-04", "output_url": "https://example.org/first.zip"},
-                    {"run_id": "2026-03-18-13-32-34", "output_url": "https://example.org/last.zip"}
-                ]"#,
+                json!([
+                    fresh_entry("2017-12-14-02-01-04", "https://example.org/first.zip", 240),
+                    fresh_entry("2026-03-18-13-32-34", "https://example.org/last.zip", 2),
+                ])
+                .to_string(),
             )
             .create_async()
             .await;
         let client = test_client(&server);
-        let result = fetch_latest_build(&client, &server.url()).await.unwrap();
-        assert_eq!(result.0, "2026-03-18-13-32-34");
-        assert_eq!(result.1, "https://example.org/last.zip");
+        let history_url = server.url();
+        let result = fetch_latest_run(&client, &history_url).await.unwrap();
+        assert_eq!(result.run_id, "2026-03-18-13-32-34");
+        assert_eq!(result.output_url, "https://example.org/last.zip");
+        assert_eq!(result.history_url, history_url);
         mock.assert_async().await;
     }
 
     #[tokio::test]
-    async fn test_fetch_latest_build_missing_output_url() {
+    async fn test_fetch_latest_run_falls_back_on_missing_fields() {
+        // The newest entry is missing `end_time` (e.g. a run still in
+        // progress, or a future change to history.json); we must fall
+        // back to the next-older entry rather than error out or use
+        // partial data.
+        let mut server = Server::new_async().await;
+        let mut incomplete = fresh_entry("2026-03-19-00-00-00", "https://example.org/wip.zip", 1);
+        incomplete.as_object_mut().unwrap().remove("end_time");
+        server
+            .mock("GET", "/")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                json!([
+                    fresh_entry("2026-03-18-13-32-34", "https://example.org/last.zip", 5),
+                    incomplete,
+                ])
+                .to_string(),
+            )
+            .create_async()
+            .await;
+        let client = test_client(&server);
+        let result = fetch_latest_run(&client, &server.url()).await.unwrap();
+        assert_eq!(result.run_id, "2026-03-18-13-32-34");
+    }
+
+    #[tokio::test]
+    async fn test_fetch_latest_run_falls_back_on_broken_stats() {
+        // The newest entry claims only a single spider ran -- far below
+        // MIN_SPIDERS -- so it looks broken; fall back to the older run.
+        let mut server = Server::new_async().await;
+        let mut broken = fresh_entry("2026-03-19-00-00-00", "https://example.org/broken.zip", 1);
+        broken["spiders"] = json!(1);
+        server
+            .mock("GET", "/")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                json!([
+                    fresh_entry("2026-03-18-13-32-34", "https://example.org/last.zip", 5),
+                    broken,
+                ])
+                .to_string(),
+            )
+            .create_async()
+            .await;
+        let client = test_client(&server);
+        let result = fetch_latest_run(&client, &server.url()).await.unwrap();
+        assert_eq!(result.run_id, "2026-03-18-13-32-34");
+    }
+
+    #[tokio::test]
+    async fn test_fetch_latest_run_rejects_stale_run() {
+        // The only entry is complete and sane, but ended well past
+        // MAX_STALENESS -- refuse rather than silently using stale data.
+        let mut server = Server::new_async().await;
+        server
+            .mock("GET", "/")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                json!([fresh_entry(
+                    "2026-01-01-00-00-00",
+                    "https://example.org/old.zip",
+                    24 * 70, // 10 weeks ago
+                )])
+                .to_string(),
+            )
+            .create_async()
+            .await;
+        let client = test_client(&server);
+        let err = fetch_latest_run(&client, &server.url()).await.unwrap_err();
+        assert!(err.to_string().contains("2026-01-01-00-00-00"));
+        assert!(err.to_string().contains("staleness limit"));
+    }
+
+    #[tokio::test]
+    async fn test_fetch_latest_run_missing_output_url() {
         let mut server = Server::new_async().await;
         server
             .mock("GET", "/")
@@ -199,12 +470,25 @@ mod tests {
             .await;
 
         let client = test_client(&server);
-        let result = fetch_latest_build(&client, &server.url()).await;
-        assert!(result.is_err());
+        let err = fetch_latest_run(&client, &server.url()).await.unwrap_err();
+        assert!(err.to_string().contains("missing 'run_id'"));
     }
 
     #[tokio::test]
-    async fn test_write_meta() {}
+    async fn test_fetch_latest_run_empty_history() {
+        let mut server = Server::new_async().await;
+        server
+            .mock("GET", "/")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body("[]")
+            .create_async()
+            .await;
+
+        let client = test_client(&server);
+        let err = fetch_latest_run(&client, &server.url()).await.unwrap_err();
+        assert!(err.to_string().contains("no entries"));
+    }
 
     fn test_client(_server: &Server) -> Client {
         Client::builder()

--- a/src/atp/mod.rs
+++ b/src/atp/mod.rs
@@ -13,7 +13,10 @@ use std::io::{BufRead, BufReader, Read};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc::{Receiver, SyncSender, sync_channel};
-use time::{OffsetDateTime, UtcDateTime, format_description::well_known::Iso8601};
+use time::{
+    OffsetDateTime, UtcDateTime,
+    format_description::well_known::{Iso8601, Rfc3339},
+};
 
 use crate::places::{ParquetWriter, Place};
 use crate::{PROGRESS_BAR_STYLE, matchers::MatchMask};
@@ -30,7 +33,27 @@ pub async fn import_atp(
         return Ok(out);
     }
 
-    let input_zip = fetch::fetch_atp(fetch::ATP_RUN_HISTORY_URL, client, progress, workdir).await?;
+    let (input_zip, atp_metadata) =
+        fetch::fetch_atp(fetch::ATP_RUN_HISTORY_URL, client, progress, workdir).await?;
+    let atp_start_time = atp_metadata
+        .start_time
+        .format(&Rfc3339)
+        .expect("UtcDateTime should always format as RFC3339");
+    let atp_end_time = atp_metadata
+        .end_time
+        .format(&Rfc3339)
+        .expect("UtcDateTime should always format as RFC3339");
+    log::info!(
+        run_id = atp_metadata.run_id.as_str(),
+        output_url = atp_metadata.output_url.as_str(),
+        history_url = atp_metadata.history_url.as_str(),
+        start_time = atp_start_time.as_str(),
+        end_time = atp_end_time.as_str(),
+        spiders = atp_metadata.spiders,
+        total_lines = atp_metadata.total_lines,
+        size_bytes = atp_metadata.size_bytes;
+        "fetched AllThePlaces dump"
+    );
 
     // To avoid deadlock, we must not use Rayon threads here.
     // https://dev.to/sgchris/scoped-threads-with-stdthreadscope-in-rust-163-48f9

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -60,11 +60,21 @@ pub fn run_pipeline(http_client: &reqwest::Client, workdir: &Path) -> Result<()>
 /// the step succeeds or fails, so a step that errors out (e.g. due to
 /// an actual OOM) still gets its "end" snapshot, with an elapsed time,
 /// on the way out.
+///
+/// A step that returns `Err` also gets its error logged here, at ERROR
+/// level, with the full `anyhow` context chain -- this is the single
+/// place that does so, rather than every fallible call site logging its
+/// own error on top of returning it. Without this, an error would only
+/// ever surface via `main()`'s default unwind on the way out of the
+/// process, never in `pipeline.log` itself.
 fn run_step<T>(name: &str, step: impl FnOnce() -> Result<T>) -> Result<T> {
     let start = Instant::now();
     log_snapshot(name, "start", None);
     let result = step();
     log_snapshot(name, "end", Some(start.elapsed().as_secs_f64()));
+    if let Err(e) = &result {
+        log::error!(step = name; "{name} failed: {e:#}");
+    }
     result
 }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -13,6 +13,13 @@ fn test_pipeline() -> Result<()> {
     atp.push("tests/test_data/alltheplaces.zip");
     symlink(&atp, workdir.path().join("alltheplaces.zip"))?;
 
+    // fetch_atp() requires the metadata sidecar alongside a pre-existing
+    // alltheplaces.zip (see AtpMetadata in src/atp/fetch.rs), so it has to
+    // be symlinked in too, not just the zip itself.
+    let mut atp_meta = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    atp_meta.push("tests/test_data/alltheplaces.meta.json");
+    symlink(&atp_meta, workdir.path().join("alltheplaces.meta.json"))?;
+
     let mut osm = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     osm.push("tests/test_data/zugerland.osm.pbf");
     symlink(&osm, workdir.path().join("osm-planet.pbf"))?;

--- a/tests/test_data/alltheplaces.meta.json
+++ b/tests/test_data/alltheplaces.meta.json
@@ -1,0 +1,1 @@
+{"run_id":"2026-01-01-00-00-00","output_url":"https://alltheplaces-data.openaddresses.io/runs/2026-01-01-00-00-00/output.zip","history_url":"https://data.alltheplaces.xyz/runs/history.json","start_time":"2026-01-01T00:00:00Z","end_time":"2026-01-01T03:00:00Z","spiders":3,"total_lines":8,"size_bytes":4483}


### PR DESCRIPTION
## Summary
- New `AtpMetadata` in `src/atp/fetch.rs`, mirroring `PbfHeader` from #634 but for the AllThePlaces run that feeds `alltheplaces.parquet`: `run_id`, `output_url`, `history_url`, `start_time`, `end_time`, `spiders`, `total_lines`, `size_bytes`, all parsed from AllThePlaces' `history.json`.
- All fields are required. `history.json` only lists finished runs, so `fetch_latest_run` walks entries from newest to oldest, skipping (and `WARN`-logging) any entry that's missing a field or whose stats look broken -- below `MIN_SPIDERS`/`MIN_TOTAL_LINES`/`MIN_SIZE_BYTES`, deliberately loose floors just meant to catch a catastrophically broken run, not routine fluctuation. If the newest usable entry is older than `MAX_STALENESS` (6 weeks), we refuse to run rather than silently work from stale input.
- `import_atp` logs the metadata at INFO right after fetching -- not CycloneDX yet, just the underlying attributes -- so it's visible in `pipeline.log` ahead of the actual embedding work tracked in #638.
- `fetch_atp`'s cached-zip path now reads the metadata back from `alltheplaces.meta.json` instead of silently skipping it, so provenance survives a re-run that reuses an already-downloaded zip.
- Bonus fix found along the way: `run_step` (`src/pipeline/mod.rs`) already logged a memstats/timing snapshot whether a step succeeded or failed, but never the error itself -- so a fatal error only ever reached `pipeline.log` as an unexplained "end" snapshot, with the actual message only surfacing via `main()`'s default unwind on process exit. Now `run_step` logs it at ERROR with the full `anyhow` context chain, in the one place every top-level step already passes through.

## Why
Closes #639, a sub-issue of #638 (embedding pipeline-input provenance into our output as a CycloneDX-style data BOM). This is the AllThePlaces analogue of #634: parse the metadata and log it, ahead of the actual embedding work.

## Testing
- `cargo test --lib`: 220 passed.
- `cargo fmt --check` and `cargo clippy --lib -- -D warnings`: clean.
- New tests cover: fallback on a missing field, fallback on broken stats, refusal on a stale-only entry, empty-history and missing-required-field errors, and the existing round-trip/caching tests (updated to generate timestamps relative to real `UtcDateTime::now()`, since staleness is checked against wall-clock time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
