### PR TITLE
Rename test-container.yml's workflow to "Container Tests"

### DIFF
--- a/.github/workflows/test-container.yml
+++ b/.github/workflows/test-container.yml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026 Sascha Brawer <sascha@brawer.ch>
 # SPDX-License-Identifier: MIT
 
-name: Tests
+name: Container Tests
 
 on:
   push:


### PR DESCRIPTION
Both \`test.yml\` and \`test-container.yml\` were named plain "Tests" -- identical in the GitHub Actions tab, hard to tell apart at a glance. Renaming this one specifically since it's safe to: the branch-protection ruleset's required status check is keyed to \`test.yml\`'s *job* name ("Execute unit and integration tests"), confirmed via \`gh api repos/alltheplaces/osm-diffs/rulesets/11597145\` -- not either workflow's \`name:\` field. This change doesn't touch what gates merges to \`main\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)