### PR TITLE
cloud_test.py: fix AttributeError when up calls start

### DIFF
--- a/scripts/test-branch-on-hetzner/cloud_test.py
+++ b/scripts/test-branch-on-hetzner/cloud_test.py
@@ -243,7 +243,10 @@ def cmd_start(args):
     ip = server_ip(args.name)
     workdir = workdir_for(args.name)
 
-    if args.clean:
+    # getattr, not args.clean: cmd_up() calls this reusing "up"'s own
+    # argparse namespace, which has no --clean flag (only "start"'s
+    # does) -- args.clean would raise AttributeError there.
+    if getattr(args, "clean", False):
         print(f"Clearing {workdir}, keeping the planet download ...", file=sys.stderr)
         keep = " ".join(f"! -name {shlex.quote(f)}" for f in PLANET_FILES)
         ssh_cmd(ip, f"find {shlex.quote(workdir)} -mindepth 1 {keep} -delete")


### PR DESCRIPTION
Real bug, caught during today's memory-pressure validation run (see #665): `cmd_up()` calls `cmd_start(args)` reusing `up`'s own argparse namespace, which never defined `--clean` (only `start`'s parser does) — crashed with `AttributeError: 'Namespace' object has no attribute 'clean'` right after `create`+`deploy` had already succeeded (built and installed the binary on a real, now-paid-for VM).

Not caught by the earlier shakedown because that exercised `create`/`deploy`/`start` as separate commands, never `up` as one composite call — a real gap in that testing, now closed by extension (this is exactly the kind of thing worth remembering: subcommands passing tested in isolation doesn't mean their composition is tested).

Fix: `getattr(args, "clean", False)` in `cmd_start` instead of `args.clean`, so it works regardless of which subparser's namespace it's called with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)