### PR TITLE
Cut conflate over to OsmFeatureIndex

### DIFF
--- a/src/matchers/mod.rs
+++ b/src/matchers/mod.rs
@@ -252,13 +252,11 @@ fn meters_to_chord_angle(radius_meters: f64) -> ChordAngle {
 /// decoded `geo::Geometry` for Hausdorff-distance scoring, or a
 /// pre-tokenized name for Token Sort Ratio matching -- can attach fields
 /// here without another trait-signature change.
-#[allow(unused)]
 pub struct OsmCandidate<'a> {
     pub feature: &'a Feature,
     pub strings: &'a StringPool<'a>,
 }
 
-#[allow(unused)]
 impl<'a> OsmCandidate<'a> {
     /// Decodes `feature.tags` -- flat `[key_id, value_id, ...]` pairs of
     /// `StringPool` indices -- into `(key, value)` string pairs. Cheap: a
@@ -296,7 +294,6 @@ pub trait Matcher {
     /// geometry-aware `OsmFeatureIndex` path instead of `Place`. Landing
     /// alongside `score`/`suggest_edit` rather than replacing them, as
     /// part of a staged migration of OSM-side matching off `Place`.
-    #[allow(unused)]
     fn score_osm_candidate(&self, candidate: &OsmCandidate) -> f64;
 }
 
@@ -336,7 +333,6 @@ fn distance_score(pt: &Point, place: &Place, max_meters: f64) -> f64 {
 /// `Place`) doesn't carry a precomputed position, so callers scoring an
 /// [OsmCandidate] compute one themselves (e.g. a decoded geometry's
 /// centroid) and pass it in here.
-#[allow(unused)]
 fn geo_point_distance(pt: &Point, geo_pt: &geo::Point<f64>) -> f64 {
     let ll = s2::latlng::LatLng::from_degrees(geo_pt.y(), geo_pt.x());
     let pt2 = Point::from(ll);
@@ -344,7 +340,6 @@ fn geo_point_distance(pt: &Point, geo_pt: &geo::Point<f64>) -> f64 {
 }
 
 /// Like `distance_score`, but for [geo_point_distance].
-#[allow(unused)]
 fn geo_point_distance_score(pt: &Point, geo_pt: &geo::Point<f64>, max_meters: f64) -> f64 {
     let dist = geo_point_distance(pt, geo_pt);
     if dist <= max_meters {

--- a/src/pipeline/conflate/mod.rs
+++ b/src/pipeline/conflate/mod.rs
@@ -18,8 +18,16 @@ use std::{
         mpsc::{Receiver, SyncSender, sync_channel},
     },
     thread,
+    time::{Duration, Instant},
 };
 use time::UtcDateTime;
+
+/// How often [produce_rows] logs a progress/memory snapshot while
+/// running -- a wall-clock interval, not a feature count, since what
+/// matters here is watching RSS/page-cache behavior *over time* as this
+/// repeatedly queries and decodes from `OsmFeatureIndex`'s mmap'd
+/// tables, not RSS at a fixed fraction of progress.
+const PROGRESS_LOG_INTERVAL: Duration = Duration::from_secs(30);
 
 mod writer;
 use writer::{ParquetRow, ParquetWriter};
@@ -90,12 +98,29 @@ fn produce_rows(
         level_mod: 1,
     };
 
+    let start = Instant::now();
+    let atp_features_processed = AtomicU64::new(0);
+    let osm_candidates_decoded = AtomicU64::new(0);
+    // Wall-clock timestamp (millis since `start`) of the last progress
+    // log line, so concurrent workers can race on a compare_exchange to
+    // decide who logs next -- occasionally missing or double-logging a
+    // snapshot at the boundary is fine for a diagnostic like this.
+    let last_progress_log_ms = AtomicU64::new(0);
+
     for group in atp_index.scan_row_groups() {
         // Each group is processed by the Rayon thread pool in parallel,
         // but the outer loop is sequential — so nearby places (within a
         // group) always go to nearby workers, preserving spatial locality.
         group?.par_iter().try_for_each(|atp| {
             progress_bar.inc(1);
+            atp_features_processed.fetch_add(1, Ordering::Relaxed);
+            maybe_log_progress(start, &last_progress_log_ms, || {
+                (
+                    atp_features_processed.load(Ordering::Relaxed),
+                    osm_candidates_decoded.load(Ordering::Relaxed),
+                )
+            });
+
             let Some(matcher) = create_matcher(atp) else {
                 return Ok(());
             };
@@ -115,6 +140,7 @@ fn produce_rows(
             for (lo, hi) in MergedCellRanges::new(covering) {
                 for r in osm.index.query(lo..=hi, atp.mask) {
                     let feature = osm.index.get_feature(r)?;
+                    osm_candidates_decoded.fetch_add(1, Ordering::Relaxed);
                     let candidate = OsmCandidate {
                         feature: &feature,
                         strings: &osm.strings,
@@ -135,7 +161,57 @@ fn produce_rows(
     }
 
     progress_bar.finish();
+    log::info!(
+        elapsed_seconds = start.elapsed().as_secs_f64(),
+        atp_features_processed = atp_features_processed.load(Ordering::Relaxed),
+        osm_candidates_decoded = osm_candidates_decoded.load(Ordering::Relaxed);
+        "conflate.match: done"
+    );
     Ok(())
+}
+
+/// Logs a `conflate.match: progress` snapshot (elapsed time, the two
+/// counts from `counts`, and a `crate::memstats` snapshot -- `rss_bytes`/
+/// `rss_file_bytes` in particular, since that's where resident pages of
+/// `OsmFeatureIndex`'s mmap'd tables are expected to show up) at most
+/// once per [PROGRESS_LOG_INTERVAL], across however many parallel
+/// callers race to call this. `counts` is a closure, not plain
+/// arguments, so the (relaxed, so individually cheap) atomic loads to
+/// build it only happen on the rare call that actually ends up logging.
+fn maybe_log_progress(
+    start: Instant,
+    last_log_ms: &AtomicU64,
+    counts: impl FnOnce() -> (u64, u64),
+) {
+    let now_ms = start.elapsed().as_millis() as u64;
+    let last = last_log_ms.load(Ordering::Relaxed);
+    let interval_ms = PROGRESS_LOG_INTERVAL.as_millis() as u64;
+    if now_ms.saturating_sub(last) < interval_ms {
+        return;
+    }
+    if last_log_ms
+        .compare_exchange(last, now_ms, Ordering::Relaxed, Ordering::Relaxed)
+        .is_err()
+    {
+        return; // another thread already logged this interval
+    }
+
+    let (atp_features_processed, osm_candidates_decoded) = counts();
+    let stats = crate::memstats::snapshot();
+    log::info!(
+        elapsed_seconds = start.elapsed().as_secs_f64(),
+        atp_features_processed = atp_features_processed,
+        osm_candidates_decoded = osm_candidates_decoded,
+        rss_bytes = stats.rss_bytes,
+        rss_peak_bytes = stats.rss_peak_bytes,
+        rss_anon_bytes = stats.rss_anon_bytes,
+        rss_file_bytes = stats.rss_file_bytes,
+        rss_shmem_bytes = stats.rss_shmem_bytes,
+        cgroup_current_bytes = stats.cgroup_current_bytes,
+        cgroup_max_bytes = stats.cgroup_max_bytes,
+        cgroup_peak_bytes = stats.cgroup_peak_bytes;
+        "conflate.match: progress"
+    );
 }
 
 fn write_conflated(
@@ -146,6 +222,7 @@ fn write_conflated(
     pipeline_run_id: &str,
     pipeline_start_time: UtcDateTime,
 ) -> Result<()> {
+    let start = Instant::now();
     let row_count = AtomicU64::new(0);
     let sorter: ExternalSorter<ParquetRow, std::io::Error, MemoryLimitedBufferBuilder> =
         ExternalSorterBuilder::new()
@@ -172,5 +249,10 @@ fn write_conflated(
     }
     writer.close()?;
     progress.finish();
+    log::info!(
+        elapsed_seconds = start.elapsed().as_secs_f64(),
+        rows_written = row_count.load(Ordering::SeqCst);
+        "conflate.write: done"
+    );
     Ok(())
 }

--- a/src/pipeline/conflate/mod.rs
+++ b/src/pipeline/conflate/mod.rs
@@ -1,10 +1,10 @@
 use super::last_modified;
 use crate::{
     make_progress_bar,
-    matchers::{create_matcher, match_distance},
-    pipeline::osm::FeatureStore,
+    matchers::{OsmCandidate, create_matcher, match_distance},
     places::{Place, PlaceIndex},
     s2_util::MergedCellRanges,
+    tables::{Feature, OsmFeatures},
 };
 use anyhow::{Context, Ok, Result};
 use ext_sort::{ExternalSorter, ExternalSorterBuilder, buffer::mem::MemoryLimitedBufferBuilder};
@@ -28,14 +28,13 @@ use writer::{ParquetRow, ParquetWriter};
 pub fn conflate(
     atp: &Path,
     coverage: &Path,
-    osm: &Path,
-    osm_store: &dyn FeatureStore,
+    osm: &OsmFeatures,
     progress: &MultiProgress,
     workdir: &Path,
     pipeline_run_id: &str,
     pipeline_start_time: UtcDateTime,
 ) -> Result<PathBuf> {
-    let input_modified = last_modified(&[atp, coverage, osm])?;
+    let input_modified = last_modified(&[atp, coverage])?.max(osm.modified()?);
     let out_path = workdir.join("conflated.parquet");
     if out_path.exists() && last_modified(&[&out_path])? >= input_modified {
         return Ok(out_path);
@@ -46,20 +45,13 @@ pub fn conflate(
     let producer_progress =
         make_progress_bar(progress, "conflate.match", num_atp_features, "ATP features");
     let writer_progress = make_progress_bar(progress, "conflate.write", 0, "parquet rows");
-    let osm_index = PlaceIndex::open(osm, 32)?;
 
     let mut producer_result = Ok(());
     let mut writer_result = Ok(());
     thread::scope(|s| {
         let (tx, rx) = sync_channel::<ParquetRow>(8192);
         s.spawn(|| {
-            producer_result = produce_rows(
-                atp_index.clone(),
-                osm_index.clone(),
-                osm_store,
-                producer_progress,
-                tx,
-            );
+            producer_result = produce_rows(atp_index.clone(), osm, producer_progress, tx);
         });
         s.spawn(|| {
             writer_result = write_conflated(
@@ -81,14 +73,13 @@ pub fn conflate(
 #[allow(unused)]
 struct ConflatedFeature {
     atp: Option<Place>,
-    osm: Option<Place>,
+    osm: Option<Feature>,
     // TODO: Signals for ranking.
 }
 
 fn produce_rows(
     atp_index: Arc<PlaceIndex>,
-    osm_index: Arc<PlaceIndex>,
-    osm_store: &dyn FeatureStore,
+    osm: &OsmFeatures,
     progress_bar: ProgressBar,
     out: SyncSender<ParquetRow>,
 ) -> Result<()> {
@@ -122,39 +113,21 @@ fn produce_rows(
                 coverer.covering(&cap)
             };
             for (lo, hi) in MergedCellRanges::new(covering) {
-                let mut iter = osm_index.query(lo..=hi, atp.mask)?;
-                let mut best_candidate: Option<&Place> = None;
-                for candidate in &mut iter {
-                    let candidate = candidate?;
-                    let score = matcher.score(candidate);
+                for r in osm.index.query(lo..=hi, atp.mask) {
+                    let feature = osm.index.get_feature(r)?;
+                    let candidate = OsmCandidate {
+                        feature: &feature,
+                        strings: &osm.strings,
+                    };
+                    let score = matcher.score_osm_candidate(&candidate);
                     if score > best_score {
-                        best_candidate = Some(candidate);
                         best_score = score;
+                        conflated.osm = Some(feature);
                     }
-                }
-                if let Some(osm) = best_candidate {
-                    conflated.osm = Some(osm.deep_clone());
                 }
             }
 
-            // TODO: Use a custom function instead of try_from, so we
-            // can pass a reference to FeatureStore to extract the
-            // geometry (and any other attributes not needed for
-            // matching).
-            let row = ParquetRow::try_from(conflated)?;
-            if let Some(row_osm_id) = row.osm_id {
-                let osm_id = row_osm_id.get() / 10;
-                let osm_type = row_osm_id.get() % 10;
-                match osm_type {
-                    // TODO: Currently, we only get some result for ways.
-                    // Change the osm.filter step of the pipeline to construct
-                    // feature_index also for nodes and relations.
-                    1 => if let Some(_node) = osm_store.get_node(osm_id) {},
-                    2 => if let Some(_way) = osm_store.get_way(osm_id) {},
-                    3 => if let Some(_relation) = osm_store.get_relation(osm_id) {},
-                    _ => {}
-                };
-            };
+            let row = ParquetRow::from_conflated(conflated, &osm.strings)?;
             out.send(row)?;
 
             Ok(())

--- a/src/pipeline/conflate/writer.rs
+++ b/src/pipeline/conflate/writer.rs
@@ -1,4 +1,4 @@
-use anyhow::{Ok, Result};
+use anyhow::{Context, Ok, Result};
 use arrow::array::{
     ArrayRef, RecordBatch, StructArray,
     builder::{
@@ -8,6 +8,7 @@ use arrow::array::{
 use arrow_buffer::builder::NullBufferBuilder;
 use arrow_schema::{DataType, SchemaRef};
 use deepsize::DeepSizeOf;
+use geo::Centroid;
 use parquet::{
     arrow::{ArrowWriter, arrow_writer::ArrowWriterOptions},
     basic::{Compression, ZstdLevel},
@@ -23,6 +24,7 @@ use std::{
 };
 
 use super::ConflatedFeature;
+use crate::{matchers::OsmCandidate, tables::StringPool};
 
 pub struct ParquetWriter {
     path: PathBuf,
@@ -297,16 +299,40 @@ impl ParquetWriter {
     }
 }
 
-impl TryFrom<ConflatedFeature> for ParquetRow {
-    type Error = anyhow::Error;
-
-    fn try_from(cf: ConflatedFeature) -> Result<Self, Self::Error> {
+impl ParquetRow {
+    /// Replaces the old `TryFrom<ConflatedFeature>` -- unlike a `TryFrom`
+    /// impl, this can take the extra `osm_strings` parameter needed to
+    /// resolve an OSM `Feature`'s tag ids into actual strings.
+    pub(super) fn from_conflated(
+        cf: ConflatedFeature,
+        osm_strings: &StringPool,
+    ) -> Result<ParquetRow> {
         let atp = cf.atp;
         let osm = cf.osm;
-        let s2_cell_id = if let Some(ref osm) = osm {
-            osm.s2_cell_id
-        } else if let Some(ref atp) = atp {
+
+        // Internal sort key. Almost always available for free from `atp`
+        // -- `produce_rows` only ever calls this with `atp: Some(..)`,
+        // since it iterates ATP places outward, so the `osm`-only branch
+        // below is unreached today, kept only so this function stays
+        // correct if a caller ever does construct an OSM-only row (e.g.
+        // a future "suggest creating this as a new OSM feature" flow).
+        // Feature carries no precomputed position the way Place does
+        // (see https://github.com/alltheplaces/osm-diffs/issues/662), so
+        // that branch has to decode geometry and compute a centroid --
+        // fine for a today-unreached path, not fine to do unconditionally.
+        let s2_cell_id = if let Some(ref atp) = atp {
             atp.s2_cell_id
+        } else if let Some(ref feature) = osm {
+            let candidate = OsmCandidate {
+                feature,
+                strings: osm_strings,
+            };
+            let centroid = candidate
+                .geometry()?
+                .centroid()
+                .context("OSM feature geometry has no centroid")?;
+            let ll = s2::latlng::LatLng::from_degrees(centroid.y(), centroid.x());
+            s2::cellid::CellID::from(ll).0
         } else {
             anyhow::bail!("ConflatedRow must not have atp and osm both None")
         };
@@ -332,12 +358,23 @@ impl TryFrom<ConflatedFeature> for ParquetRow {
         let osm_version;
         let osm_shape_wkb;
         let osm_tags;
-        if let Some(osm) = osm {
-            osm_id = osm.osm_id;
-            osm_changeset = osm.osm_changeset;
-            osm_version = osm.osm_version;
-            osm_shape_wkb = wkb(&osm.shape());
-            osm_tags = osm.tags;
+        if let Some(feature) = osm {
+            osm_id = NonZeroU64::new(feature.id);
+            osm_changeset = NonZeroU64::new(feature.changeset);
+            osm_version = NonZeroU32::new(feature.version);
+            osm_tags = feature
+                .tags
+                .chunks_exact(2)
+                .map(|kv| {
+                    (
+                        osm_strings.get(kv[0] as usize).to_owned(),
+                        osm_strings.get(kv[1] as usize).to_owned(),
+                    )
+                })
+                .collect();
+            // Already valid OGC Simple Features WKB -- no reconstruction
+            // from a synthetic point needed, unlike the old Place path.
+            osm_shape_wkb = feature.geometry_wkb;
         } else {
             osm_id = None;
             osm_changeset = None;

--- a/src/pipeline/conflate/writer.rs
+++ b/src/pipeline/conflate/writer.rs
@@ -300,9 +300,10 @@ impl ParquetWriter {
 }
 
 impl ParquetRow {
-    /// Replaces the old `TryFrom<ConflatedFeature>` -- unlike a `TryFrom`
-    /// impl, this can take the extra `osm_strings` parameter needed to
-    /// resolve an OSM `Feature`'s tag ids into actual strings.
+    /// Builds a `ParquetRow` from a matched (or unmatched) ATP/OSM pair.
+    /// An inherent function rather than a `TryFrom` impl so it can take
+    /// `osm_strings`, needed to resolve an OSM `Feature`'s tag ids into
+    /// actual strings.
     pub(super) fn from_conflated(
         cf: ConflatedFeature,
         osm_strings: &StringPool,
@@ -330,7 +331,7 @@ impl ParquetRow {
             let centroid = candidate
                 .geometry()?
                 .centroid()
-                .context("OSM feature geometry has no centroid")?;
+                .with_context(|| format!("OSM feature {} geometry has no centroid", feature.id))?;
             let ll = s2::latlng::LatLng::from_degrees(centroid.y(), centroid.x());
             s2::cellid::CellID::from(ll).0
         } else {

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -53,15 +53,14 @@ pub fn run_pipeline(
     let coverage = run_step("build_coverage", || {
         crate::coverage::build_coverage(&atp, &progress, workdir)
     })?;
-    let (osm_parquet, osm_store) = run_step("import_osm", || {
+    let (osm_parquet, osm_features) = run_step("import_osm", || {
         osm::import_osm(&coverage, &progress, workdir)
     })?;
     let _conflated = run_step("conflate", || {
         conflate::conflate(
             &atp,
             &coverage,
-            &osm_parquet,
-            &*osm_store,
+            &osm_features,
             &progress,
             workdir,
             pipeline_run_id,

--- a/src/pipeline/osm/assemble.rs
+++ b/src/pipeline/osm/assemble.rs
@@ -19,7 +19,7 @@ use rayon::prelude::*;
 use s2::{cellid::CellID, cellunion::CellUnion};
 use std::{
     fs::File,
-    path::Path,
+    path::{Path, PathBuf},
     sync::{
         atomic::{AtomicU64, Ordering},
         mpsc::sync_channel,
@@ -65,12 +65,20 @@ pub fn assemble<'a>(
     })
 }
 
+/// Where [assemble_strings] writes its `StringPool`. Exposed so callers
+/// that need to reopen it later (e.g. `import_osm`'s memoized-shortcut
+/// path, once it also needs to return a `StringPool`) don't have to
+/// duplicate the literal path.
+pub(super) fn strings_path(workdir: &Path) -> PathBuf {
+    workdir.join("osm-assemble.strings")
+}
+
 fn assemble_strings<'a>(
     strings: &StringCounts,
     progress: &MultiProgress,
     workdir: &Path,
 ) -> Result<StringPool<'a>> {
-    let string_pool_path = workdir.join("osm-assemble.strings");
+    let string_pool_path = strings_path(workdir);
     if string_pool_path.exists() {
         let input_modified = strings.modified()?;
         let output_modified = std::fs::metadata(&string_pool_path)?.modified()?;

--- a/src/pipeline/osm/filter.rs
+++ b/src/pipeline/osm/filter.rs
@@ -44,6 +44,12 @@ impl<'a> FilteredFeatureStore<'a> {
             && workdir.join("osm-filtered-relations").exists()
     }
 
+    // import_osm()'s memoized-shortcut path used to open a
+    // FilteredFeatureStore here (to hand back to conflate's old
+    // Place-based path); unused now that conflate looks up matched OSM
+    // features via OsmFeatureIndex instead. Left in place -- see the
+    // note on FeatureStore's get_node/get_way/get_relation.
+    #[allow(unused)]
     pub fn open(workdir: &Path) -> Result<FilteredFeatureStore<'a>> {
         let nodes = FilteredFile::open(&workdir.join("osm-filtered-nodes"))?;
         let ways = FilteredFile::open(&workdir.join("osm-filtered-ways"))?;
@@ -874,6 +880,10 @@ pub mod filtered_file {
             Some(&self.feature_data[start..limit])
         }
 
+        // Only ever called from FeatureStore::get_way/get_relation's
+        // implementations, unused for the same reason those are -- see
+        // the note on FeatureStore's get_node/get_way/get_relation.
+        #[allow(unused)]
         pub fn feature_index(&self, id: u64) -> Option<u64> {
             let index = if cfg!(target_endian = "little") {
                 self.feature_index_keys.binary_search(&id)

--- a/src/pipeline/osm/mod.rs
+++ b/src/pipeline/osm/mod.rs
@@ -17,6 +17,7 @@ use time::UtcDateTime;
 use time::format_description::well_known::Rfc3339;
 
 use crate::coverage::Coverage;
+use crate::tables::OsmFeatures;
 use crate::utils::to_hex;
 use crate::{make_download_bar, make_progress_bar};
 
@@ -33,17 +34,22 @@ mod prune;
 use filter::FilteredFeatureStore;
 use prune::Prunings;
 
-pub fn import_osm(
+pub fn import_osm<'a>(
     coverage: &Path,
     progress: &MultiProgress,
     workdir: &Path,
-) -> Result<(PathBuf, Box<dyn FeatureStore>)> {
+) -> Result<(PathBuf, OsmFeatures<'a>)> {
     assert!(workdir.exists());
 
     let out_path = workdir.join("osm.parquet");
-    if out_path.exists() && FilteredFeatureStore::exists(workdir) {
-        let store = FilteredFeatureStore::open(workdir)?;
-        return Ok((out_path, Box::new(store)));
+    let osm_index_path = workdir.join("osm-features.index");
+    let strings_path = assemble::strings_path(workdir);
+    if out_path.exists()
+        && FilteredFeatureStore::exists(workdir)
+        && OsmFeatures::exists(&osm_index_path, &strings_path)
+    {
+        let osm_features = OsmFeatures::open(&osm_index_path, &strings_path)?;
+        return Ok((out_path, osm_features));
     }
 
     let (pbf, fetch_metadata) = fetch::fetch_planet(progress, workdir)?;
@@ -65,18 +71,15 @@ pub fn import_osm(
 
     let prunings = Prunings::create(&mut reader, progress, workdir)?;
     let assembly = assemble::assemble(&mut reader, &prunings, progress, workdir)?;
-    let _osm_index = index::build_index(
-        &assembly,
-        progress,
-        workdir,
-        &workdir.join("osm-features.index"),
-    )?;
-    if false {
-        todo!();
-    }
+    let index = index::build_index(&assembly, progress, workdir, &osm_index_path)?;
+    let osm_features = OsmFeatures {
+        index,
+        strings: assembly.strings,
+    };
 
     // TODO: Remove the old version of the pipeline (everything below),
-    // once the new code actually works.
+    // once conflate/suggest_edits no longer need it (suggest_edits still
+    // does, as of this writing).
     let coverage = Coverage::load(coverage)
         .with_context(|| format!("could not open coverage file `{:?}`", coverage))?;
 
@@ -124,7 +127,7 @@ pub fn import_osm(
     let feature_store = filter::FilteredFeatureStore::new(nodes, ways, relations);
     old_assemble::assemble(&feature_store, progress, workdir, &out_path)?;
 
-    Ok((out_path, Box::new(feature_store)))
+    Ok((out_path, osm_features))
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -183,8 +186,17 @@ enum RelationMember {
 /// Abstracts OSM feature retrieval, so the geometry logic is independent of the storage.
 /// Implemented by MockFeatureStore for testing, and FilteredFeatureStore in production.
 pub trait FeatureStore: Send + Sync {
+    // get_node/get_way/get_relation were, until now, used by conflate's
+    // old Place-based path -- unused now that conflate looks up matched
+    // OSM features via OsmFeatureIndex instead. Left in place, not
+    // deleted, since FeatureStore/FilteredFeatureStore are still needed
+    // by the rest of the old pipeline (removal tracked as part of
+    // deleting the old path entirely, see #655).
+    #[allow(unused)]
     fn get_node(&self, id: u64) -> Option<Node>;
+    #[allow(unused)]
     fn get_way(&self, id: u64) -> Option<Way>;
+    #[allow(unused)]
     fn get_relation(&self, id: u64) -> Option<Relation>;
 
     fn node_count(&self) -> u64;

--- a/src/tables/feature_index.rs
+++ b/src/tables/feature_index.rs
@@ -65,7 +65,7 @@
 
 use crate::matchers::MatchMask;
 use crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES;
-use crate::tables::{Feature, FeatureToIndex};
+use crate::tables::{Feature, FeatureToIndex, StringPool};
 use anyhow::{Context, Result};
 use deepsize::DeepSizeOf;
 use ext_sort::{
@@ -119,7 +119,13 @@ pub struct LocalFeatureRef(u32);
 pub struct OsmFeatureIndex<'a> {
     features_file: File,
     _features_mmap: Mmap,
+    // Backs len()/is_empty()/feature_id(), not yet called by any real
+    // caller (conflate always decodes the full Feature via get_feature()
+    // instead) -- may be picked up once suggest_edits also moves onto
+    // this index.
+    #[allow(unused)]
     entries_count: usize,
+    #[allow(unused)]
     id: &'a [u64],
     starts: &'a [u64],
     blobs: &'a [u8],
@@ -405,11 +411,13 @@ impl<'a> OsmFeatureIndex<'a> {
     }
 
     /// The number of features in this index.
+    #[allow(unused)]
     pub fn len(&self) -> usize {
         self.entries_count
     }
 
     /// Whether this index has no features.
+    #[allow(unused)]
     pub fn is_empty(&self) -> bool {
         self.entries_count == 0
     }
@@ -462,6 +470,7 @@ impl<'a> OsmFeatureIndex<'a> {
     /// for {node,way,relation}, same encoding as `Feature.id` elsewhere in
     /// this codebase (see `make_feature_id`/`feature_to_osm_id` in
     /// `pipeline::osm::assemble`). O(1), array read only -- no decode.
+    #[allow(unused)]
     pub fn feature_id(&self, r: LocalFeatureRef) -> u64 {
         u64::from_le(self.id[r.0 as usize])
     }
@@ -474,6 +483,53 @@ impl<'a> OsmFeatureIndex<'a> {
         let end = usize::try_from(u64::from_le(self.starts[i + 1]))?;
         Feature::decode(&self.blobs[start..end])
             .with_context(|| format!("failed to decode Feature at {r:?}"))
+    }
+}
+
+/// Bundles an [OsmFeatureIndex] with the [StringPool] needed to resolve
+/// its features' tag ids. The two are built independently -- the string
+/// pool is built earlier, by a different pipeline stage, and shared by
+/// every consumer of the index, not owned by `OsmFeatureIndex` itself --
+/// but almost always used together, so this exists purely so callers
+/// have one thing to pass around instead of two.
+///
+/// `OsmFeatureIndex` deliberately stays `StringPool`-agnostic: it
+/// doesn't need one for its own job (storing/querying `Feature` protos),
+/// only callers decoding tags do. Compare [crate::matchers::OsmCandidate],
+/// which pairs a single `&Feature` with `&StringPool` the same way, one
+/// level down (a single candidate rather than the whole index).
+pub struct OsmFeatures<'a> {
+    pub index: OsmFeatureIndex<'a>,
+    pub strings: StringPool<'a>,
+}
+
+impl<'a> OsmFeatures<'a> {
+    /// Whether both of `index_path`'s files and `strings_path` already
+    /// exist -- for callers that memoize an expensive build step behind
+    /// an existence check rather than reopening unconditionally.
+    pub fn exists(index_path: &Path, strings_path: &Path) -> bool {
+        OsmFeatureIndex::exists(index_path) && strings_path.exists()
+    }
+
+    /// Opens an already-built index and string pool. Doesn't build
+    /// either from scratch -- unlike `OsmFeatureIndex`, there's no
+    /// single `OsmFeatures::create()`, since the index and string pool
+    /// are built by different pipeline stages at different times; a
+    /// caller that already has both values in hand (e.g. because it just
+    /// built them) can just construct `OsmFeatures { index, strings }`
+    /// directly instead.
+    pub fn open(index_path: &Path, strings_path: &Path) -> Result<OsmFeatures<'a>> {
+        Ok(OsmFeatures {
+            index: OsmFeatureIndex::open(index_path)?,
+            strings: StringPool::open(strings_path)?,
+        })
+    }
+
+    /// The later of the index's and string pool's own modification
+    /// times, for a caller doing its own staleness check against this
+    /// bundle as a single unit.
+    pub fn modified(&self) -> Result<SystemTime> {
+        Ok(self.index.modified()?.max(self.strings.modified()?))
     }
 }
 

--- a/src/tables/mod.rs
+++ b/src/tables/mod.rs
@@ -8,7 +8,6 @@
 #[allow(unused)]
 mod blob_table;
 mod coord_table;
-#[allow(unused)]
 mod feature_index;
 #[allow(unused)]
 mod geometry_store;
@@ -29,7 +28,8 @@ mod features {
 pub use blob_table::BlobTable;
 pub use coord_table::CoordTable;
 #[allow(unused)]
-pub use feature_index::{LocalFeatureRef, OsmFeatureIndex};
+pub use feature_index::LocalFeatureRef;
+pub use feature_index::{OsmFeatureIndex, OsmFeatures};
 pub use features::{Feature, FeatureToIndex, RelationMember};
 #[allow(unused)]
 pub use geometry_store::GeometryStore;

--- a/src/tables/string_pool.rs
+++ b/src/tables/string_pool.rs
@@ -81,13 +81,14 @@ use std::{
     io,
     io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write},
     path::{Path, PathBuf},
+    time::SystemTime,
 };
 
 /// Read-only, memory-mapped table of strings, retrievable both by
 /// original insertion index ([StringPool::get]) and by value
 /// ([StringPool::lookup]). See the "File format" section above.
 pub struct StringPool<'a> {
-    _file: File,
+    file: File,
     _mmap: Mmap,
     len: usize,
     buckets: &'a [u32],
@@ -254,7 +255,7 @@ impl<'a> StringPool<'a> {
         };
 
         Ok(StringPool {
-            _file: file,
+            file,
             _mmap: mmap,
             len,
             buckets,
@@ -281,6 +282,11 @@ impl<'a> StringPool<'a> {
     #[allow(unused)]
     pub fn len(&self) -> usize {
         self.len
+    }
+
+    /// Returns the modification time of the backing file.
+    pub fn modified(&self) -> Result<SystemTime> {
+        Ok(self.file.metadata()?.modified()?)
     }
 
     /// Returns the index under which `key` was stored (as accepted by


### PR DESCRIPTION
PR 4 of the staged sequence tracked in #655. This is the PR the whole
effort is actually about — real OSM geometry in `conflated.parquet`.

`conflate()` no longer touches `Place`/`PlaceIndex` or `FeatureStore` on
the OSM side: it takes a `&tables::OsmFeatures` (new bundle type — an
`OsmFeatureIndex` plus the `StringPool` needed to resolve its tag ids,
built independently by different pipeline stages but almost always used
together) instead of `osm: &Path` + `osm_store: &dyn FeatureStore`.
`ConflatedFeature.osm` is now `Option<Feature>`. `produce_rows` queries
the new index, decodes each surviving candidate via `get_feature()`, and
scores it with `PoiMatcher::score_osm_candidate` (added in #661) instead
of the `Place`-based `score()`. This also deletes the entirely-dead
`osm_store.get_node/way/relation` block conflate carried since #656 —
its results were always discarded; the TODO above it ("use a custom
function instead of try_from, so we can pass a reference to FeatureStore
to extract the geometry") is exactly what this PR does, just via
`OsmFeatureIndex` instead of `FeatureStore`.

**writer.rs**: `TryFrom<ConflatedFeature> for ParquetRow` becomes
`ParquetRow::from_conflated(cf, osm_strings)` — an inherent function can
take the extra `StringPool` parameter a trait impl can't.
`osm_shape_wkb` is now `feature.geometry_wkb`, unchanged — already valid
OGC Simple Features WKB, no more reconstructing a synthetic point from
an S2 cell. The GeoParquet-style schema already had a real
`osm.geometry` column; only the value was ever wrong.

**import_osm()** returns `(PathBuf, OsmFeatures<'a>)` instead of
`(PathBuf, Box<dyn FeatureStore>)` — `osm.parquet`'s path is kept
(`suggest_edits`, PR 5, still needs it), the `FeatureStore` side is
dropped now that nothing needs it. Its own memoized-shortcut path now
also checks `OsmFeatures::exists()` before taking the fast path.

**tables::OsmFeatures { index, strings }**: `exists()`/`open()`/
`modified()` (the latter the max of both components' own `modified()`,
so a caller doing its own staleness check treats the pair as one unit —
conflate uses this right away). `OsmFeatureIndex` itself stays
`StringPool`-agnostic on purpose — it doesn't need one for its own job,
only callers decoding tags do, same reasoning as `OsmCandidate` pairing
`&Feature` with `&StringPool` one level down. `StringPool` gained the
matching `modified()` (it already held onto its `File`, just as
`_file`, unused until now).

**Old-path fallout**, marked `#[allow(unused)]` rather than deleted (out
of scope for this PR — `FeatureStore`/`FilteredFeatureStore` are still
used by the rest of the old path, removal is PR 6):
`FeatureStore::get_node/get_way/get_relation`,
`FilteredFeatureStore::open`, `FilteredFile::feature_index`.

## Testing

Verified against the CLI + test fixtures, not just `cargo test`: all 3
real `brand:wikidata` matches in the fixture (Tchibo/MediaMarkt/Denner,
the same candidates identified while planning #655) now come back as
**POLYGON** in `conflated.parquet`'s `osm.geometry` column, not the old
synthetic POINT — checked via DuckDB's spatial extension, which reads
the file's GeoParquet-style metadata natively:

```
┌─────────┬───────────┬────────────┬────────────────┐
│  type   │    id     │   spider   │ osm_geom_type  │
├─────────┼───────────┼────────────┼────────────────┤
│ way     │ 608979139 │ tchibo     │ POLYGON        │
│ way     │ 737021556 │ mediamarkt │ POLYGON        │
│ way     │ 737021557 │ denner_ch  │ POLYGON        │
└─────────┴───────────┴────────────┴────────────────┘
```

Tags/changeset/version cross-checked against the raw fixture data.
ATP-side geometry unaffected (still POINT, as expected — ATP stays on
`Place`). Second run confirmed `conflated.parquet` is correctly
memoized (unchanged mtime).

`cargo test --lib` (246 passed), `cargo test --test integration_test`
(4 passed), `cargo clippy --all-targets -- -D warnings` clean, `cargo
fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)