### PR TITLE
Rename PLANET_PBF_FILENAME to match upstream's planet-latest.osm.pbf

### DIFF
--- a/src/pipeline/osm/mod.rs
+++ b/src/pipeline/osm/mod.rs
@@ -249,8 +249,10 @@ fn build_relation_parents<R: Read + Seek + Send>(
 
 /// Filename, within `workdir`, that `fetch::fetch_planet` downloads the
 /// OSM planet PBF to. Shared with `crate::provenance`, which needs to
-/// find it again (via `read_header`) without re-fetching.
-pub(crate) const PLANET_PBF_FILENAME: &str = "osm-planet.pbf";
+/// find it again (via `read_header`) without re-fetching. Matches
+/// upstream's own name for this file (see `OSM_TORRENT_URL` in
+/// `fetch.rs`), rather than inventing a local one.
+pub(crate) const PLANET_PBF_FILENAME: &str = "planet-latest.osm.pbf";
 
 /// Provenance metadata read from a PBF file's `OSMHeader` block: which
 /// OpenStreetMap replication state the data corresponds to, and what

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -22,7 +22,7 @@ fn test_pipeline() -> Result<()> {
 
     let mut osm = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     osm.push("tests/test_data/zugerland.osm.pbf");
-    symlink(&osm, workdir.path().join("osm-planet.pbf"))?;
+    symlink(&osm, workdir.path().join("planet-latest.osm.pbf"))?;
 
     Command::new(cargo_bin!("osm-diffs"))
         .arg("run")


### PR DESCRIPTION
## Summary
Renames `PLANET_PBF_FILENAME` from `osm-planet.pbf` (a name we made up locally) to `planet-latest.osm.pbf`, matching upstream's own name for this file (`OSM_TORRENT_URL` in `src/pipeline/osm/fetch.rs`).

`crate::provenance`'s `osm_component()` already referenced the constant rather than a literal, so it picks up the rename automatically -- confirmed by re-running the pipeline end-to-end and checking the embedded BOM. Only two places needed an actual edit: the constant definition, and `tests/integration_test.rs`'s fixture symlink (a separate binary/test target, can't reach the `pub(crate)` constant).

## Why
Closes #648.

## Testing
- `cargo test`: 231 lib + 4 integration tests pass.
- `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`: clean.
- Manually verified end-to-end: ran the binary against a workdir with the input renamed to `planet-latest.osm.pbf`, confirmed the embedded BOM's OSM component's `bom-ref`/`name` both read `planet-latest.osm.pbf`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
