### PR TITLE
Cut suggest_edits over to conflated.parquet (PR 5 of #655)

### DIFF
--- a/src/edit_suggesters/mod.rs
+++ b/src/edit_suggesters/mod.rs
@@ -1,0 +1,45 @@
+//! Turns a conflated ATP+OSM feature pair -- one that
+//! `crate::pipeline::conflate` has already determined refer to the same
+//! real-world object -- into a suggested OpenStreetMap edit.
+//!
+//! Deliberately separate from `crate::matchers::Matcher`, even though
+//! both are dispatched by category: matching needs different signals
+//! per category to decide *whether* two features are the same object
+//! (e.g. brand for shops; a restaurant or museum matcher would likely
+//! need different signals again). But once a match is settled, deciding
+//! *what to change* -- e.g. diffing `opening_hours` -- doesn't care how
+//! the match was made, and that logic can be shared across categories
+//! that matching itself needs to tell apart. So `EditSuggester`
+//! implementations don't need to mirror `Matcher` implementations
+//! one-for-one; there may end up being far fewer of them.
+
+mod poi;
+
+/// Suggests a tag-level edit for an OSM feature already matched to an
+/// AllThePlaces feature. Operates on plain tag lists -- not `Place`/
+/// `Feature` -- since by this point matching is done and only the tags
+/// on both sides matter.
+pub trait EditSuggester {
+    /// Returns the changed/added tags to propose, or `None` if there's
+    /// nothing worth suggesting.
+    fn suggest_edit(
+        &self,
+        atp_tags: &[(String, String)],
+        osm_tags: &[(String, String)],
+    ) -> Option<Vec<(String, String)>>;
+}
+
+/// Picks an [EditSuggester] for an AllThePlaces feature's tags, or
+/// `None` if we don't (yet) generate edits for this kind of feature.
+pub fn create_edit_suggester(atp_tags: &[(String, String)]) -> Option<Box<dyn EditSuggester>> {
+    let mut mask = crate::matchers::MatchMask::default();
+    for (key, value) in atp_tags {
+        mask.add_tag(key, value);
+    }
+    if mask.intersects(&crate::matchers::MatchMask::SHOP) {
+        Some(Box::new(poi::PoiEditSuggester))
+    } else {
+        // TODO: Trees, infrastructure, ... once matching supports them.
+        None
+    }
+}

--- a/src/edit_suggesters/poi.rs
+++ b/src/edit_suggesters/poi.rs
@@ -1,0 +1,122 @@
+use super::EditSuggester;
+use std::collections::HashMap;
+
+/// Suggests tag edits for POI-like OSM features (shops today; other
+/// categories once matching supports them -- see the module doc for why
+/// that doesn't imply an edit suggester per matcher). Ported from the
+/// old `PoiMatcher::suggest_edit` (see git history), unchanged in logic:
+/// only *where* it lives changed, not *what* it does.
+pub struct PoiEditSuggester;
+
+impl PoiEditSuggester {
+    /// Tells whether we trust an AllThePlaces tag enough to suggest an
+    /// OpenStreetMap edit. AllThePlaces mostly propagates whatever comes
+    /// from spidered websites, so we use an allowlist to prevent
+    /// spamming human OpenStreetMap editors.
+    fn is_atp_tag_trustworthy(key: &str) -> bool {
+        // Before you add entries to this list, please make sure that the quality
+        // is good. To evaluate, look at the diff of workdir/shops.jsonl
+        // from before and after your change to this code.
+        matches!(
+            key,
+            "email" | "end_date" | "fax" | "opening_hours" | "phone" | "start_date" | "website"
+        )
+    }
+}
+
+impl EditSuggester for PoiEditSuggester {
+    fn suggest_edit(
+        &self,
+        atp_tags: &[(String, String)],
+        osm_tags: &[(String, String)],
+    ) -> Option<Vec<(String, String)>> {
+        let osm_tags: HashMap<&str, &str> = osm_tags
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.as_str()))
+            .collect();
+        let tag_edits: Vec<(String, String)> = atp_tags
+            .iter()
+            .filter(|(key, _atp_value)| Self::is_atp_tag_trustworthy(key))
+            .filter(|(key, atp_value)| {
+                if let Some(osm_value) = osm_tags.get(key.as_str()) {
+                    atp_value != osm_value
+                } else {
+                    true // OSM feature has no value yet for this key
+                }
+            })
+            .cloned()
+            .collect();
+        if tag_edits.is_empty() {
+            None
+        } else {
+            Some(tag_edits)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tags(t: &[(&str, &str)]) -> Vec<(String, String)> {
+        t.iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn suggests_edit_for_trustworthy_changed_tag() {
+        let atp = tags(&[
+            ("opening_hours", "Mo-Fr 09:00-20:00"),
+            ("name", "New Yorker"),
+        ]);
+        let osm = tags(&[
+            ("opening_hours", "Mo-Fr 08:00-18:00"),
+            ("name", "New Yorker"),
+        ]);
+        let edit = PoiEditSuggester
+            .suggest_edit(&atp, &osm)
+            .expect("should suggest an edit");
+        assert_eq!(
+            edit,
+            vec![("opening_hours".to_string(), "Mo-Fr 09:00-20:00".to_string())]
+        );
+    }
+
+    #[test]
+    fn no_edit_when_tags_already_match() {
+        let atp = tags(&[("opening_hours", "Mo-Fr 09:00-20:00")]);
+        let osm = tags(&[("opening_hours", "Mo-Fr 09:00-20:00")]);
+        assert!(PoiEditSuggester.suggest_edit(&atp, &osm).is_none());
+    }
+
+    #[test]
+    fn ignores_untrustworthy_atp_tags() {
+        // `name` is not on the trustworthy allowlist -- even though ATP
+        // and OSM disagree, we don't want to propose spamming a human
+        // editor with an unreviewed name change.
+        let atp = tags(&[("name", "Something Else")]);
+        let osm = tags(&[("name", "Original Name")]);
+        assert!(PoiEditSuggester.suggest_edit(&atp, &osm).is_none());
+    }
+
+    #[test]
+    fn suggests_edit_for_tag_missing_on_osm_side() {
+        let atp = tags(&[("website", "https://example.com")]);
+        let osm = tags(&[]);
+        let edit = PoiEditSuggester
+            .suggest_edit(&atp, &osm)
+            .expect("should suggest an edit");
+        assert_eq!(
+            edit,
+            vec![("website".to_string(), "https://example.com".to_string())]
+        );
+    }
+
+    #[test]
+    fn no_edit_when_no_trustworthy_tags_present() {
+        let atp = tags(&[("brand", "New Yorker")]);
+        let osm = tags(&[]);
+        assert!(PoiEditSuggester.suggest_edit(&atp, &osm).is_none());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 
 mod atp;
 mod coverage;
+mod edit_suggesters;
 mod geometry;
 mod logging;
 mod matchers;

--- a/src/matchers/mod.rs
+++ b/src/matchers/mod.rs
@@ -286,14 +286,24 @@ impl<'a> OsmCandidate<'a> {
 pub trait Matcher {
     /// Returns a score between 0.0 and 1.0 indicating how well the place matches.
     /// A high score means a good match; 0.0 means the place is clearly not a match.
+    ///
+    /// Unused since `suggest_edits` moved off the old Place-based OSM
+    /// path (alltheplaces/osm-diffs#655) -- `score_osm_candidate` is
+    /// the only thing anything still calls. Kept, rather than deleted
+    /// here, because deleting it cleanly also means moving
+    /// `conflate()`'s ATP-side reading off `PlaceIndex` (see that
+    /// type's own now-unused query/cache machinery); that's a separate,
+    /// focused follow-up rather than part of this change.
+    #[allow(dead_code)]
     fn score(&self, place: &Place) -> f64;
-
-    fn suggest_edit(&self, osm_feature: &Place) -> Option<Place>;
 
     /// Like `score`, but against an [OsmCandidate] backed by the new,
     /// geometry-aware `OsmFeatureIndex` path instead of `Place`. Landing
-    /// alongside `score`/`suggest_edit` rather than replacing them, as
-    /// part of a staged migration of OSM-side matching off `Place`.
+    /// alongside `score` rather than replacing it, as part of a staged
+    /// migration of OSM-side matching off `Place`. (Note there's no
+    /// `Matcher::suggest_edit` any more -- turning a matched pair into a
+    /// proposed edit is a different concern from matching itself, and
+    /// lives in `crate::edit_suggesters` instead.)
     fn score_osm_candidate(&self, candidate: &OsmCandidate) -> f64;
 }
 
@@ -314,11 +324,15 @@ pub fn create_matcher(place: &Place) -> Option<Box<dyn Matcher + '_>> {
     }
 }
 
+// Only used by Matcher::score (see its doc comment for why that's
+// currently unused but not yet deleted).
+#[allow(dead_code)]
 fn distance(pt: &Point, place: &Place) -> f64 {
     let pt2 = Point(CellID(place.s2_cell_id).raw_point().normalize());
     pt.distance(&pt2).rad() * EARTH_RADIUS_METERS
 }
 
+#[allow(dead_code)]
 fn distance_score(pt: &Point, place: &Place, max_meters: f64) -> f64 {
     let dist = distance(pt, place);
     if dist <= max_meters {

--- a/src/matchers/poi_matcher.rs
+++ b/src/matchers/poi_matcher.rs
@@ -4,7 +4,6 @@ use super::{
 use crate::places::Place;
 use geo::Centroid;
 use s2::{cell::Cell, cellid::CellID, point::Point};
-use std::collections::HashMap;
 
 /// Finds the first `brand:wikidata` tag in `tags` and parses its value.
 /// Shared by `for_place`, `score`, and `score_osm_candidate` -- same
@@ -16,18 +15,17 @@ fn find_brand_wikidata<'a>(tags: impl Iterator<Item = (&'a str, &'a str)>) -> Op
         .and_then(|(_, v)| parse_wikidata_id(v))
 }
 
-pub struct PoiMatcher<'a> {
-    atp_place: &'a Place,
+pub struct PoiMatcher {
     center: Point,
     brand_wikidata: u64,
 }
 
-impl<'a> PoiMatcher<'a> {
+impl PoiMatcher {
     // TODO: For now, we only match based on brand:wikidata.
     // We should also look at names, by computing the token sort ratio,
     // but we should do this in a way that works for CJK. So we need
     // a decent segmenter that works for CJK languages. Maybe Lindera?
-    pub fn for_place(place: &'a Place) -> Option<PoiMatcher<'a>> {
+    pub fn for_place(place: &Place) -> Option<PoiMatcher> {
         if !place.mask.intersects(&MatchMask::SHOP) {
             return None;
         }
@@ -35,27 +33,13 @@ impl<'a> PoiMatcher<'a> {
         let brand_wikidata = find_brand_wikidata(tags)?;
         let center = Cell::from(CellID(place.s2_cell_id)).center();
         Some(PoiMatcher {
-            atp_place: place,
             center,
             brand_wikidata,
         })
     }
-
-    /// Tells whether we trust an AllThePlaces tag enough to suggest an OpenStreetMap edit.
-    /// AllThePlaces mostly propagates whatever comes from spidered websites,
-    /// so we use an allowlist to prevent spamming human OpenStreetMap editors.
-    fn is_atp_tag_trustworthy(key: &str) -> bool {
-        // Before you add entries to this list, please make sure that the quality
-        // is good. To evaluate, look at the diff of workdir/shops.jsonl
-        // from before and after your change to this code.
-        matches!(
-            key,
-            "email" | "end_date" | "fax" | "opening_hours" | "phone" | "start_date" | "website"
-        )
-    }
 }
 
-impl<'a> Matcher for PoiMatcher<'a> {
+impl Matcher for PoiMatcher {
     fn score(&self, candidate: &Place) -> f64 {
         let tags = candidate.tags.iter().map(|(k, v)| (k.as_str(), v.as_str()));
         if find_brand_wikidata(tags) != Some(self.brand_wikidata) {
@@ -77,43 +61,6 @@ impl<'a> Matcher for PoiMatcher<'a> {
             return 0.0;
         };
         geo_point_distance_score(&self.center, &centroid, 400.0)
-    }
-
-    // TODO: This is not really a Matcher task. Move this elsewhere,
-    // once we figure out what the final output format should be
-    // for the pipeline.
-    fn suggest_edit(&self, osm_feature: &Place) -> Option<Place> {
-        let osm_tags: HashMap<&str, &str> = osm_feature
-            .tags
-            .iter()
-            .map(|(k, v)| (k.as_str(), v.as_str()))
-            .collect();
-        let tag_edits: Vec<(String, String)> = self
-            .atp_place
-            .tags
-            .iter()
-            .filter(|(key, _atp_value)| Self::is_atp_tag_trustworthy(key))
-            .filter(|(key, atp_value)| {
-                if let Some(osm_value) = osm_tags.get::<str>(key.as_ref()) {
-                    atp_value != osm_value
-                } else {
-                    true // OSM feature has no value yet for this key
-                }
-            })
-            .cloned()
-            .collect();
-        if tag_edits.is_empty() {
-            return None;
-        }
-        Some(Place {
-            s2_cell_id: osm_feature.s2_cell_id,
-            osm_id: osm_feature.osm_id,
-            osm_changeset: osm_feature.osm_changeset,
-            osm_version: osm_feature.osm_version,
-            source: self.atp_place.source.clone(),
-            mask: osm_feature.mask,
-            tags: tag_edits,
-        })
     }
 }
 

--- a/src/pipeline/edits.rs
+++ b/src/pipeline/edits.rs
@@ -1,24 +1,116 @@
-use crate::matchers::create_matcher;
-use crate::places::{Place, PlaceIndex};
-use crate::s2_util::MergedCellRanges;
-use crate::{TileLayer, make_progress_bar, matchers::match_distance};
-use anyhow::Result;
+//! Turns `conflated.parquet` (produced by `crate::pipeline::conflate`)
+//! into suggested OpenStreetMap edits, one GeoJSON tile layer per
+//! category.
+//!
+//! Deliberately does *not* search OSM independently: `conflate()` has
+//! already decided, for every AllThePlaces feature, which OSM feature
+//! (if any) refers to the same real-world object -- redoing that search
+//! here would mean paying for the whole candidate scan twice, and could
+//! in principle disagree with conflate's answer. Instead this scans
+//! `conflated.parquet` once, sequentially, and asks a
+//! `crate::edit_suggesters::EditSuggester` what to change for each
+//! already-matched pair.
+
+use crate::edit_suggesters::create_edit_suggester;
+use crate::{TileLayer, make_progress_bar};
+use anyhow::{Context, Result};
+use arrow::array::{
+    Array, BinaryArray, MapArray, RecordBatch, StringArray, StructArray, UInt32Array, UInt64Array,
+};
+use deepsize::DeepSizeOf;
 use ext_sort::{ExternalSorter, ExternalSorterBuilder, buffer::mem::MemoryLimitedBufferBuilder};
+use geo::Centroid;
+use geo_traits::to_geo::ToGeoGeometry;
 use indicatif::{MultiProgress, ProgressBar};
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use rayon::prelude::*;
-use s2::{cap::Cap, cell::Cell, cellid::CellID, region::RegionCoverer};
+use serde::{Deserialize, Serialize};
 use std::fs::{File, rename};
 use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc::{Receiver, SyncSender, sync_channel};
 use std::thread;
+use std::time::Instant;
+use wkb::reader::read_wkb;
+
+/// One suggested change to an existing OpenStreetMap feature -- never a
+/// suggestion to create a new feature (see the TODO on
+/// `crate::places::Place::to_geojson`, which this mirrors for now: we
+/// only ever suggest edits for AllThePlaces features `conflate()` has
+/// matched to something that already exists in OSM).
+///
+/// `Ord`/`Eq` are implemented by hand (not derived) because they only
+/// need to compare `osm_id` -- that's the only thing `write_edits`'s
+/// sort-then-dedup needs, and `centroid`'s `f64`s don't have a natural
+/// total order anyway.
+#[derive(Debug, Clone, DeepSizeOf, Serialize, Deserialize)]
+pub struct SuggestedEdit {
+    pub osm_id: u64,
+    pub osm_type: String, // "node" | "way" | "relation"
+    pub osm_changeset: u64,
+    pub osm_version: u32,
+    pub tags: Vec<(String, String)>,
+    /// (longitude, latitude). Just the OSM feature's centroid for now,
+    /// not its full shape -- see the plan referenced in
+    /// alltheplaces/osm-diffs#655 for why this is deliberately scoped
+    /// down; revisit once tile layers are known to handle non-point
+    /// geometry the way this pipeline needs.
+    centroid: (f64, f64),
+}
+
+impl PartialEq for SuggestedEdit {
+    fn eq(&self, other: &Self) -> bool {
+        self.osm_id == other.osm_id
+    }
+}
+impl Eq for SuggestedEdit {}
+impl PartialOrd for SuggestedEdit {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl Ord for SuggestedEdit {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.osm_id.cmp(&other.osm_id)
+    }
+}
+
+impl SuggestedEdit {
+    pub fn to_geojson(&self) -> geojson::Feature {
+        // Let's not emit coordinates with fake micrometer precision.
+        let rounded_lon = (self.centroid.0 * 1e7).round() / 1e7;
+        let rounded_lat = (self.centroid.1 * 1e7).round() / 1e7;
+        let point = geo::point!(x: rounded_lon, y: rounded_lat);
+
+        let mut properties: serde_json::Map<String, serde_json::Value> = self
+            .tags
+            .iter()
+            .map(|(k, v)| (k.clone(), serde_json::Value::String(v.clone())))
+            .collect();
+        properties.insert(
+            String::from("@osm_changeset"),
+            serde_json::Value::from(self.osm_changeset),
+        );
+        properties.insert(
+            String::from("@osm_version"),
+            serde_json::Value::from(self.osm_version),
+        );
+
+        geojson::Feature {
+            bbox: None,
+            geometry: Some(geojson::Geometry::from(&point)),
+            id: Some(geojson::feature::Id::Number(self.osm_id.into())),
+            properties: Some(properties),
+            foreign_members: None,
+        }
+    }
+}
 
 struct EditWriter {
-    shops: SyncSender<Place>,
-    _infrastructure: SyncSender<Place>,
-    _trees: SyncSender<Place>,
+    shops: SyncSender<SuggestedEdit>,
+    _infrastructure: SyncSender<SuggestedEdit>,
+    _trees: SyncSender<SuggestedEdit>,
 }
 
 impl EditWriter {
@@ -34,9 +126,7 @@ impl EditWriter {
 }
 
 pub fn suggest_edits(
-    _coverage: &Path,
-    atp: &Path,
-    osm: &Path,
+    conflated: &Path,
     progress: &MultiProgress,
     workdir: &Path,
 ) -> Result<Vec<TileLayer>> {
@@ -47,27 +137,30 @@ pub fn suggest_edits(
         return Ok(layers);
     }
 
-    let atp = PlaceIndex::open(atp, 1)?;
-    let num_atp_places = atp.total_rows() as u64;
-    let progress_bar = make_progress_bar(progress, "sugg-edit", num_atp_places, "ATP features");
-    let osm = PlaceIndex::open(osm, 32)?; // TODO: More but smaller row groups for OSM.
+    let num_rows = {
+        // Parquet row counts live in file metadata -- cheap, no row I/O.
+        let file = File::open(conflated)?;
+        ParquetRecordBatchReaderBuilder::try_new(file)?
+            .metadata()
+            .file_metadata()
+            .num_rows() as u64
+    };
+    let progress_bar = make_progress_bar(progress, "sugg-edit", num_rows, "conflated features");
 
     let mut producer_result = Ok(());
     let mut num_shop_edits = Ok(0);
     let mut num_infrastructure_edits = Ok(0);
     let mut num_tree_edits = Ok(0);
     thread::scope(|s| {
-        let (shops_tx, shops_rx) = sync_channel::<Place>(8192);
-        let (infrastructure_tx, infrastructure_rx) = sync_channel::<Place>(8192);
-        let (trees_tx, trees_rx) = sync_channel::<Place>(8192);
+        let (shops_tx, shops_rx) = sync_channel::<SuggestedEdit>(8192);
+        let (infrastructure_tx, infrastructure_rx) = sync_channel::<SuggestedEdit>(8192);
+        let (trees_tx, trees_rx) = sync_channel::<SuggestedEdit>(8192);
         let writer = EditWriter {
             shops: shops_tx,
             _infrastructure: infrastructure_tx,
             _trees: trees_tx,
         };
-        s.spawn(|| {
-            producer_result = produce_edits(atp.clone(), osm.clone(), &progress_bar, writer)
-        });
+        s.spawn(|| producer_result = produce_edits(conflated, num_rows, &progress_bar, writer));
         s.spawn(|| num_shop_edits = write_edits(shops_rx, &layers[0].path, workdir));
         s.spawn(|| {
             num_infrastructure_edits = write_edits(infrastructure_rx, &layers[1].path, workdir)
@@ -76,97 +169,210 @@ pub fn suggest_edits(
     });
     producer_result?;
     let num_edits = num_shop_edits? + num_infrastructure_edits? + num_tree_edits?;
-    progress_bar.finish_with_message(format!("ATP features → {} suggested OSM edits", num_edits));
-
-    let cache_stats = osm.cache_stats();
-    log::info!(
-        "cache hits: {} misses: {} hit rate: {:.1}%",
-        cache_stats.hits,
-        cache_stats.misses,
-        cache_stats.hit_rate().unwrap_or(0.0) * 100.0
-    );
+    progress_bar.finish_with_message(format!(
+        "{} conflated features → {} suggested OSM edits",
+        num_rows, num_edits
+    ));
 
     Ok(layers)
 }
 
+/// One decoded row of `conflated.parquet` that has both an ATP and an
+/// OSM side -- i.e. one that `conflate()` matched. Rows with no OSM
+/// match don't decode into this (nothing to suggest an edit for), but
+/// still count against the caller's progress bar; see [read_conflated_rows].
+struct ConflatedRow {
+    atp_tags: Vec<(String, String)>,
+    osm_type: String,
+    osm_id: u64,
+    osm_tags: Vec<(String, String)>,
+    osm_changeset: u64,
+    osm_version: u32,
+    osm_geometry_wkb: Vec<u8>,
+}
+
 fn produce_edits(
-    atp: Arc<PlaceIndex>,
-    osm: Arc<PlaceIndex>,
+    conflated: &Path,
+    num_rows: u64,
     progress_bar: &ProgressBar,
     out: EditWriter,
 ) -> Result<()> {
-    let coverer = RegionCoverer {
-        max_cells: 16,
-        min_level: 12,
-        max_level: s2::cellid::MAX_LEVEL as u8,
-        level_mod: 1,
-    };
+    let start = Instant::now();
+    let num_edits = AtomicU64::new(0);
 
-    let num_atp_features = AtomicU64::new(0);
-    let num_candidates = AtomicU64::new(0);
-    let num_matches = AtomicU64::new(0);
-
-    for group in atp.scan_row_groups() {
-        // Each group is processed by the Rayon thread pool in parallel,
-        // but the outer loop is sequential — so nearby places (within a
-        // group) always go to nearby workers, preserving spatial locality.
-        group?.par_iter().try_for_each(|place| {
+    for batch in read_conflated_rows(conflated)? {
+        batch?.par_iter().try_for_each(|row| {
             progress_bar.inc(1);
-            if let Some(matcher) = create_matcher(place) {
-                num_atp_features.fetch_add(1, Ordering::Relaxed);
-                let s2_cell = Cell::from(CellID(place.s2_cell_id));
-                let center = s2_cell.center();
-                let radius = match_distance(&place.mask);
-                let cap = Cap::from_center_chordangle(&center, &radius);
-                let covering = coverer.covering(&cap);
-                let mut best_candidate: Option<Place> = None;
-                let mut best_score: f64 = 0.0;
-                for (lo, hi) in MergedCellRanges::new(covering) {
-                    let mut iter = osm.query(lo..=hi, place.mask)?;
-                    let mut bc: Option<&Place> = None;
-                    for candidate in &mut iter {
-                        num_candidates.fetch_add(1, Ordering::Relaxed);
-                        let candidate = candidate?;
-                        let score = matcher.score(candidate);
-                        if score > best_score {
-                            bc = Some(candidate);
-                            best_score = score;
-                        }
-                    }
-                    if let Some(b) = bc {
-                        best_candidate = Some(b.deep_clone());
-                    }
-                }
-                if let Some(best_candidate) = best_candidate
-                    && best_score > 0.0
-                {
-                    num_matches.fetch_add(1, Ordering::Relaxed);
-                    if let Some(edit) = matcher.suggest_edit(&best_candidate) {
-                        log::debug!(
-                            "score={} place={:?} best_candidate={:?} edit={:?}",
-                            best_score,
-                            place,
-                            best_candidate,
-                            edit
-                        );
-                        // TODO: Dispatch to one of {shops, infrastructure, trees}.
-                        out.shops.send(edit)?;
-                    }
-                }
+            let Some(row) = row else {
+                return Ok(());
             };
+            let Some(suggester) = create_edit_suggester(&row.atp_tags) else {
+                return Ok(());
+            };
+            let Some(tags) = suggester.suggest_edit(&row.atp_tags, &row.osm_tags) else {
+                return Ok(());
+            };
+            let edit = SuggestedEdit {
+                osm_id: row.osm_id,
+                osm_type: row.osm_type.clone(),
+                osm_changeset: row.osm_changeset,
+                osm_version: row.osm_version,
+                tags,
+                centroid: decode_centroid(&row.osm_geometry_wkb)?,
+            };
+            num_edits.fetch_add(1, Ordering::Relaxed);
+            // TODO: Dispatch to one of {shops, infrastructure, trees}
+            // once edit suggesters exist for more than shops.
+            out.shops.send(edit)?;
             Ok::<(), anyhow::Error>(())
         })?;
     }
 
+    log::info!(
+        elapsed_seconds = start.elapsed().as_secs_f64(),
+        conflated_rows = num_rows,
+        edits_suggested = num_edits.load(Ordering::Relaxed);
+        "suggest_edits: done"
+    );
     Ok(())
 }
 
-fn write_edits(edits: Receiver<Place>, path: &Path, workdir: &Path) -> Result<u64> {
+fn decode_centroid(wkb: &[u8]) -> Result<(f64, f64)> {
+    let geometry = read_wkb(wkb)
+        .context("failed to decode OSM geometry")?
+        .to_geometry();
+    let centroid = geometry
+        .centroid()
+        .context("OSM geometry has no centroid")?;
+    Ok((centroid.x(), centroid.y()))
+}
+
+/// Sequentially reads `conflated.parquet` batch by batch (Arrow's
+/// natural row-group-ish chunking) -- no caching, no spatial index,
+/// since every row is visited exactly once, in file order. The caller
+/// processes each batch in parallel with Rayon; batches preserve
+/// spatial locality (the file is S2-sorted) even though nothing here
+/// relies on that ordering itself.
+fn read_conflated_rows(
+    path: &Path,
+) -> Result<impl Iterator<Item = Result<Vec<Option<ConflatedRow>>>>> {
+    let file = File::open(path)?;
+    let reader = ParquetRecordBatchReaderBuilder::try_new(file)?.build()?;
+    Ok(reader.map(|batch| {
+        let batch = batch?;
+        (0..batch.num_rows())
+            .map(|row| extract_conflated_row(&batch, row))
+            .collect()
+    }))
+}
+
+/// `None` means this row has no OSM match (or, in principle, no ATP
+/// side either -- the schema allows it even though `conflate()` never
+/// actually produces such a row) -- nothing to suggest an edit for, but
+/// still a real row the caller should count against its progress bar.
+fn extract_conflated_row(batch: &RecordBatch, row: usize) -> Result<Option<ConflatedRow>> {
+    let atp = get_struct(batch, "atp")?;
+    if atp.is_null(row) {
+        return Ok(None);
+    }
+    let osm = get_struct(batch, "osm")?;
+    if osm.is_null(row) {
+        return Ok(None);
+    }
+
+    Ok(Some(ConflatedRow {
+        atp_tags: get_tags(atp, "tags", row)?,
+        osm_type: get_string(osm, "type", row)?,
+        osm_id: get_u64(osm, "id", row)?,
+        osm_tags: get_tags(osm, "tags", row)?,
+        osm_changeset: get_u64(osm, "changeset", row)?,
+        osm_version: get_u32(osm, "version", row)?,
+        osm_geometry_wkb: get_binary(osm, "geometry", row)?,
+    }))
+}
+
+fn get_struct<'a>(batch: &'a RecordBatch, name: &str) -> Result<&'a StructArray> {
+    batch
+        .column_by_name(name)
+        .with_context(|| format!("missing column '{name}'"))?
+        .as_any()
+        .downcast_ref::<StructArray>()
+        .with_context(|| format!("column '{name}' is not a struct"))
+}
+
+fn get_string(s: &StructArray, name: &str, row: usize) -> Result<String> {
+    Ok(s.column_by_name(name)
+        .with_context(|| format!("missing field '{name}'"))?
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .with_context(|| format!("field '{name}' is not a string"))?
+        .value(row)
+        .to_owned())
+}
+
+fn get_u64(s: &StructArray, name: &str, row: usize) -> Result<u64> {
+    Ok(s.column_by_name(name)
+        .with_context(|| format!("missing field '{name}'"))?
+        .as_any()
+        .downcast_ref::<UInt64Array>()
+        .with_context(|| format!("field '{name}' is not UInt64"))?
+        .value(row))
+}
+
+fn get_u32(s: &StructArray, name: &str, row: usize) -> Result<u32> {
+    Ok(s.column_by_name(name)
+        .with_context(|| format!("missing field '{name}'"))?
+        .as_any()
+        .downcast_ref::<UInt32Array>()
+        .with_context(|| format!("field '{name}' is not UInt32"))?
+        .value(row))
+}
+
+fn get_binary(s: &StructArray, name: &str, row: usize) -> Result<Vec<u8>> {
+    Ok(s.column_by_name(name)
+        .with_context(|| format!("missing field '{name}'"))?
+        .as_any()
+        .downcast_ref::<BinaryArray>()
+        .with_context(|| format!("field '{name}' is not binary"))?
+        .value(row)
+        .to_vec())
+}
+
+fn get_tags(s: &StructArray, name: &str, row: usize) -> Result<Vec<(String, String)>> {
+    let col = s
+        .column_by_name(name)
+        .with_context(|| format!("missing field '{name}'"))?
+        .as_any()
+        .downcast_ref::<MapArray>()
+        .with_context(|| format!("field '{name}' is not a map"))?;
+
+    let entry = col.value(row);
+    let keys = entry
+        .column_by_name("key")
+        .with_context(|| format!("map '{name}' has no 'key' field"))?
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .with_context(|| format!("map '{name}' keys are not strings"))?;
+    let values = entry
+        .column_by_name("value")
+        .with_context(|| format!("map '{name}' has no 'value' field"))?
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .with_context(|| format!("map '{name}' values are not strings"))?;
+
+    let mut tags = Vec::with_capacity(keys.len());
+    for i in 0..keys.len() {
+        tags.push((keys.value(i).to_owned(), values.value(i).to_owned()));
+    }
+    Ok(tags)
+}
+
+fn write_edits(edits: Receiver<SuggestedEdit>, path: &Path, workdir: &Path) -> Result<u64> {
     let mut tmp_path = PathBuf::from(&path);
     tmp_path.add_extension("tmp");
     let mut writer = BufWriter::with_capacity(32768, File::create(&tmp_path)?);
 
-    let sorter: ExternalSorter<Place, std::io::Error, MemoryLimitedBufferBuilder> =
+    let sorter: ExternalSorter<SuggestedEdit, std::io::Error, MemoryLimitedBufferBuilder> =
         ExternalSorterBuilder::new()
             .with_tmp_dir(workdir)
             .with_buffer(MemoryLimitedBufferBuilder::new(150_000_000))
@@ -181,10 +387,10 @@ fn write_edits(edits: Receiver<Place>, path: &Path, workdir: &Path) -> Result<u6
     for edit in sorted {
         let edit = edit?;
         // Only emit one single edit per OSM ID.
-        if edit.osm_id == last_osm_id {
+        if Some(edit.osm_id) == last_osm_id {
             continue;
         }
-        last_osm_id = edit.osm_id;
+        last_osm_id = Some(edit.osm_id);
         let mut line = edit.to_geojson().to_string();
         line.push('\n');
         writer.write_all(line.as_ref())?;

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -53,10 +53,15 @@ pub fn run_pipeline(
     let coverage = run_step("build_coverage", || {
         crate::coverage::build_coverage(&atp, &progress, workdir)
     })?;
-    let (osm_parquet, osm_features) = run_step("import_osm", || {
+    // `_osm_parquet` (the old Place-based OSM output) is no longer
+    // consumed by anything now that suggest_edits reads conflated.parquet
+    // instead -- see alltheplaces/osm-diffs#655. Still built by
+    // import_osm() today; whether that's still worth doing is a separate
+    // decision, deliberately not made here.
+    let (_osm_parquet, osm_features) = run_step("import_osm", || {
         osm::import_osm(&coverage, &progress, workdir)
     })?;
-    let _conflated = run_step("conflate", || {
+    let conflated = run_step("conflate", || {
         conflate::conflate(
             &atp,
             &coverage,
@@ -68,7 +73,7 @@ pub fn run_pipeline(
         )
     })?;
     let edits = run_step("suggest_edits", || {
-        edits::suggest_edits(&coverage, &atp, &osm_parquet, &progress, workdir)
+        edits::suggest_edits(&conflated, &progress, workdir)
     })?;
     let tiles = run_step("render_tiles", || {
         tiles::render_tiles(&edits, &progress, workdir)

--- a/src/places/place_index.rs
+++ b/src/places/place_index.rs
@@ -1,3 +1,17 @@
+// `PlaceIndex`'s query/LRU-cache machinery (query, cache_stats,
+// build_segments, prune_row_groups, CacheStats, and RowGroupInfo's
+// s2_min/s2_max) served spatial OSM-candidate lookups -- a need that
+// went away twice over: once when conflate() moved to OsmFeatureIndex
+// (alltheplaces/osm-diffs#665), again when suggest_edits stopped
+// searching OSM at all (#655). Only `open`/`scan_row_groups` (used by
+// conflate() to read ATP sequentially) are still live. Left in place
+// rather than deleted here: a proper cleanup also means moving that
+// ATP read off `PlaceIndex` entirely (it never needed a cache -- every
+// row is visited once, in file order), which is a separate, focused
+// follow-up rather than part of the suggest_edits change that made
+// this dead.
+#![allow(dead_code)]
+
 use arrow::array::{
     Array, MapArray, RecordBatch, StringArray, UInt16Array, UInt32Array, UInt64Array,
 };

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,6 +1,6 @@
-use anyhow::{Ok, Result};
+use anyhow::{Context, Ok, Result};
 use assert_cmd::{Command, cargo_bin};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tempfile::TempDir;
 
 #[test]
@@ -42,6 +42,73 @@ fn test_pipeline() -> Result<()> {
         .arg(workdir.path())
         .assert()
         .success();
+
+    assert_shops_jsonl(&workdir.path().join("shops.jsonl"))?;
+
+    Ok(())
+}
+
+/// Checks `suggest_edits`'s output against the fixture data's known
+/// shops (see `tests/test_data/zugerland.osm.pbf` /
+/// `alltheplaces.zip`) -- pins concrete expected values, not just "the
+/// file has some content", so a regression in tag-diffing or GeoJSON
+/// output actually gets caught, not just a crash.
+fn assert_shops_jsonl(path: &Path) -> Result<()> {
+    let content =
+        std::fs::read_to_string(path).with_context(|| format!("could not read {path:?}"))?;
+    let lines: Vec<&str> = content.lines().collect();
+    assert_eq!(
+        lines.len(),
+        3,
+        "expected 3 suggested shop edits, got:\n{content}"
+    );
+
+    let features: Vec<serde_json::Value> = lines
+        .iter()
+        .map(|line| Ok(serde_json::from_str(line)?))
+        .collect::<Result<_>>()?;
+
+    // Every row is a well-formed GeoJSON Point feature, carrying the
+    // OSM base changeset/version it was suggested against -- needed to
+    // detect edit conflicts later, even though nothing uploads edits
+    // yet.
+    for feature in &features {
+        assert_eq!(feature["type"], "Feature");
+        assert_eq!(feature["geometry"]["type"], "Point");
+        assert!(feature["id"].is_number(), "feature has no id: {feature}");
+        assert!(
+            feature["properties"]["@osm_changeset"].is_number(),
+            "feature has no @osm_changeset: {feature}"
+        );
+        assert!(
+            feature["properties"]["@osm_version"].is_number(),
+            "feature has no @osm_version: {feature}"
+        );
+    }
+
+    // One specific, known edit: this OSM feature's opening_hours and
+    // phone differ from AllThePlaces' in the fixture data.
+    let edit = features
+        .iter()
+        .find(|f| f["id"] == 737021556)
+        .expect("expected a suggested edit for OSM feature 737021556");
+    assert_eq!(
+        edit["properties"]["opening_hours"],
+        "Mo-Th 09:00-19:00; Fr 09:00-21:00; Sa 08:00-17:00"
+    );
+    assert_eq!(edit["properties"]["phone"], "+41 848 544 455");
+    // Only the tags that actually differ (and are on the trustworthy
+    // allowlist -- see PoiEditSuggester) should be suggested, nothing else.
+    assert_eq!(
+        edit["properties"]
+            .as_object()
+            .expect("properties should be an object")
+            .keys()
+            .filter(|k| !k.starts_with('@'))
+            .count(),
+        2,
+        "unexpected extra tags in suggested edit: {edit}"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
PR 5 of the #655 rollout. Design discussed at length in that issue's thread before implementing.

## What changed

`suggest_edits` no longer searches OSM independently — `conflate()` already decided, per ATP feature, which OSM feature (if any) is the same real-world object. Redoing that search in `suggest_edits` too meant paying for the whole candidate scan a second time, and could in principle disagree with conflate's answer. Instead, `suggest_edits` now does one sequential scan over `conflated.parquet` and asks an `EditSuggester` what to change for each already-matched pair.

- New `src/edit_suggesters/` (`EditSuggester` trait + `PoiEditSuggester`), deliberately separate from `Matcher`: matching needs different signals per category to decide *whether* two features are the same object, but diffing tags once a match is settled doesn't care *how* the match was made, and that logic can be shared across categories matching itself needs to tell apart.
- `Matcher::suggest_edit` is gone — no `OsmCandidate`-based replacement was added, since generating edits isn't a matching concern any more.
- `PoiMatcher` no longer borrows the ATP `Place` (that was only needed for the old `suggest_edit`); drops its lifetime parameter as a result.
- `suggest_edits`' `conflated.parquet` reader is a small, purpose-built sequential Arrow/Parquet scan — no caching, no spatial index, since every row is visited exactly once, in file order.
- Deliberately did **not** add a persisted match-score column to `conflated.parquet` — that file is meant to stay a clean, externally-legible data product, and both old and new code use the same "any nonzero score wins" bar today, so this isn't a behavior change.

## Deferred, not in scope here

`conflate()`'s ATP-side read still goes through `PlaceIndex`, so its now-dead query/LRU-cache machinery (nothing else calls `query()`/`cache_stats()` any more) is `#[allow(dead_code)]` rather than deleted — cleanly removing it also means moving that ATP read off `PlaceIndex` onto a plain sequential reader, which is a separate, focused follow-up PR rather than part of this change.

## Testing

`test_pipeline` now asserts on `shops.jsonl`'s actual contents (concrete expected tags/values from the fixture data), not just that the run succeeds — verified it actually catches regressions by temporarily breaking the trustworthy-tag allowlist and confirming the test fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)