### PR TITLE
docs/CONTRIBUTING.md: drop coverage-threshold detail

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -18,9 +18,8 @@ cargo test
 
 These match what CI runs on every PR (see
 [`.github/workflows/test.yml`](../.github/workflows/test.yml) for the
-exact invocations, including a minimum test-coverage threshold `cargo
-test` alone doesn't check). Running them locally first saves a
-round-trip through CI.
+exact invocations). Running them locally first saves a round-trip
+through CI — see [`TESTING.md`](TESTING.md) for what else CI checks.
 
 ## Where to go next
 


### PR DESCRIPTION
Small follow-up to #674: the coverage-threshold parenthetical was a bit of a detail for CONTRIBUTING.md's high-level newcomer checklist. TESTING.md already covers it in full ("Test coverage is measured with cargo-llvm-cov..."), so this just drops it from CONTRIBUTING.md and points there instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)