### PR TITLE
Link SECURITY.md to SUPPLY_CHAIN_SECURITY.md

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -5,3 +5,5 @@ please report it privately.
 
 We prefer that you use the [GitHub mechanism for privately reporting a vulnerability](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability). Under the
 [repository’s security tab](https://github.com/alltheplaces/osm-diffs/security), click "Report a vulnerability" to open the advisory form.
+
+For how we secure the release process itself — build provenance, SBOMs, signed attestations — see [`SUPPLY_CHAIN_SECURITY.md`](SUPPLY_CHAIN_SECURITY.md).


### PR DESCRIPTION
## Summary
- `docs/SECURITY.md` covers vulnerability reporting; `docs/SUPPLY_CHAIN_SECURITY.md` covers a different concern — verifying releases via provenance, SBOMs, and signed attestations.
- A reader landing on `SECURITY.md` had no path to the supply-chain doc, so add a one-line pointer at the end (kept separate from the vulnerability-reporting instructions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)