### PR TITLE
docs/CONTRIBUTING.md: spell out CI, link to test.yml

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -6,7 +6,7 @@ there's no such thing as too small a
 [Pull Request (PR)](https://docs.github.com/en/pull-requests/get-started/about-pull-requests).
 
 Please be kind to each other and to maintainers; see our
-[Code of Conduct](CODE_OF_CONDUCT.md).
+[Code of Conduct](https://github.com/alltheplaces/osm-diffs/blob/main/docs/CODE_OF_CONDUCT.md).
 
 ## Before opening a Pull Request
 
@@ -18,16 +18,18 @@ cargo test
 
 After you've sent a Pull Request, our Continuous Integration (CI) runs a
 series of checks on it — the commands above match
-[what CI runs](../.github/workflows/test.yml). Running them locally
-first saves a round-trip through CI — see [`TESTING.md`](TESTING.md)
+[what CI runs](https://github.com/alltheplaces/osm-diffs/blob/main/.github/workflows/test.yml).
+Running them locally first saves a round-trip through CI — see
+[`TESTING.md`](https://github.com/alltheplaces/osm-diffs/blob/main/docs/TESTING.md)
 for what else CI checks.
 
 ## Where to go next
 
-- [`docs/TESTING.md`](TESTING.md) — how this project's tests are
-  organized, and how to try a change on real full-planet data before
-  it lands.
-- [`docs/RELEASING.md`](RELEASING.md) — how a release actually ships,
-  for once your change has landed on `main`.
+- [`docs/TESTING.md`](https://github.com/alltheplaces/osm-diffs/blob/main/docs/TESTING.md)
+  — how this project's tests are organized, and how to try a change on
+  real full-planet data before it lands.
+- [`docs/RELEASING.md`](https://github.com/alltheplaces/osm-diffs/blob/main/docs/RELEASING.md)
+  — how a release actually ships, for once your change has landed on
+  `main`.
 
 That's it — open a PR, and we'll take it from there. 🙂

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -16,10 +16,11 @@ cargo clippy --all-targets -- -D warnings
 cargo test
 ```
 
-These match what CI runs on every PR (see
-[`.github/workflows/test.yml`](../.github/workflows/test.yml) for the
-exact invocations). Running them locally first saves a round-trip
-through CI — see [`TESTING.md`](TESTING.md) for what else CI checks.
+After you've sent a Pull Request, our Continuous Integration (CI) runs a
+series of checks on it — the commands above match
+[what CI runs](../.github/workflows/test.yml). Running them locally
+first saves a round-trip through CI — see [`TESTING.md`](TESTING.md)
+for what else CI checks.
 
 ## Where to go next
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -17,7 +17,7 @@ cargo test
 ```
 
 After you've sent a Pull Request, our Continuous Integration (CI) runs a
-series of checks on it — the commands above match
+series of checks on it — the commands above are a subset of
 [what CI runs](https://github.com/alltheplaces/osm-diffs/blob/main/.github/workflows/test.yml).
 Running them locally first saves a round-trip through CI — see
 [`TESTING.md`](https://github.com/alltheplaces/osm-diffs/blob/main/docs/TESTING.md)


### PR DESCRIPTION
Follow-up per feedback on #674/#675: spells out "Continuous Integration (CI)" on first mention for readers new to the term, makes "what CI runs" a link straight to `test.yml`, and drops the now-redundant parenthetical for brevity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)