### PR TITLE
Build OsmFeatureIndex in import_osm(), still unconsumed

### DIFF
--- a/src/pipeline/osm/index.rs
+++ b/src/pipeline/osm/index.rs
@@ -30,9 +30,12 @@ use std::thread;
 /// bridging a single reader's iterator would just serialize on the
 /// decompressor anyway, adding rayon dispatch overhead for no gain. Four
 /// independent streams decoding concurrently is the actual parallelism
-/// win here. (If that's ever not enough, the ceiling isn't fixed at
-/// four -- `assemble_nodes`/`assemble_ways`/etc. could shard their own
-/// `RecordWriter` output into several files instead of one each.)
+/// win here. Not optimizing further than that for now -- worth checking
+/// whether this is an actual bottleneck first. If it is, sharding
+/// `assemble_nodes`/`assemble_ways`'s own `RecordWriter` output into more
+/// files would raise the ceiling above four; `leaf_relations`/
+/// `super_relations` likely wouldn't benefit the same way, since
+/// OpenStreetMap has comparatively few relations.
 pub fn build_index<'a>(
     assembly: &Assembly,
     progress: &MultiProgress,
@@ -54,7 +57,7 @@ pub fn build_index<'a>(
         progress,
         "osm.index                   ",
         total,
-        "records → index",
+        "features → index",
     );
 
     let mut create_result: Option<Result<OsmFeatureIndex<'a>>> = None;

--- a/src/pipeline/osm/index.rs
+++ b/src/pipeline/osm/index.rs
@@ -1,0 +1,94 @@
+//! Builds an [OsmFeatureIndex] from an [Assembly]'s four `RecordReader`s.
+//!
+//! Not yet consumed anywhere -- `import_osm` in `mod.rs` calls this and
+//! discards the result, the same way it already discards `Assembly`
+//! itself, until `conflate`/`suggest_edits` are ready to use it. This
+//! exists so the index-building step gets exercised against real PBF
+//! data -- and can be watched with actual production-scale metrics --
+//! before anything downstream depends on it.
+
+use super::assemble::Assembly;
+use crate::make_progress_bar;
+use crate::tables::{FeatureToIndex, OsmFeatureIndex, RecordReader};
+use anyhow::{Context, Result};
+use indicatif::MultiProgress;
+use prost::Message;
+use std::path::Path;
+use std::sync::mpsc::sync_channel;
+use std::thread;
+
+/// Merges `assembly`'s four `RecordReader`s (nodes, ways, leaf_relations,
+/// super_relations) and builds the `OsmFeatureIndex` at `out`.
+///
+/// Four producer threads -- one per `RecordReader` -- each sequentially
+/// decode their own stream and send decoded `FeatureToIndex` records down
+/// a shared multi-producer channel; `OsmFeatureIndex::create` drains it.
+///
+/// Deliberately not `rayon::par_bridge()`: the expensive part (LZ4
+/// decompression) happens *inside* each `RecordReader::iter()` call while
+/// pulling the next record, which is inherently sequential per stream --
+/// bridging a single reader's iterator would just serialize on the
+/// decompressor anyway, adding rayon dispatch overhead for no gain. Four
+/// independent streams decoding concurrently is the actual parallelism
+/// win here. (If that's ever not enough, the ceiling isn't fixed at
+/// four -- `assemble_nodes`/`assemble_ways`/etc. could shard their own
+/// `RecordWriter` output into several files instead of one each.)
+pub fn build_index<'a>(
+    assembly: &Assembly,
+    progress: &MultiProgress,
+    workdir: &Path,
+    out: &Path,
+) -> Result<OsmFeatureIndex<'a>> {
+    if OsmFeatureIndex::exists(out) {
+        return OsmFeatureIndex::open(out);
+    }
+
+    let sources: [(&str, &RecordReader); 4] = [
+        ("nodes", &assembly.nodes),
+        ("ways", &assembly.ways),
+        ("leaf_relations", &assembly.leaf_relations),
+        ("super_relations", &assembly.super_relations),
+    ];
+    let total: u64 = sources.iter().map(|(_, r)| r.len() as u64).sum();
+    let progress_bar = make_progress_bar(
+        progress,
+        "osm.index                   ",
+        total,
+        "records → index",
+    );
+
+    let mut create_result: Option<Result<OsmFeatureIndex<'a>>> = None;
+    thread::scope(|s| -> Result<()> {
+        let (tx, rx) = sync_channel::<FeatureToIndex>(1024);
+        let progress_bar = &progress_bar;
+
+        let producers: Vec<_> = sources
+            .into_iter()
+            .map(|(name, reader)| {
+                let tx = tx.clone();
+                s.spawn(move || -> Result<()> {
+                    for record in reader.iter()? {
+                        let bytes = record?;
+                        let fti = FeatureToIndex::decode(bytes.as_slice()).with_context(|| {
+                            format!("failed to decode a FeatureToIndex record from {name}")
+                        })?;
+                        tx.send(fti)?;
+                        progress_bar.inc(1);
+                    }
+                    Ok(())
+                })
+            })
+            .collect();
+        drop(tx); // so rx.into_iter() ends once every producer's clone is dropped
+
+        create_result = Some(OsmFeatureIndex::create(rx.into_iter(), workdir, out));
+
+        for producer in producers {
+            producer.join().expect("panic in producer")?;
+        }
+        Ok(())
+    })?;
+
+    progress_bar.finish();
+    create_result.expect("thread::scope runs its closure exactly once")
+}

--- a/src/pipeline/osm/mod.rs
+++ b/src/pipeline/osm/mod.rs
@@ -26,6 +26,7 @@ mod cover;
 mod fetch;
 mod filter;
 mod id_tagging_schema;
+mod index;
 mod old_assemble;
 mod prune;
 
@@ -63,7 +64,13 @@ pub fn import_osm(
     );
 
     let prunings = Prunings::create(&mut reader, progress, workdir)?;
-    let _assembly = assemble::assemble(&mut reader, &prunings, progress, workdir)?;
+    let assembly = assemble::assemble(&mut reader, &prunings, progress, workdir)?;
+    let _osm_index = index::build_index(
+        &assembly,
+        progress,
+        workdir,
+        &workdir.join("osm-features.index"),
+    )?;
     if false {
         todo!();
     }

--- a/src/tables/feature_index.rs
+++ b/src/tables/feature_index.rs
@@ -164,6 +164,14 @@ impl<'a> OsmFeatureIndex<'a> {
         p
     }
 
+    /// Whether both files an `OsmFeatureIndex` at `path` needs already
+    /// exist -- same role as e.g. `FilteredFeatureStore::exists`, for
+    /// callers that memoize an expensive build step behind an existence
+    /// check rather than reopening unconditionally.
+    pub fn exists(path: &Path) -> bool {
+        path.exists() && Self::inverted_index_path(path).exists()
+    }
+
     /// Builds an `OsmFeatureIndex` from `fti`, which may be in any order.
     ///
     /// Two passes, since a feature's [LocalFeatureRef] is only known once
@@ -897,5 +905,24 @@ mod tests {
         std::fs::write(&bad, b"not the right file format at all, padded to 64+ bytes so it clears the header-size check")
             .expect("write");
         assert!(OsmFeatureIndex::open(&bad).is_err());
+    }
+
+    #[test]
+    fn exists_requires_both_files() {
+        let dir = TempDir::new().expect("tempdir");
+        let out = dir.path().join("osm-features.index");
+        assert!(!OsmFeatureIndex::exists(&out));
+
+        OsmFeatureIndex::create(
+            vec![fti(1, 1, &[1], MatchMask::SHOP.0)].into_iter(),
+            dir.path(),
+            &out,
+        )
+        .expect("create");
+        assert!(OsmFeatureIndex::exists(&out));
+
+        // Missing just the inverted-index half should still report false.
+        std::fs::remove_file(OsmFeatureIndex::inverted_index_path(&out)).expect("remove");
+        assert!(!OsmFeatureIndex::exists(&out));
     }
 }


### PR DESCRIPTION
PR 2 of the staged sequence tracked in #655.

New `src/pipeline/osm/index.rs`: merges an `Assembly`'s four
`RecordReader`s (nodes, ways, leaf_relations, super_relations) via one
producer thread per reader — each an independent LZ4 stream, decoded
concurrently — feeding a shared multi-producer channel into
`OsmFeatureIndex::create()`. Deliberately not `rayon::par_bridge()`: the
expensive part (LZ4 decompression) happens inside `RecordReader::iter()`
itself, which is inherently sequential per stream, so bridging a single
reader's iterator wouldn't parallelize anything — four independent
streams decoding concurrently is the actual win.

Wired into `import_osm()` right after `assemble::assemble()`, result
discarded for now (`let _osm_index = ...`), the same way `Assembly`
itself is already discarded today. This is the first exercise of the
index against real PBF data, before `conflate`/`suggest_edits` (PR 4/5)
depend on it.

Also adds `OsmFeatureIndex::exists(path)`, mirroring
`FilteredFeatureStore::exists`, so this step memoizes the same way other
pipeline stages do.

## Testing
- `cargo test --lib` (241 passed), `cargo test --test integration_test`
  (4 passed), `cargo clippy --all-targets -- -D warnings` clean, `cargo
  fmt --check` clean.
- Manually verified end-to-end against the built CLI binary + test
  fixtures (not just `cargo test`): a full `osm-diffs run` produces valid
  `osm-features.index` + `osm-features.index.inverted` files, and a
  second run correctly skips rebuilding them (unchanged mtime, no
  duplicate "pass 1 → pass 2 spool file" log line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)