### PR TITLE
cloud_test.py: raise LimitNOFILE for the osm-diffs-run unit

### DIFF
--- a/scripts/test-branch-on-hetzner/cloud_test.py
+++ b/scripts/test-branch-on-hetzner/cloud_test.py
@@ -263,6 +263,14 @@ def cmd_start(args):
     ssh_cmd(
         ip,
         "systemd-run --unit=osm-diffs-run --collect "
+        # Debian's systemd defaults new units to the same 1024
+        # soft-limit open-file cap an interactive shell gets --
+        # switching to systemd-run does NOT fix the EMFILE crash a
+        # large external sort's spilled-chunk merge hit during the
+        # PR 665 experiment (build_coverage, specifically). Raise it
+        # explicitly rather than relying on ambient defaults that
+        # already bit us once.
+        "--property=LimitNOFILE=65536:65536 "
         f"--working-directory={REMOTE_DIR} -- "
         f"/usr/local/bin/osm-diffs run --workdir {shlex.quote(workdir)}",
     )


### PR DESCRIPTION
Follow-up caught while reviewing what last night's manual PR 665 experiment learned that isn't yet encoded in #668's tooling.

`start` launches the pipeline via `systemd-run --unit=osm-diffs-run`, but nothing raises its file descriptor limit. Debian's systemd defaults new transient units to the same 1024-soft-limit open-file cap an interactive shell gets (matches `ulimit -a` on all three machines from the PR 665 experiment: soft 1024, hard 524288) -- so switching `start`'s launch mechanism from an interactive shell to `systemd-run` did **not** fix the `EMFILE` crash `build_coverage`'s external-sort spilled-chunk merge hit that night. A real full-planet run through `start` would very likely hit it again, silently.

Fix: `--property=LimitNOFILE=65536:65536` on the `osm-diffs-run` unit specifically (the monitor doesn't need it).

Not verified against a live VM -- `systemd-run --property=` is standard, well-documented syntax, and the change is low-risk enough that it's not worth spinning up a machine solely to confirm it before merging. Worth keeping an eye on during the next real `start`, and easy to fix if it turns out to need adjusting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
