### PR TITLE
Log OsmFeatureIndex::create()'s counts, sizes, and phase timing

### DIFF
--- a/src/pipeline/osm/index.rs
+++ b/src/pipeline/osm/index.rs
@@ -43,6 +43,7 @@ pub fn build_index<'a>(
     out: &Path,
 ) -> Result<OsmFeatureIndex<'a>> {
     if OsmFeatureIndex::exists(out) {
+        log::info!("skipping OsmFeatureIndex build, already found {:?}", out);
         return OsmFeatureIndex::open(out);
     }
 

--- a/src/tables/feature_index.rs
+++ b/src/tables/feature_index.rs
@@ -82,7 +82,7 @@ use std::{
     mem::size_of,
     ops::RangeInclusive,
     path::{Path, PathBuf},
-    time::SystemTime,
+    time::{Instant, SystemTime},
 };
 
 /// Size of each file's header, in bytes: see the "File format" section above.
@@ -191,6 +191,7 @@ impl<'a> OsmFeatureIndex<'a> {
         workdir: &Path,
         out: &Path,
     ) -> Result<OsmFeatureIndex<'a>> {
+        let create_start = Instant::now();
         let inverted_index_path = Self::inverted_index_path(out);
         let pass2_spool_path = {
             let mut p = PathBuf::from(out);
@@ -218,10 +219,11 @@ impl<'a> OsmFeatureIndex<'a> {
             BufWriter::with_capacity(64 * 1024, File::create(&pass2_spool_path)?);
         for (i, item) in sorted1.enumerate() {
             // A LocalFeatureRef can only address up to u32::MAX features.
-            // Current planet-wide pruning keeps on the order of 500M
-            // features, well within range, but a future change to the
-            // pruning logic could conceivably push this past 2^32 --
-            // fail loudly rather than silently truncate/wrap.
+            // Current planet-wide pruning keeps on the order of 160
+            // million features (162,812,789, measured on the 2026-08-03
+            // planet snapshot), well within range, but a future change
+            // to the pruning logic could conceivably push this past
+            // 2^32 -- fail loudly rather than silently truncate/wrap.
             let local_index = u32::try_from(i).context(
                 "OsmFeatureIndex: more than u32::MAX features, \
                  LocalFeatureRef can no longer address them all",
@@ -237,13 +239,18 @@ impl<'a> OsmFeatureIndex<'a> {
                 pass2_writer.write_all(&local_index.to_le_bytes())?;
             }
         }
+        let feature_count = feature_storage_writer.entries_count();
         feature_storage_writer.close()?;
         pass2_writer.flush()?;
         drop(pass2_writer);
+        let pass1_elapsed = create_start.elapsed();
 
         // Pass 2.
+        let pass2_start = Instant::now();
         let pass2_spool_bytes = std::fs::metadata(&pass2_spool_path)?.len();
         log::info!(
+            elapsed_seconds = pass1_elapsed.as_secs_f64(),
+            feature_count = feature_count,
             bytes = pass2_spool_bytes,
             path = pass2_spool_path.display().to_string();
             "OsmFeatureIndex::create: pass 1 → pass 2 spool file"
@@ -267,8 +274,23 @@ impl<'a> OsmFeatureIndex<'a> {
             } = item?;
             inverted_index_writer.write(coverage_cell_id, match_mask, local_index)?;
         }
+        let inverted_index_entries = inverted_index_writer.entries_count();
         inverted_index_writer.close()?;
         remove_file(&pass2_spool_path)?;
+        let pass2_elapsed = pass2_start.elapsed();
+
+        let features_bytes = std::fs::metadata(out)?.len();
+        let inverted_index_bytes = std::fs::metadata(&inverted_index_path)?.len();
+        log::info!(
+            pass1_seconds = pass1_elapsed.as_secs_f64(),
+            pass2_seconds = pass2_elapsed.as_secs_f64(),
+            total_seconds = create_start.elapsed().as_secs_f64(),
+            feature_count = feature_count,
+            inverted_index_entries = inverted_index_entries,
+            features_bytes = features_bytes,
+            inverted_index_bytes = inverted_index_bytes;
+            "OsmFeatureIndex::create: done"
+        );
 
         Self::open(out)
     }
@@ -587,6 +609,13 @@ impl FeatureStorageWriter {
         Ok(())
     }
 
+    /// Number of entries written so far. For logging a summary once
+    /// writing is done -- read this before `close(self)` consumes the
+    /// writer.
+    fn entries_count(&self) -> u64 {
+        self.entries_count
+    }
+
     fn close(mut self) -> Result<()> {
         let blobs_size: u64 = self.blobs_writer.stream_position()?;
         self.starts_writer.write_all(&blobs_size.to_le_bytes())?;
@@ -684,6 +713,13 @@ impl InvertedIndexWriter {
 
         self.entries_count += 1;
         Ok(())
+    }
+
+    /// Number of entries written so far. For logging a summary once
+    /// writing is done -- read this before `close(self)` consumes the
+    /// writer.
+    fn entries_count(&self) -> u64 {
+        self.entries_count
     }
 
     fn close(mut self) -> Result<()> {


### PR DESCRIPTION
Follow-up to #660, prompted by manually testing it against the full OSM
planet (see discussion on #655): the only way to learn the feature
count, or how long pass 2 took, was to read them off the terminal's
indicatif progress bar (for the count) or infer them from filesystem
mtimes across two different clocks (for timing) — which is exactly how
a UTC-vs-local-time mixup during that investigation briefly looked like
a 2-hour pass 2, when it was actually ~14 seconds. None of that should
require reading tea leaves; it should be in the log.

- `OsmFeatureIndex::create()` now logs two lines: pass 1's completion
  (extended with `elapsed_seconds` and `feature_count`, alongside the
  existing pass-2-spool-file `bytes`/`path`) and a new `"done"` line
  with `pass1_seconds`/`pass2_seconds`/`total_seconds`, `feature_count`,
  `inverted_index_entries`, and both output files' byte sizes.
- `FeatureStorageWriter`/`InvertedIndexWriter` gain a small
  `entries_count()` getter each, so `create()` can read the count
  already being tracked internally rather than duplicating a counter.
- `build_index()` now logs when it skips rebuilding because
  `OsmFeatureIndex::exists(out)` already holds, matching the
  `"skipping build_coverage, already found ..."` pattern `coverage.rs`
  already uses — previously this path was silent, indistinguishable in
  the log from "there was nothing to skip".
- Corrected a code comment's feature-count estimate from a stale "500M"
  guess to the actual measured 162,812,789 (2026-08-03 planet
  snapshot).

## Testing
- Manually verified against the CLI + test fixtures: both new log
  lines fire with correct values (`feature_count`/sizes matching the
  on-disk files), and the skip-log fires when forcing `import_osm()`
  past its older, outer memoization gate to actually reach this code
  on a second run.
- `cargo test --lib` (241 passed), `cargo test --test integration_test`
  (4 passed), `cargo clippy --all-targets -- -D warnings` clean, `cargo
  fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)