### PR TITLE
Add docs/CONTRIBUTING.md and docs/TESTING.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,6 @@ feed edit proposals to [MapRoulette](https://maproulette.org/) where
 human users can manually check each edit before applying it to
 OpenStreetMap.
 
-See [`docs/`](docs/) for how to cut a release and the supply-chain
-security practices behind it.
+New here? See [`docs/CONTRIBUTING.md`](docs/CONTRIBUTING.md) to get
+started, and [`docs/`](docs/) generally for testing, cutting a
+release, and our security practices.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# Contributing
+
+Thanks for taking a look at `osm-diffs`! 👋 Contributions, questions,
+and bug reports are all welcome — this project is still early, so
+there's no such thing as too small a
+[Pull Request (PR)](https://docs.github.com/en/pull-requests/get-started/about-pull-requests).
+
+Please be kind to each other and to maintainers; see our
+[Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Before opening a Pull Request
+
+```sh
+cargo fmt
+cargo clippy --all-targets -- -D warnings
+cargo test
+```
+
+These match what CI runs on every PR (see
+[`.github/workflows/test.yml`](../.github/workflows/test.yml) for the
+exact invocations, including a minimum test-coverage threshold `cargo
+test` alone doesn't check). Running them locally first saves a
+round-trip through CI.
+
+## Where to go next
+
+- [`docs/TESTING.md`](TESTING.md) — how this project's tests are
+  organized, and how to try a change on real full-planet data before
+  it lands.
+- [`docs/RELEASING.md`](RELEASING.md) — how a release actually ships,
+  for once your change has landed on `main`.
+
+That's it — open a PR, and we'll take it from there. 🙂

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,9 @@
 # Documentation
 
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — start here if you're new.
+- [`TESTING.md`](TESTING.md) — how this project's tests are organized,
+  what CI enforces, and how to try a change on real hardware before it
+  lands.
 - [`RELEASING.md`](RELEASING.md) — how to cut a release of `osm-diffs`.
 - [`SUPPLY_CHAIN_SECURITY.md`](SUPPLY_CHAIN_SECURITY.md) — the concepts
   behind our release process: containers, multi-architecture images,

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -7,3 +7,5 @@ We prefer that you use the [GitHub mechanism for privately reporting a vulnerabi
 [repository’s security tab](https://github.com/alltheplaces/osm-diffs/security), click "Report a vulnerability" to open the advisory form.
 
 For how we secure the release process itself — build provenance, SBOMs, signed attestations — see [`SUPPLY_CHAIN_SECURITY.md`](https://github.com/alltheplaces/osm-diffs/blob/main/docs/SUPPLY_CHAIN_SECURITY.md).
+
+We also run [SAST](https://en.wikipedia.org/wiki/Static_application_security_testing) via [GitHub CodeQL](https://codeql.github.com/) on every change, enforced by branch protection on `main` — see [`TESTING.md`](https://github.com/alltheplaces/osm-diffs/blob/main/docs/TESTING.md) for details.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,66 @@
+# Testing
+
+## Running Tests
+
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the commands to run before
+opening a PR (formatting, linting, tests) — not repeated here to avoid
+two copies going stale independently.
+
+## Test Structure
+
+- **Unit tests**: in source files, as `#[cfg(test)]` modules (standard
+  Rust pattern).
+- **Integration tests**: [`tests/`](../tests) — a full pipeline run
+  against a real OSM extract (a Swiss shopping mall) plus minimal
+  AllThePlaces data. Fast enough to run on every `cargo test`.
+
+## CI
+
+Every PR and push to `main` runs
+[`test.yml`](../.github/workflows/test.yml) (formatting, linting,
+tests, and a minimum coverage threshold) and
+[`codeql.yml`](../.github/workflows/codeql.yml) (static analysis).
+PRs that touch `Containerfile` or `scripts/sbom/` also run
+[`test-container.yml`](../.github/workflows/test-container.yml).
+
+Test coverage is measured with [`cargo-llvm-cov`](https://github.com/taiki-e/cargo-llvm-cov)
+(`cargo llvm-cov test`, using `rustc`'s built-in LLVM source-based
+coverage instrumentation), exported as
+[Cobertura XML](https://www.baeldung.com/cobertura) — originally a
+Java coverage tool's report format, now emitted by plenty of non-Java
+tools too, `cargo-llvm-cov` among them — and uploaded to
+[Coveralls](https://coveralls.io/github/alltheplaces/osm-diffs?branch=main)
+— that's the little coverage badge at the top of the main
+[`README.md`](../README.md). CI fails if line coverage drops below the
+threshold set in `test.yml`.
+
+[SAST](https://en.wikipedia.org/wiki/Static_application_security_testing)
+is handled by [GitHub CodeQL](https://codeql.github.com/)
+(`codeql.yml`), which builds a semantic model of the code and queries
+it for known vulnerability patterns — unsafe deserialization, command
+injection, that kind of thing — rather than just linting for style.
+On a PR, findings post directly on the review thread.
+`codeql.yml` also runs on a weekly schedule against `main`, independent
+of any PR or push; *those* findings don't have a PR to comment on, so
+they show up instead as code scanning alerts on the repository's
+[Security tab](https://github.com/alltheplaces/osm-diffs/security).
+
+`main` is protected by a
+[ruleset](https://github.com/alltheplaces/osm-diffs/rules/11597145)
+requiring `test.yml`'s tests and a clean CodeQL scan before merging —
+so a red check there isn't optional. `test-container.yml` isn't part
+of that ruleset (it only triggers on the paths above, and GitHub can't
+gate merges on a check that doesn't always run) — treat a failure
+there as seriously as any other, it just isn't enforced the same way.
+
+## For Large System Changes
+
+Neither of these runs in CI — both are for ad hoc validation against
+real hardware before a change lands, not automated gates:
+
+- [`scripts/test-branch-on-macos/`](../scripts/test-branch-on-macos) —
+  full pipeline on your dev machine. Free, fast to iterate with.
+- [`scripts/test-branch-on-hetzner/`](../scripts/test-branch-on-hetzner)
+  — full pipeline on real cloud hardware, built from your feature
+  branch. Costs real money and needs Hetzner credentials — see its
+  README before reaching for it.


### PR DESCRIPTION
Two new docs, split per discussion: \`CONTRIBUTING.md\` for the actual dev-loop commands (kept in sync with \`test.yml\` by linking to it rather than duplicating the exact invocations), \`TESTING.md\` for the higher-level picture (test structure, what CI enforces and how, the two \`scripts/test-branch-on-*\` tools for validating a change on real hardware before it lands).

Verified while writing this, not assumed:
- Branch protection on \`main\` is a [ruleset](https://github.com/alltheplaces/osm-diffs/rules/11597145), not classic branch protection (\`gh api repos/alltheplaces/osm-diffs/branches/main/protection\` 404s "Branch not protected").
- The ruleset's required status check is keyed to \`test.yml\`'s **job** name ("Execute unit and integration tests"), not either workflow's \`name:\` field -- companion PR #673 renames \`test-container.yml\`'s workflow name safely on that basis.
- CodeQL is also an enforced gate via the same ruleset (\`code_scanning\` rule, \`alerts_threshold: "all"\`), not just an informational scan.

Also updates \`README.md\` to point new contributors at \`CONTRIBUTING.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)