### PR TITLE
Compute and embed the OSM planet file's SHA-256 hash (#646, OSM half)

### DIFF
--- a/src/atp/fetch.rs
+++ b/src/atp/fetch.rs
@@ -1,4 +1,5 @@
 use crate::make_download_bar;
+use crate::utils::to_hex;
 use anyhow::{Context, Ok, Result, anyhow};
 use aws_lc_rs::digest::{Context as DigestContext, SHA256};
 use futures_util::StreamExt;
@@ -56,11 +57,11 @@ pub struct AtpMetadata {
     pub history_url: String,
 
     /// When AllThePlaces started running the spiders for this run.
-    #[serde(with = "rfc3339")]
+    #[serde(with = "crate::utils::rfc3339")]
     pub start_time: UtcDateTime,
 
     /// When AllThePlaces finished running the spiders for this run.
-    #[serde(with = "rfc3339")]
+    #[serde(with = "crate::utils::rfc3339")]
     pub end_time: UtcDateTime,
 
     /// Number of spiders (individual data sources) included in this run.
@@ -82,24 +83,6 @@ pub struct AtpMetadata {
     /// distrust the way it would be for the other fields (see the
     /// struct doc) -- it's just a different lifecycle stage.
     pub sha256: Option<String>,
-}
-
-/// (De)serializes [`UtcDateTime`] as RFC 3339 strings, e.g.
-/// "2026-03-04T15:16:17Z". `time`'s own `serde` feature would do this for
-/// us, but isn't enabled in this crate; this is small enough not to be
-/// worth the extra dependency surface.
-mod rfc3339 {
-    use serde::{Deserialize, Deserializer, Serializer, de::Error as _, ser::Error as _};
-    use time::{UtcDateTime, format_description::well_known::Rfc3339};
-
-    pub fn serialize<S: Serializer>(t: &UtcDateTime, s: S) -> Result<S::Ok, S::Error> {
-        s.serialize_str(&t.format(&Rfc3339).map_err(S::Error::custom)?)
-    }
-
-    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<UtcDateTime, D::Error> {
-        let text = String::deserialize(d)?;
-        UtcDateTime::parse(&text, &Rfc3339).map_err(D::Error::custom)
-    }
 }
 
 pub async fn fetch_atp(
@@ -175,15 +158,6 @@ async fn download_atp(
     write_meta_json(&metadata, meta_json_dest).await?;
     bar.finish();
     Ok(metadata)
-}
-
-fn to_hex(bytes: &[u8]) -> String {
-    use std::fmt::Write;
-    let mut hex = String::with_capacity(bytes.len() * 2);
-    for byte in bytes {
-        write!(hex, "{byte:02x}").expect("writing to a String cannot fail");
-    }
-    hex
 }
 
 /// Queries `history_url` (`history.json`) and returns the metadata for

--- a/src/atp/mod.rs
+++ b/src/atp/mod.rs
@@ -57,7 +57,8 @@ pub async fn import_atp(
         end_time = atp_end_time.as_str(),
         spiders = atp_metadata.spiders,
         total_lines = atp_metadata.total_lines,
-        size_bytes = atp_metadata.size_bytes;
+        size_bytes = atp_metadata.size_bytes,
+        sha256 = atp_metadata.sha256.as_deref();
         "fetched AllThePlaces dump"
     );
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ mod places;
 mod provenance;
 mod s2_util;
 mod tables;
+mod utils;
 
 // Re-exported for main.rs.
 pub use pipeline::run_pipeline;

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -10,11 +10,11 @@ mod edits;
 mod geostats; // TODO: Move into crate::geometry?
 mod osm;
 
-// Only these two re-exported crate-wide (rather than making all of
+// Only these three re-exported crate-wide (rather than making all of
 // `osm` pub(crate)): crate::provenance needs them to assemble this
 // pipeline's provenance BOM, nothing outside `pipeline` needs the rest
 // of osm's API (BlobReader, Node/Way/Relation, import_osm, ...).
-pub(crate) use osm::{OsmMetadata, PLANET_PBF_FILENAME, read_header};
+pub(crate) use osm::{OsmMetadata, PLANET_PBF_FILENAME, read_cached_metadata};
 mod tiles;
 mod upload;
 

--- a/src/pipeline/osm/fetch.rs
+++ b/src/pipeline/osm/fetch.rs
@@ -1,16 +1,24 @@
 use crate::make_download_bar;
-use anyhow::{Ok, Result};
+use anyhow::{Context, Ok, Result};
 use indicatif::MultiProgress;
 use librqbit::{AddTorrent, AddTorrentOptions, Session, SessionOptions};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+use super::OsmMetadata;
+
 const OSM_TORRENT_URL: &str = "https://planet.openstreetmap.org/pbf/planet-latest.osm.pbf.torrent";
 
-pub fn fetch_planet(progress: &MultiProgress, workdir: &Path) -> Result<PathBuf> {
+pub fn fetch_planet(progress: &MultiProgress, workdir: &Path) -> Result<(PathBuf, OsmMetadata)> {
     let pbf_path: PathBuf = workdir.join(super::PLANET_PBF_FILENAME);
     if pbf_path.exists() {
-        return Ok(pbf_path);
+        let metadata = super::read_cached_metadata(workdir).with_context(|| {
+            format!(
+                "{} exists, but its metadata could not be read",
+                pbf_path.display()
+            )
+        })?;
+        return Ok((pbf_path, metadata));
     }
 
     tokio::runtime::Builder::new_multi_thread()
@@ -18,7 +26,12 @@ pub fn fetch_planet(progress: &MultiProgress, workdir: &Path) -> Result<PathBuf>
         .build()?
         .block_on(download_osm_planet(progress, workdir, &pbf_path))?;
 
-    Ok(pbf_path)
+    // Not async: a plain buffered read/hash of the (potentially tens of
+    // GB) downloaded file, outside the tokio runtime used for the
+    // torrent download above.
+    let metadata = super::compute_and_persist_metadata(&pbf_path, workdir, progress)?;
+
+    Ok((pbf_path, metadata))
 }
 
 async fn download_osm_planet(

--- a/src/pipeline/osm/mod.rs
+++ b/src/pipeline/osm/mod.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Ok, Result, anyhow};
+use aws_lc_rs::digest::{Context as DigestContext, SHA256};
 use indicatif::MultiProgress;
 use osm_pbf_iter::{Blob, Primitive, PrimitiveBlock, RelationMemberType};
 use protobuf_iter::MessageIter;
@@ -16,7 +17,8 @@ use time::UtcDateTime;
 use time::format_description::well_known::Rfc3339;
 
 use crate::coverage::Coverage;
-use crate::make_progress_bar;
+use crate::utils::to_hex;
+use crate::{make_download_bar, make_progress_bar};
 
 mod assemble;
 mod coords;
@@ -43,7 +45,7 @@ pub fn import_osm(
         return Ok((out_path, Box::new(store)));
     }
 
-    let pbf = fetch::fetch_planet(progress, workdir)?;
+    let (pbf, fetch_metadata) = fetch::fetch_planet(progress, workdir)?;
     let pbf_error = || format!("could not open file `{:?}`", pbf);
     let mut file = File::open(&pbf).with_context(pbf_error)?;
     let mut reader = BlobReader::open(&mut file).with_context(pbf_error)?;
@@ -55,7 +57,8 @@ pub fn import_osm(
     log::info!(
         replication_timestamp = replication_timestamp.as_str(),
         source = header.source.as_deref(),
-        writing_program = header.writing_program.as_deref();
+        writing_program = header.writing_program.as_deref(),
+        sha256 = fetch_metadata.sha256.as_deref();
         "opened OpenStreetMap planet file"
     );
 
@@ -258,11 +261,23 @@ pub(crate) const PLANET_PBF_FILENAME: &str = "planet-latest.osm.pbf";
 /// OpenStreetMap replication state the data corresponds to, and what
 /// produced the file. Lets us embed the provenance of our input data
 /// into our output files.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct OsmMetadata {
+    #[serde(with = "crate::utils::rfc3339")]
     pub replication_timestamp: UtcDateTime,
     pub source: Option<String>,
     pub writing_program: Option<String>,
+
+    /// SHA-256 of the downloaded planet file, as lowercase hex --
+    /// computed by us, not reported by OpenStreetMap. `None` for a
+    /// value built by `parse_header_block`/`read_header` (which only
+    /// ever reads the small `OSMHeader` block, not the rest of the
+    /// file -- there's no hash to give); `Some` only for the value
+    /// `compute_and_persist_metadata` builds after actually hashing the
+    /// whole file. Same shape as `AtpMetadata::sha256`, for an
+    /// analogous reason: this struct is used both before and after the
+    /// point where a hash becomes available.
+    pub sha256: Option<String>,
 }
 
 /// Reads just the `OSMHeader` block from the very start of a PBF file --
@@ -291,6 +306,78 @@ pub fn read_header(path: &Path) -> Result<OsmMetadata> {
     let offset = 4_u64 + (blob_header.len() as u64);
     let blob = BlobReader::<File>::read_blob(&mut file, offset, data_size)?;
     BlobReader::<File>::parse_header_block(&blob.into_data())
+}
+
+/// Filename, within `workdir`, that [`compute_and_persist_metadata`]
+/// persists a fully-populated [`OsmMetadata`] (including `sha256`) to.
+/// Derived from [`PLANET_PBF_FILENAME`] rather than a separate literal,
+/// so it can't drift if that ever changes again (see #648).
+fn meta_json_path(workdir: &Path) -> PathBuf {
+    workdir.join(format!("{PLANET_PBF_FILENAME}.meta.json"))
+}
+
+/// Reads back the [`OsmMetadata`] persisted for a prior
+/// `fetch::fetch_planet` call in `workdir`.
+pub(crate) fn read_cached_metadata(workdir: &Path) -> Result<OsmMetadata> {
+    let path = meta_json_path(workdir);
+    let data = std::fs::read_to_string(&path)
+        .with_context(|| format!("Failed to read {}", path.display()))?;
+    serde_json::from_str(&data).with_context(|| format!("Failed to parse {}", path.display()))
+}
+
+/// Computes a fully-populated [`OsmMetadata`] for a freshly downloaded
+/// planet file at `pbf_path` -- its header (cheap, via [`read_header`])
+/// and the SHA-256 of its entire contents (not cheap: one dedicated
+/// sequential read pass over the whole file, see [`hash_file`]) -- and
+/// persists it to `workdir`, so a later call in the same `workdir` reads
+/// it back via [`read_cached_metadata`] instead of re-hashing.
+pub(crate) fn compute_and_persist_metadata(
+    pbf_path: &Path,
+    workdir: &Path,
+    progress: &MultiProgress,
+) -> Result<OsmMetadata> {
+    let header = read_header(pbf_path)?;
+    let sha256 = hash_file(pbf_path, progress)?;
+    let metadata = OsmMetadata {
+        sha256: Some(sha256),
+        ..header
+    };
+    let path = meta_json_path(workdir);
+    let data = serde_json::to_string(&metadata)?;
+    std::fs::write(&path, &data).with_context(|| format!("Failed to write {}", path.display()))?;
+    Ok(metadata)
+}
+
+/// Reads `path` sequentially in fixed-size chunks and returns its
+/// SHA-256 as lowercase hex, via the same `aws_lc_rs` crypto library
+/// this crate already uses for TLS (see `build_client()` in
+/// `main.rs`), not a second, separate hashing implementation.
+///
+/// Deliberately a plain buffered read, not `memmap2::Mmap` (which this
+/// crate does use elsewhere, e.g. for the AllThePlaces zip): `path`
+/// here is the OSM planet dump, tens of GB, and mmap'ing something that
+/// large risks inflating RSS/page-cache accounting in ways that could
+/// trip this pipeline's own cgroup memory-limit warnings (see
+/// `crate::memstats`) for no benefit -- a small fixed buffer keeps
+/// memory flat regardless of file size.
+fn hash_file(path: &Path, progress: &MultiProgress) -> Result<String> {
+    let mut file = File::open(path).with_context(|| format!("could not open file `{:?}`", path))?;
+    let len = file.metadata().map(|m| m.len()).ok();
+    let bar = make_download_bar(progress, "osm.hash      ", len);
+    let mut hasher = DigestContext::new(&SHA256);
+    let mut buf = vec![0u8; 8 * 1024 * 1024]; // 8 MiB
+    loop {
+        let n = file
+            .read(&mut buf)
+            .with_context(|| format!("could not read file `{:?}`", path))?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+        bar.inc(n as u64);
+    }
+    bar.finish();
+    Ok(to_hex(hasher.finish().as_ref()))
 }
 
 /// Reads data blobs from OpenStreetMap PBF files.
@@ -555,6 +642,7 @@ impl<'a, R: Read + Seek + Send> BlobReader<'a, R> {
                 .ok_or_else(|| anyhow!("OSMHeader block has no osmosis_replication_timestamp"))?,
             source,
             writing_program,
+            sha256: None,
         })
     }
 }

--- a/src/provenance.rs
+++ b/src/provenance.rs
@@ -8,7 +8,7 @@
 //!
 //! Reads each input source's metadata straight back from `workdir` --
 //! [`AtpMetadata`] via [`crate::atp::read_cached_metadata`],
-//! [`OsmMetadata`] via [`crate::pipeline::read_header`] -- rather than
+//! [`OsmMetadata`] via [`crate::pipeline::read_cached_metadata`] -- rather than
 //! having it threaded through from `import_atp`/`import_osm`'s return
 //! values, so this stays decoupled from however those importers (and
 //! whatever indexing they feed into) end up wired together.
@@ -104,9 +104,8 @@ pub fn build_bom_for_conflated_parquet(
 ) -> Result<Value> {
     let atp_metadata =
         atp::read_cached_metadata(workdir).context("could not read AllThePlaces provenance")?;
-    let osm_planet = workdir.join(pipeline::PLANET_PBF_FILENAME);
-    let osm_metadata =
-        pipeline::read_header(&osm_planet).context("could not read OpenStreetMap provenance")?;
+    let osm_metadata = pipeline::read_cached_metadata(workdir)
+        .context("could not read OpenStreetMap provenance")?;
 
     let run_timestamp = format_rfc3339(UtcDateTime::now());
     let start_timestamp = format_rfc3339(pipeline_start_time);
@@ -127,7 +126,7 @@ pub fn build_bom_for_conflated_parquet(
         },
         "components": [
             atp_component(&atp_metadata)?,
-            osm_component(&osm_metadata),
+            osm_component(&osm_metadata)?,
         ],
         // Declares conflated.parquet's two inputs as *its* dependencies,
         // so the dependency graph has a single root (conflated.parquet)
@@ -224,9 +223,18 @@ fn atp_component(atp: &AtpMetadata) -> Result<Value> {
     }))
 }
 
-fn osm_component(osm: &OsmMetadata) -> Value {
+fn osm_component(osm: &OsmMetadata) -> Result<Value> {
     let replication_timestamp = format_rfc3339(osm.replication_timestamp);
-    json!({
+    // Always Some by the time this runs: import_osm (which computes it,
+    // see OsmMetadata::sha256's doc comment) is a prerequisite pipeline
+    // step that always runs before conflate. Erroring rather than
+    // falling back to a placeholder if it's ever missing -- e.g. a
+    // workdir left over from before this field existed -- matches how
+    // atp_component treats AtpMetadata::sha256.
+    let sha256 = osm.sha256.as_deref().context(
+        "OpenStreetMap metadata has no sha256 (workdir from an older osm-diffs version?)",
+    )?;
+    Ok(json!({
         // Reference PLANET_PBF_FILENAME rather than a literal, so this
         // can't drift from the file's actual local name (see #648 for a
         // proposal to rename it to match upstream's own convention).
@@ -237,16 +245,15 @@ fn osm_component(osm: &OsmMetadata) -> Value {
         "supplier": osm_supplier(),
         "licenses": license("ODbL-1.0", ODBL_URL),
         "copyright": OSM_COPYRIGHT,
-        // TODO(#646): checksum is a placeholder until we compute a real
-        // SHA-256 hash of the downloaded .osm.pbf; the purl is invalid
-        // until then, expected to be fixed before this ever runs in
-        // production.
-        "purl": format!("pkg:generic/openstreetmap/planet@{replication_timestamp}?checksum=sha256:TODO"),
+        "hashes": [{"alg": "SHA-256", "content": sha256}],
+        "purl": format!(
+            "pkg:generic/openstreetmap/planet@{replication_timestamp}?checksum=sha256:{sha256}"
+        ),
         "data": [{"type": "dataset"}],
         "externalReferences": [
             license_external_reference(ODBL_URL),
         ],
-    })
+    }))
 }
 
 /// Ties `tool_component()`, the two input `*_component()`s, and
@@ -311,6 +318,19 @@ mod tests {
         let mut pbf_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         pbf_path.push("tests/test_data/zugerland.osm.pbf");
         std::os::unix::fs::symlink(&pbf_path, workdir.join(pipeline::PLANET_PBF_FILENAME))?;
+        // read_cached_metadata reads this sidecar rather than re-hashing
+        // zugerland.osm.pbf on every test run; sha256 is that file's
+        // real SHA-256 (`shasum -a 256 tests/test_data/zugerland.osm.pbf`),
+        // the other fields match test_blob_reader's known values for it.
+        fs::write(
+            workdir.join(format!("{}.meta.json", pipeline::PLANET_PBF_FILENAME)),
+            r#"{
+                "replication_timestamp": "2026-01-27T08:11:02Z",
+                "source": null,
+                "writing_program": "osmx",
+                "sha256": "56e12b62871018c7a969c9924bcfb1bdce15676bee706156260f101db809b9e1"
+            }"#,
+        )?;
         Ok(())
     }
 
@@ -390,9 +410,15 @@ mod tests {
         assert_eq!(osm["licenses"][0]["license"]["id"], "ODbL-1.0");
         assert_eq!(osm["licenses"][0]["license"]["url"], ODBL_URL);
         assert_eq!(osm["copyright"], OSM_COPYRIGHT);
+        assert_eq!(osm["hashes"][0]["alg"], "SHA-256");
+        assert_eq!(
+            osm["hashes"][0]["content"],
+            "56e12b62871018c7a969c9924bcfb1bdce15676bee706156260f101db809b9e1"
+        );
         assert_eq!(
             osm["purl"],
-            "pkg:generic/openstreetmap/planet@2026-01-27T08:11:02Z?checksum=sha256:TODO"
+            "pkg:generic/openstreetmap/planet@2026-01-27T08:11:02Z?checksum=sha256:\
+             56e12b62871018c7a969c9924bcfb1bdce15676bee706156260f101db809b9e1"
         );
 
         // Single-rooted dependency graph: conflated.parquet depends on

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,44 @@
+//! Small, generic helpers shared by more than one place in the crate.
+//! A natural home for other such helpers as they accumulate -- e.g.
+//! `crate::memstats` is arguably one of these too, just not moved here
+//! (yet).
+
+/// Renders `bytes` as a lowercase hex string, e.g. for a digest.
+pub(crate) fn to_hex(bytes: &[u8]) -> String {
+    use std::fmt::Write;
+    let mut hex = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        write!(hex, "{byte:02x}").expect("writing to a String cannot fail");
+    }
+    hex
+}
+
+/// (De)serializes [`time::UtcDateTime`] as RFC 3339 strings, e.g.
+/// "2026-03-04T15:16:17Z" -- for use as
+/// `#[serde(with = "crate::utils::rfc3339")]`. `time`'s own `serde`
+/// feature would do this for us, but isn't enabled in this crate; this
+/// is small enough not to be worth the extra dependency surface.
+pub(crate) mod rfc3339 {
+    use serde::{Deserialize, Deserializer, Serializer, de::Error as _, ser::Error as _};
+    use time::{UtcDateTime, format_description::well_known::Rfc3339};
+
+    pub fn serialize<S: Serializer>(t: &UtcDateTime, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(&t.format(&Rfc3339).map_err(S::Error::custom)?)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<UtcDateTime, D::Error> {
+        let text = String::deserialize(d)?;
+        UtcDateTime::parse(&text, &Rfc3339).map_err(D::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_to_hex() {
+        assert_eq!(to_hex(&[]), "");
+        assert_eq!(to_hex(&[0x00, 0xff, 0x0a]), "00ff0a");
+    }
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -24,6 +24,18 @@ fn test_pipeline() -> Result<()> {
     osm.push("tests/test_data/zugerland.osm.pbf");
     symlink(&osm, workdir.path().join("planet-latest.osm.pbf"))?;
 
+    // fetch_planet() requires the metadata sidecar alongside a
+    // pre-existing planet-latest.osm.pbf (see OsmMetadata in
+    // src/pipeline/osm/mod.rs), analogous to alltheplaces.meta.json
+    // above -- otherwise it would try to download a fresh copy from
+    // OSM's torrent.
+    let mut osm_meta = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    osm_meta.push("tests/test_data/planet-latest.osm.pbf.meta.json");
+    symlink(
+        &osm_meta,
+        workdir.path().join("planet-latest.osm.pbf.meta.json"),
+    )?;
+
     Command::new(cargo_bin!("osm-diffs"))
         .arg("run")
         .arg("--workdir")

--- a/tests/test_data/planet-latest.osm.pbf.meta.json
+++ b/tests/test_data/planet-latest.osm.pbf.meta.json
@@ -1,0 +1,1 @@
+{"replication_timestamp":"2026-01-27T08:11:02Z","source":null,"writing_program":"osmx","sha256":"56e12b62871018c7a969c9924bcfb1bdce15676bee706156260f101db809b9e1"}


### PR DESCRIPTION
## Summary

The OSM half of #646 (the AllThePlaces half was #650): computes and
embeds a real SHA-256 hash of the downloaded OSM planet file
(`planet-latest.osm.pbf`), replacing `crate::provenance`'s
`checksum=sha256:TODO` placeholder for that component.

- `pipeline::osm::compute_and_persist_metadata` hashes the freshly
  downloaded planet file in one dedicated sequential read pass (fixed
  8 MiB buffered chunks, not `memmap2::Mmap`, to keep memory flat
  regardless of file size -- this file is tens of GB) and persists the
  result to a `planet-latest.osm.pbf.meta.json` sidecar in `workdir`,
  alongside the header fields we already parse. A later run against
  the same `workdir` reads this back (`read_cached_metadata`) instead
  of re-hashing.
- Unlike AllThePlaces' plain sequential HTTP download, the planet file
  arrives via BitTorrent (`librqbit`), which writes pieces to disk
  itself, out of order -- so unlike ATP's hash, this one can't be
  computed incrementally during download; it has to be a separate pass
  over the completed file.
- Both hashes go through the same `aws_lc_rs::digest` (SHA-256) call
  path already used for this pipeline's TLS -- no second hashing
  implementation.
- `crate::provenance`'s `osm_component()` now emits a real
  `hashes`/`purl` checksum for the OSM component, mirroring
  `atp_component()`'s existing pattern exactly.
- Pulled the `to_hex`/RFC3339-serde helpers `atp::fetch` had grown out
  into a new `crate::utils` module, now shared by both `AtpMetadata`
  and `OsmMetadata`, instead of duplicating them for OSM.

## Verification

Ran the full pipeline against the test fixtures, then:
- confirmed both components' embedded hashes match `shasum -a 256`
  computed independently on the same files
- validated the resulting BOM with `cyclonedx validate`
- validated the resulting BOM with FOSSA's NTIA SBOM validator
  (https://fossa.com/resources/regulatory-compliance-tools/ntia-sbom-validator/)
  -- it still passes

Closes #646.

🤖 Generated with [Claude Code](https://claude.com/claude-code)