### PR TITLE
docs/SECURITY.md: use an absolute link to SUPPLY_CHAIN_SECURITY.md

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -6,4 +6,4 @@ please report it privately.
 We prefer that you use the [GitHub mechanism for privately reporting a vulnerability](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability). Under the
 [repository’s security tab](https://github.com/alltheplaces/osm-diffs/security), click "Report a vulnerability" to open the advisory form.
 
-For how we secure the release process itself — build provenance, SBOMs, signed attestations — see [`SUPPLY_CHAIN_SECURITY.md`](SUPPLY_CHAIN_SECURITY.md).
+For how we secure the release process itself — build provenance, SBOMs, signed attestations — see [`SUPPLY_CHAIN_SECURITY.md`](https://github.com/alltheplaces/osm-diffs/blob/main/docs/SUPPLY_CHAIN_SECURITY.md).


### PR DESCRIPTION
## Summary
Follow-up to #652.

The relative link added there works on the ordinary blob view (https://github.com/alltheplaces/osm-diffs/blob/main/docs/SECURITY.md) but not on GitHub's security-tab view (https://github.com/alltheplaces/osm-diffs?tab=security-ov-file), which renders SECURITY.md's content outside its normal blob context — relative links there resolve against the repo root instead of `docs/`, so `SUPPLY_CHAIN_SECURITY.md` pointed at a nonexistent top-level file.

Switched to an absolute URL, which resolves correctly in both places (matching the existing absolute link to the security tab itself, just above it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)