### PR TITLE
docs/SUPPLY_CHAIN_SECURITY.md: fix dead event-stream link

### DIFF
--- a/docs/SUPPLY_CHAIN_SECURITY.md
+++ b/docs/SUPPLY_CHAIN_SECURITY.md
@@ -179,7 +179,7 @@ a maintainer identity patiently built up over two years, then used to
 slip a remote-code-execution backdoor into a library linked into most
 Linux SSH servers — is the starkest recent example, but it’s one of
 many; the
-[`event-stream` npm compromise](https://en.wikipedia.org/wiki/Event-stream)
+[`event-stream` npm compromise](https://sentinel-project.eu/sites/default/files/docs/A-Systematic-Analysis-of-the-Event-Stream-Incident.pdf)
 and the
 [SolarWinds breach](https://en.wikipedia.org/wiki/2020_United_States_federal_government_data_breach)
 show the pattern isn’t a fluke. Regulators have taken notice too:


### PR DESCRIPTION
The Wikipedia article this linked to (https://en.wikipedia.org/wiki/Event-stream)
doesn't exist, from #658.

Replaces it with ["A Systematic Analysis of the Event-Stream Incident"](https://sentinel-project.eu/sites/default/files/docs/A-Systematic-Analysis-of-the-Event-Stream-Incident.pdf)
(Arvanitis, Ntousakis, Ioannidis, Vasilakis; EUROSEC '22, ACM) — a
peer-reviewed paper with a detailed independent analysis of the same
2018 incident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)