### PR TITLE
Consolidate external-sort chunk sizes onto EXTERNAL_SORT_CHUNK_BYTES (#657)

### DIFF
--- a/src/atp/mod.rs
+++ b/src/atp/mod.rs
@@ -88,10 +88,15 @@ fn process_places(
     let mut tmp = PathBuf::from(out);
     tmp.add_extension("tmp");
     let mut writer = ParquetWriter::try_new(/* batch size, in records */ 4 * 1024, &tmp)?;
+    // process_places's only sibling thread (process_zip) doesn't run any
+    // external sort of its own, so this gets the full chunk-size budget;
+    // see crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES.
     let sorter: ExternalSorter<Place, std::io::Error, MemoryLimitedBufferBuilder> =
         ExternalSorterBuilder::new()
             .with_tmp_dir(workdir)
-            .with_buffer(MemoryLimitedBufferBuilder::new(150_000_000))
+            .with_buffer(MemoryLimitedBufferBuilder::new(
+                crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES as u64,
+            ))
             .build()?;
 
     let num_features = AtomicU64::new(0);

--- a/src/atp/wikidata_ids.rs
+++ b/src/atp/wikidata_ids.rs
@@ -66,7 +66,7 @@ pub fn collect_wikidata_ids(atp: &Path, workdir: &Path) -> Result<PathBuf> {
         ids.into_iter(),
         workdir,
         &out,
-        crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES as u64,
+        crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES,
     )?;
     log::info!(count = count; "collect_wikidata_ids: done");
     Ok(out)

--- a/src/atp/wikidata_ids.rs
+++ b/src/atp/wikidata_ids.rs
@@ -60,7 +60,14 @@ pub fn collect_wikidata_ids(atp: &Path, workdir: &Path) -> Result<PathBuf> {
     }
 
     let count = ids.len();
-    U64Set::create(ids.into_iter(), workdir, &out)?;
+    // Sole external sort in this step (see `run_step("collect_wikidata_ids",
+    // ...)` in pipeline/mod.rs), so it gets the full chunk-size budget.
+    U64Set::create(
+        ids.into_iter(),
+        workdir,
+        &out,
+        crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES as u64,
+    )?;
     log::info!(count = count; "collect_wikidata_ids: done");
     Ok(out)
 }

--- a/src/pipeline/conflate/mod.rs
+++ b/src/pipeline/conflate/mod.rs
@@ -2,6 +2,7 @@ use super::last_modified;
 use crate::{
     make_progress_bar,
     matchers::{OsmCandidate, create_matcher, match_distance},
+    pipeline::EXTERNAL_SORT_CHUNK_BYTES,
     places::{Place, PlaceReader},
     s2_util::MergedCellRanges,
     tables::{Feature, OsmFeatures},
@@ -221,10 +222,15 @@ fn write_conflated(
 ) -> Result<()> {
     let start = Instant::now();
     let row_count = AtomicU64::new(0);
+    // write_conflated's only caller (conflate()) doesn't run any other
+    // external sort concurrently with it, so this gets the full
+    // chunk-size budget; see EXTERNAL_SORT_CHUNK_BYTES.
     let sorter: ExternalSorter<ParquetRow, std::io::Error, MemoryLimitedBufferBuilder> =
         ExternalSorterBuilder::new()
             .with_tmp_dir(workdir)
-            .with_buffer(MemoryLimitedBufferBuilder::new(150_000_000))
+            .with_buffer(MemoryLimitedBufferBuilder::new(
+                EXTERNAL_SORT_CHUNK_BYTES as u64,
+            ))
             .build()?;
     let sorted = sorter.sort(cf.iter().map(|row| {
         progress.set_length(row_count.fetch_add(1, Ordering::SeqCst));

--- a/src/pipeline/edits.rs
+++ b/src/pipeline/edits.rs
@@ -12,6 +12,7 @@
 //! already-matched pair.
 
 use crate::edit_suggesters::create_edit_suggester;
+use crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES;
 use crate::{TileLayer, make_progress_bar};
 use anyhow::{Context, Result};
 use arrow::array::{
@@ -367,6 +368,13 @@ fn get_tags(s: &StructArray, name: &str, row: usize) -> Result<Vec<(String, Stri
     Ok(tags)
 }
 
+/// Every call site (see `suggest_edits` above) spawns exactly three of
+/// these concurrently, one per output layer (shops, infrastructure,
+/// trees) -- so each gets a third of the chunk-size budget, keeping
+/// their combined peak memory within one EXTERNAL_SORT_CHUNK_BYTES
+/// rather than tripling it.
+const CONCURRENT_SORTS: u64 = 3;
+
 fn write_edits(edits: Receiver<SuggestedEdit>, path: &Path, workdir: &Path) -> Result<u64> {
     let mut tmp_path = PathBuf::from(&path);
     tmp_path.add_extension("tmp");
@@ -375,7 +383,9 @@ fn write_edits(edits: Receiver<SuggestedEdit>, path: &Path, workdir: &Path) -> R
     let sorter: ExternalSorter<SuggestedEdit, std::io::Error, MemoryLimitedBufferBuilder> =
         ExternalSorterBuilder::new()
             .with_tmp_dir(workdir)
-            .with_buffer(MemoryLimitedBufferBuilder::new(150_000_000))
+            .with_buffer(MemoryLimitedBufferBuilder::new(
+                EXTERNAL_SORT_CHUNK_BYTES as u64 / CONCURRENT_SORTS,
+            ))
             .build()?;
 
     let num_edits = AtomicU64::new(0);

--- a/src/pipeline/edits.rs
+++ b/src/pipeline/edits.rs
@@ -373,7 +373,7 @@ fn get_tags(s: &StructArray, name: &str, row: usize) -> Result<Vec<(String, Stri
 /// trees) -- so each gets a third of the chunk-size budget, keeping
 /// their combined peak memory within one EXTERNAL_SORT_CHUNK_BYTES
 /// rather than tripling it.
-const CONCURRENT_SORTS: u64 = 3;
+const CONCURRENT_SORTS: usize = 3;
 
 fn write_edits(edits: Receiver<SuggestedEdit>, path: &Path, workdir: &Path) -> Result<u64> {
     let mut tmp_path = PathBuf::from(&path);
@@ -384,7 +384,7 @@ fn write_edits(edits: Receiver<SuggestedEdit>, path: &Path, workdir: &Path) -> R
         ExternalSorterBuilder::new()
             .with_tmp_dir(workdir)
             .with_buffer(MemoryLimitedBufferBuilder::new(
-                EXTERNAL_SORT_CHUNK_BYTES as u64 / CONCURRENT_SORTS,
+                (EXTERNAL_SORT_CHUNK_BYTES / CONCURRENT_SORTS) as u64,
             ))
             .build()?;
 

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -6,12 +6,25 @@ use std::{
 use time::UtcDateTime;
 
 /// Target chunk size, in bytes, for external sorts that spill to disk
-/// across this pipeline (see the `ext_sort` crate). Chunk sizes for
-/// external sorts have grown ad hoc over time and are currently uneven
-/// across call sites for no good reason; this constant exists so new
-/// code has a shared default to reach for instead of picking another
-/// arbitrary number. Not yet applied to existing call sites -- see
-/// https://github.com/alltheplaces/osm-diffs/issues/657 for that cleanup.
+/// across this pipeline (see the `ext_sort` crate) -- a single, named
+/// knob to bump if a chunk size ever turns out wrong, instead of hunting
+/// down ad hoc magic numbers scattered across call sites (see
+/// https://github.com/alltheplaces/osm-diffs/issues/657, resolved by
+/// consolidating every call site onto this constant). A chunk is also a
+/// unit of concurrently-open file descriptors: `ext_sort` keeps every
+/// spilled chunk's file open at once during its final merge, so a
+/// smaller chunk size means more, smaller chunks and more open files for
+/// the same input -- raise this if that ever runs into an OS file
+/// descriptor limit again, as happened during the pr665 Hetzner shakedown.
+///
+/// This is a *per-thread-scope* budget, not a per-sorter one: several
+/// call sites run more than one external sort concurrently (sibling
+/// threads in the same `thread::scope`, e.g. `prune.rs`'s per-stage
+/// producer/writer pipelines), and each of those divides this constant
+/// by however many sorts run alongside it, so their combined peak memory
+/// stays within one `EXTERNAL_SORT_CHUNK_BYTES` rather than multiplying
+/// it. A call site that's the only external sort in its scope uses the
+/// full value.
 pub(crate) const EXTERNAL_SORT_CHUNK_BYTES: usize = 512 * 1024 * 1024;
 
 mod conflate;

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -17,14 +17,16 @@ use time::UtcDateTime;
 /// the same input -- raise this if that ever runs into an OS file
 /// descriptor limit again, as happened during the pr665 Hetzner shakedown.
 ///
-/// This is a *per-thread-scope* budget, not a per-sorter one: several
-/// call sites run more than one external sort concurrently (sibling
-/// threads in the same `thread::scope`, e.g. `prune.rs`'s per-stage
-/// producer/writer pipelines), and each of those divides this constant
-/// by however many sorts run alongside it, so their combined peak memory
-/// stays within one `EXTERNAL_SORT_CHUNK_BYTES` rather than multiplying
-/// it. A call site that's the only external sort in its scope uses the
-/// full value.
+/// This budget is shared among however many external sorts run
+/// *concurrently*, not handed out per sorter: several call sites run
+/// more than one external sort at the same time (e.g. `prune.rs`'s
+/// per-stage producer/writer pipelines, each running a few sorts on
+/// sibling threads within one `thread::scope` -- though not every thread
+/// in such a scope runs a sort; some just move data between channels).
+/// Each such call site divides this constant by however many sorts run
+/// alongside it, so their combined peak memory stays within one
+/// `EXTERNAL_SORT_CHUNK_BYTES` rather than multiplying it. A call site
+/// that's the only external sort in its scope uses the full value.
 pub(crate) const EXTERNAL_SORT_CHUNK_BYTES: usize = 512 * 1024 * 1024;
 
 mod conflate;

--- a/src/pipeline/osm/assemble.rs
+++ b/src/pipeline/osm/assemble.rs
@@ -94,8 +94,8 @@ fn assemble_strings<'a>(
         strings.len() as u64,
         "strings",
     );
-    // Not shared with any sibling thread (unlike several of the sorts in
-    // `prune.rs`), so it gets the full chunk-size budget; see
+    // Not concurrent with any other external sort (unlike several of the
+    // sorts in `prune.rs`), so it gets the full chunk-size budget; see
     // `crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES`. Strings vary in
     // length, so this is measured in actual bytes
     // (`MemoryLimitedBufferBuilder`), not an item count.

--- a/src/pipeline/osm/assemble.rs
+++ b/src/pipeline/osm/assemble.rs
@@ -343,7 +343,7 @@ fn assemble_ways<'a>(
                 geometry_rx.into_iter(),
                 workdir,
                 &ways_in_relations_path,
-                EXTERNAL_SORT_CHUNK_BYTES as u64,
+                EXTERNAL_SORT_CHUNK_BYTES,
             )
         });
 
@@ -520,7 +520,7 @@ fn assemble_leaf_relations<'a>(
                 super_rel_rx.into_iter(),
                 workdir,
                 &super_relations_path,
-                (EXTERNAL_SORT_CHUNK_BYTES / CONCURRENT_SORTS) as u64,
+                EXTERNAL_SORT_CHUNK_BYTES / CONCURRENT_SORTS,
             )?);
             Ok(())
         });
@@ -530,7 +530,7 @@ fn assemble_leaf_relations<'a>(
                 geometry_rx.into_iter(),
                 workdir,
                 &leaf_relations_geometry_path,
-                (EXTERNAL_SORT_CHUNK_BYTES / CONCURRENT_SORTS) as u64,
+                EXTERNAL_SORT_CHUNK_BYTES / CONCURRENT_SORTS,
             )?);
             Ok(())
         });

--- a/src/pipeline/osm/assemble.rs
+++ b/src/pipeline/osm/assemble.rs
@@ -514,13 +514,13 @@ fn assemble_leaf_relations<'a>(
         // is a plain RecordWriter, not a sort) -- split the chunk-size
         // budget between the two so their combined peak memory stays
         // within one EXTERNAL_SORT_CHUNK_BYTES, not double it.
-        const CONCURRENT_SORTS: u64 = 2;
+        const CONCURRENT_SORTS: usize = 2;
         let super_rel_writer = s.spawn(|| {
             super_relations = Some(BlobTable::create(
                 super_rel_rx.into_iter(),
                 workdir,
                 &super_relations_path,
-                EXTERNAL_SORT_CHUNK_BYTES as u64 / CONCURRENT_SORTS,
+                (EXTERNAL_SORT_CHUNK_BYTES / CONCURRENT_SORTS) as u64,
             )?);
             Ok(())
         });
@@ -530,7 +530,7 @@ fn assemble_leaf_relations<'a>(
                 geometry_rx.into_iter(),
                 workdir,
                 &leaf_relations_geometry_path,
-                EXTERNAL_SORT_CHUNK_BYTES as u64 / CONCURRENT_SORTS,
+                (EXTERNAL_SORT_CHUNK_BYTES / CONCURRENT_SORTS) as u64,
             )?);
             Ok(())
         });

--- a/src/pipeline/osm/assemble.rs
+++ b/src/pipeline/osm/assemble.rs
@@ -3,6 +3,7 @@ use crate::{
     geometry::{GeometryBuilder, PolygonFill, build_line, build_ring},
     make_progress_bar,
     matchers::MatchMask,
+    pipeline::EXTERNAL_SORT_CHUNK_BYTES,
     pipeline::osm::id_tagging_schema::is_area,
     tables::{
         BlobTable, CoordTable, Feature, FeatureToIndex, GeometryStore, GeometryTable, RecordReader,
@@ -10,7 +11,7 @@ use crate::{
     },
 };
 use anyhow::{Ok, Result};
-use ext_sort::{ExternalSorter, ExternalSorterBuilder, buffer::LimitedBufferBuilder};
+use ext_sort::{ExternalSorter, ExternalSorterBuilder, buffer::mem::MemoryLimitedBufferBuilder};
 use geo::{Centroid, Geometry, InterpolateLine, algorithm::line_measures::Haversine};
 use indicatif::MultiProgress;
 use osm_pbf_iter::{Blob, Primitive, PrimitiveBlock, RelationMemberType};
@@ -93,12 +94,16 @@ fn assemble_strings<'a>(
         strings.len() as u64,
         "strings",
     );
-    let sorter: ExternalSorter<(u64, String), std::io::Error, LimitedBufferBuilder> =
+    // Not shared with any sibling thread (unlike several of the sorts in
+    // `prune.rs`), so it gets the full chunk-size budget; see
+    // `crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES`. Strings vary in
+    // length, so this is measured in actual bytes
+    // (`MemoryLimitedBufferBuilder`), not an item count.
+    let sorter: ExternalSorter<(u64, String), std::io::Error, MemoryLimitedBufferBuilder> =
         ExternalSorterBuilder::new()
             .with_tmp_dir(workdir)
-            .with_buffer(LimitedBufferBuilder::new(
-                4 * 1024 * 1024,
-                /* preallocate */ true,
+            .with_buffer(MemoryLimitedBufferBuilder::new(
+                EXTERNAL_SORT_CHUNK_BYTES as u64,
             ))
             .build()?;
     let sorted = sorter.sort_by(
@@ -331,8 +336,15 @@ fn assemble_ways<'a>(
             Ok(())
         });
 
+        // Sole external sort in this scope (feature_writer above is a
+        // plain RecordWriter), so it gets the full chunk-size budget.
         let geometry_writer = s.spawn(|| {
-            GeometryTable::create(geometry_rx.into_iter(), workdir, &ways_in_relations_path)
+            GeometryTable::create(
+                geometry_rx.into_iter(),
+                workdir,
+                &ways_in_relations_path,
+                EXTERNAL_SORT_CHUNK_BYTES as u64,
+            )
         });
 
         feature_writer.join().expect("panic in feature_writer")?;
@@ -497,11 +509,18 @@ fn assemble_leaf_relations<'a>(
             Ok(())
         });
 
+        // super_rel_writer and leaf_geometry_writer each run their own
+        // external sort concurrently in this scope (leaf_rel_writer above
+        // is a plain RecordWriter, not a sort) -- split the chunk-size
+        // budget between the two so their combined peak memory stays
+        // within one EXTERNAL_SORT_CHUNK_BYTES, not double it.
+        const CONCURRENT_SORTS: u64 = 2;
         let super_rel_writer = s.spawn(|| {
             super_relations = Some(BlobTable::create(
                 super_rel_rx.into_iter(),
                 workdir,
                 &super_relations_path,
+                EXTERNAL_SORT_CHUNK_BYTES as u64 / CONCURRENT_SORTS,
             )?);
             Ok(())
         });
@@ -511,6 +530,7 @@ fn assemble_leaf_relations<'a>(
                 geometry_rx.into_iter(),
                 workdir,
                 &leaf_relations_geometry_path,
+                EXTERNAL_SORT_CHUNK_BYTES as u64 / CONCURRENT_SORTS,
             )?);
             Ok(())
         });

--- a/src/pipeline/osm/prune.rs
+++ b/src/pipeline/osm/prune.rs
@@ -274,7 +274,7 @@ fn prune_relations_pass_1<'a>(
                 keep_rx.into_iter(),
                 workdir,
                 &keep_relations_path,
-                (EXTERNAL_SORT_CHUNK_BYTES / CONCURRENT_SORTS) as u64,
+                EXTERNAL_SORT_CHUNK_BYTES / CONCURRENT_SORTS,
             )
         });
         let graph_writer = s.spawn(|| {
@@ -282,7 +282,7 @@ fn prune_relations_pass_1<'a>(
                 edge_rx.into_iter(),
                 workdir,
                 &relation_graph_path,
-                (EXTERNAL_SORT_CHUNK_BYTES / CONCURRENT_SORTS) as u64,
+                EXTERNAL_SORT_CHUNK_BYTES / CONCURRENT_SORTS,
             )?);
             Ok(())
         });
@@ -359,7 +359,7 @@ fn prune_relations_pass_2<'a>(
                 keep_rx.into_iter(),
                 workdir,
                 &rel_members_path,
-                (EXTERNAL_SORT_CHUNK_BYTES / CONCURRENT_SORTS) as u64,
+                EXTERNAL_SORT_CHUNK_BYTES / CONCURRENT_SORTS,
             )?);
             Ok(())
         });
@@ -369,7 +369,7 @@ fn prune_relations_pass_2<'a>(
                 strings_rx.into_iter(),
                 workdir,
                 &strings_path,
-                (EXTERNAL_SORT_CHUNK_BYTES / CONCURRENT_SORTS) as u64,
+                EXTERNAL_SORT_CHUNK_BYTES / CONCURRENT_SORTS,
             )
         });
 
@@ -475,7 +475,7 @@ fn prune_ways<'a>(
                 ways_rx.into_iter(),
                 workdir,
                 &keep_ways_path,
-                (EXTERNAL_SORT_CHUNK_BYTES / CONCURRENT_SORTS) as u64,
+                EXTERNAL_SORT_CHUNK_BYTES / CONCURRENT_SORTS,
             )?);
             Ok(())
         });
@@ -484,7 +484,7 @@ fn prune_ways<'a>(
                 coords_rx.into_iter(),
                 workdir,
                 &keep_coords_path,
-                (EXTERNAL_SORT_CHUNK_BYTES / CONCURRENT_SORTS) as u64,
+                EXTERNAL_SORT_CHUNK_BYTES / CONCURRENT_SORTS,
             )?);
             Ok(())
         });
@@ -502,7 +502,7 @@ fn prune_ways<'a>(
                 strings_rx.into_iter(),
                 workdir,
                 &strings_path,
-                (EXTERNAL_SORT_CHUNK_BYTES / CONCURRENT_SORTS) as u64,
+                EXTERNAL_SORT_CHUNK_BYTES / CONCURRENT_SORTS,
             )
         });
 
@@ -637,7 +637,7 @@ fn prune_nodes<'a>(
                 strings_rx.into_iter(),
                 workdir,
                 &strings_path,
-                (EXTERNAL_SORT_CHUNK_BYTES / CONCURRENT_SORTS) as u64,
+                EXTERNAL_SORT_CHUNK_BYTES / CONCURRENT_SORTS,
             )
         });
         let coords_writer = s.spawn(|| {
@@ -645,7 +645,7 @@ fn prune_nodes<'a>(
                 coords_rx.into_iter(),
                 workdir,
                 &coords_path,
-                (EXTERNAL_SORT_CHUNK_BYTES / CONCURRENT_SORTS) as u64,
+                EXTERNAL_SORT_CHUNK_BYTES / CONCURRENT_SORTS,
             )
         });
         let keep_nodes_writer = s.spawn(|| {
@@ -653,7 +653,7 @@ fn prune_nodes<'a>(
                 keep_rx.into_iter(),
                 workdir,
                 &keep_nodes_path,
-                (EXTERNAL_SORT_CHUNK_BYTES / CONCURRENT_SORTS) as u64,
+                EXTERNAL_SORT_CHUNK_BYTES / CONCURRENT_SORTS,
             )?);
             Ok(())
         });

--- a/src/pipeline/osm/prune.rs
+++ b/src/pipeline/osm/prune.rs
@@ -2,6 +2,7 @@ use super::BlobReader;
 use crate::{
     make_progress_bar,
     matchers::MatchMask,
+    pipeline::EXTERNAL_SORT_CHUNK_BYTES,
     tables::{CoordTable, Edge, GraphTable, StringCounts, U64Set},
 };
 use anyhow::{Ok, Result};
@@ -263,13 +264,25 @@ fn prune_relations_pass_1<'a>(
                 Ok(())
             })
         });
-        let keep_writer =
-            s.spawn(|| U64Set::create(keep_rx.into_iter(), workdir, &keep_relations_path));
+        // keep_writer and graph_writer each run their own external sort
+        // concurrently in this scope -- split the chunk-size budget
+        // between the two so their combined peak memory stays within one
+        // EXTERNAL_SORT_CHUNK_BYTES, not double it.
+        const CONCURRENT_SORTS: u64 = 2;
+        let keep_writer = s.spawn(|| {
+            U64Set::create(
+                keep_rx.into_iter(),
+                workdir,
+                &keep_relations_path,
+                EXTERNAL_SORT_CHUNK_BYTES as u64 / CONCURRENT_SORTS,
+            )
+        });
         let graph_writer = s.spawn(|| {
             relations_graph = Some(GraphTable::create(
                 edge_rx.into_iter(),
                 workdir,
                 &relation_graph_path,
+                EXTERNAL_SORT_CHUNK_BYTES as u64 / CONCURRENT_SORTS,
             )?);
             Ok(())
         });
@@ -336,17 +349,29 @@ fn prune_relations_pass_2<'a>(
             })
         });
 
+        // keep_writer and strings_writer each run their own external sort
+        // concurrently in this scope -- split the chunk-size budget
+        // between the two so their combined peak memory stays within one
+        // EXTERNAL_SORT_CHUNK_BYTES, not double it.
+        const CONCURRENT_SORTS: u64 = 2;
         let keep_writer = s.spawn(|| {
             rel_members = Some(U64Set::create(
                 keep_rx.into_iter(),
                 workdir,
                 &rel_members_path,
+                EXTERNAL_SORT_CHUNK_BYTES as u64 / CONCURRENT_SORTS,
             )?);
             Ok(())
         });
 
-        let strings_writer =
-            s.spawn(|| StringCounts::create(strings_rx.into_iter(), workdir, &strings_path));
+        let strings_writer = s.spawn(|| {
+            StringCounts::create(
+                strings_rx.into_iter(),
+                workdir,
+                &strings_path,
+                EXTERNAL_SORT_CHUNK_BYTES as u64 / CONCURRENT_SORTS,
+            )
+        });
 
         strings_writer.join().expect("panic in strings_writer")?;
         keep_writer.join().expect("panic in keep_writer")?;
@@ -440,11 +465,17 @@ fn prune_ways<'a>(
             }
             Ok(())
         });
+        // keep_ways_writer, keep_coords_writer, and strings_writer (below)
+        // each run their own external sort concurrently in this scope --
+        // split the chunk-size budget three ways so their combined peak
+        // memory stays within one EXTERNAL_SORT_CHUNK_BYTES, not triple it.
+        const CONCURRENT_SORTS: u64 = 3;
         let keep_ways_writer = s.spawn(|| {
             keep_ways = Some(U64Set::create(
                 ways_rx.into_iter(),
                 workdir,
                 &keep_ways_path,
+                EXTERNAL_SORT_CHUNK_BYTES as u64 / CONCURRENT_SORTS,
             )?);
             Ok(())
         });
@@ -453,6 +484,7 @@ fn prune_ways<'a>(
                 coords_rx.into_iter(),
                 workdir,
                 &keep_coords_path,
+                EXTERNAL_SORT_CHUNK_BYTES as u64 / CONCURRENT_SORTS,
             )?);
             Ok(())
         });
@@ -465,8 +497,14 @@ fn prune_ways<'a>(
             Ok(())
         });
 
-        let strings_writer =
-            s.spawn(|| StringCounts::create(strings_rx.into_iter(), workdir, &strings_path));
+        let strings_writer = s.spawn(|| {
+            StringCounts::create(
+                strings_rx.into_iter(),
+                workdir,
+                &strings_path,
+                EXTERNAL_SORT_CHUNK_BYTES as u64 / CONCURRENT_SORTS,
+            )
+        });
 
         strings_writer.join().expect("panic in strings_writer")?;
         keep_coords_writer
@@ -589,15 +627,33 @@ fn prune_nodes<'a>(
             Ok(())
         });
 
-        let strings_writer =
-            s.spawn(|| StringCounts::create(strings_rx.into_iter(), workdir, &strings_path));
-        let coords_writer =
-            s.spawn(|| CoordTable::create(coords_rx.into_iter(), workdir, &coords_path));
+        // strings_writer, coords_writer, and keep_nodes_writer each run
+        // their own external sort concurrently in this scope -- split the
+        // chunk-size budget three ways so their combined peak memory
+        // stays within one EXTERNAL_SORT_CHUNK_BYTES, not triple it.
+        const CONCURRENT_SORTS: u64 = 3;
+        let strings_writer = s.spawn(|| {
+            StringCounts::create(
+                strings_rx.into_iter(),
+                workdir,
+                &strings_path,
+                EXTERNAL_SORT_CHUNK_BYTES as u64 / CONCURRENT_SORTS,
+            )
+        });
+        let coords_writer = s.spawn(|| {
+            CoordTable::create(
+                coords_rx.into_iter(),
+                workdir,
+                &coords_path,
+                EXTERNAL_SORT_CHUNK_BYTES as u64 / CONCURRENT_SORTS,
+            )
+        });
         let keep_nodes_writer = s.spawn(|| {
             keep_nodes = Some(U64Set::create(
                 keep_rx.into_iter(),
                 workdir,
                 &keep_nodes_path,
+                EXTERNAL_SORT_CHUNK_BYTES as u64 / CONCURRENT_SORTS,
             )?);
             Ok(())
         });

--- a/src/pipeline/osm/prune.rs
+++ b/src/pipeline/osm/prune.rs
@@ -268,13 +268,13 @@ fn prune_relations_pass_1<'a>(
         // concurrently in this scope -- split the chunk-size budget
         // between the two so their combined peak memory stays within one
         // EXTERNAL_SORT_CHUNK_BYTES, not double it.
-        const CONCURRENT_SORTS: u64 = 2;
+        const CONCURRENT_SORTS: usize = 2;
         let keep_writer = s.spawn(|| {
             U64Set::create(
                 keep_rx.into_iter(),
                 workdir,
                 &keep_relations_path,
-                EXTERNAL_SORT_CHUNK_BYTES as u64 / CONCURRENT_SORTS,
+                (EXTERNAL_SORT_CHUNK_BYTES / CONCURRENT_SORTS) as u64,
             )
         });
         let graph_writer = s.spawn(|| {
@@ -282,7 +282,7 @@ fn prune_relations_pass_1<'a>(
                 edge_rx.into_iter(),
                 workdir,
                 &relation_graph_path,
-                EXTERNAL_SORT_CHUNK_BYTES as u64 / CONCURRENT_SORTS,
+                (EXTERNAL_SORT_CHUNK_BYTES / CONCURRENT_SORTS) as u64,
             )?);
             Ok(())
         });
@@ -353,13 +353,13 @@ fn prune_relations_pass_2<'a>(
         // concurrently in this scope -- split the chunk-size budget
         // between the two so their combined peak memory stays within one
         // EXTERNAL_SORT_CHUNK_BYTES, not double it.
-        const CONCURRENT_SORTS: u64 = 2;
+        const CONCURRENT_SORTS: usize = 2;
         let keep_writer = s.spawn(|| {
             rel_members = Some(U64Set::create(
                 keep_rx.into_iter(),
                 workdir,
                 &rel_members_path,
-                EXTERNAL_SORT_CHUNK_BYTES as u64 / CONCURRENT_SORTS,
+                (EXTERNAL_SORT_CHUNK_BYTES / CONCURRENT_SORTS) as u64,
             )?);
             Ok(())
         });
@@ -369,7 +369,7 @@ fn prune_relations_pass_2<'a>(
                 strings_rx.into_iter(),
                 workdir,
                 &strings_path,
-                EXTERNAL_SORT_CHUNK_BYTES as u64 / CONCURRENT_SORTS,
+                (EXTERNAL_SORT_CHUNK_BYTES / CONCURRENT_SORTS) as u64,
             )
         });
 
@@ -469,13 +469,13 @@ fn prune_ways<'a>(
         // each run their own external sort concurrently in this scope --
         // split the chunk-size budget three ways so their combined peak
         // memory stays within one EXTERNAL_SORT_CHUNK_BYTES, not triple it.
-        const CONCURRENT_SORTS: u64 = 3;
+        const CONCURRENT_SORTS: usize = 3;
         let keep_ways_writer = s.spawn(|| {
             keep_ways = Some(U64Set::create(
                 ways_rx.into_iter(),
                 workdir,
                 &keep_ways_path,
-                EXTERNAL_SORT_CHUNK_BYTES as u64 / CONCURRENT_SORTS,
+                (EXTERNAL_SORT_CHUNK_BYTES / CONCURRENT_SORTS) as u64,
             )?);
             Ok(())
         });
@@ -484,7 +484,7 @@ fn prune_ways<'a>(
                 coords_rx.into_iter(),
                 workdir,
                 &keep_coords_path,
-                EXTERNAL_SORT_CHUNK_BYTES as u64 / CONCURRENT_SORTS,
+                (EXTERNAL_SORT_CHUNK_BYTES / CONCURRENT_SORTS) as u64,
             )?);
             Ok(())
         });
@@ -502,7 +502,7 @@ fn prune_ways<'a>(
                 strings_rx.into_iter(),
                 workdir,
                 &strings_path,
-                EXTERNAL_SORT_CHUNK_BYTES as u64 / CONCURRENT_SORTS,
+                (EXTERNAL_SORT_CHUNK_BYTES / CONCURRENT_SORTS) as u64,
             )
         });
 
@@ -631,13 +631,13 @@ fn prune_nodes<'a>(
         // their own external sort concurrently in this scope -- split the
         // chunk-size budget three ways so their combined peak memory
         // stays within one EXTERNAL_SORT_CHUNK_BYTES, not triple it.
-        const CONCURRENT_SORTS: u64 = 3;
+        const CONCURRENT_SORTS: usize = 3;
         let strings_writer = s.spawn(|| {
             StringCounts::create(
                 strings_rx.into_iter(),
                 workdir,
                 &strings_path,
-                EXTERNAL_SORT_CHUNK_BYTES as u64 / CONCURRENT_SORTS,
+                (EXTERNAL_SORT_CHUNK_BYTES / CONCURRENT_SORTS) as u64,
             )
         });
         let coords_writer = s.spawn(|| {
@@ -645,7 +645,7 @@ fn prune_nodes<'a>(
                 coords_rx.into_iter(),
                 workdir,
                 &coords_path,
-                EXTERNAL_SORT_CHUNK_BYTES as u64 / CONCURRENT_SORTS,
+                (EXTERNAL_SORT_CHUNK_BYTES / CONCURRENT_SORTS) as u64,
             )
         });
         let keep_nodes_writer = s.spawn(|| {
@@ -653,7 +653,7 @@ fn prune_nodes<'a>(
                 keep_rx.into_iter(),
                 workdir,
                 &keep_nodes_path,
-                EXTERNAL_SORT_CHUNK_BYTES as u64 / CONCURRENT_SORTS,
+                (EXTERNAL_SORT_CHUNK_BYTES / CONCURRENT_SORTS) as u64,
             )?);
             Ok(())
         });

--- a/src/tables/blob_table.rs
+++ b/src/tables/blob_table.rs
@@ -5,8 +5,9 @@
 //! like serialized protobuf messages, WKB geeometry, or other opaque
 //! binary payloads.
 
+use crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES;
 use anyhow::{Ok, Result};
-use ext_sort::{ExternalSorter, ExternalSorterBuilder, buffer::LimitedBufferBuilder};
+use ext_sort::{ExternalSorter, ExternalSorterBuilder, buffer::mem::MemoryLimitedBufferBuilder};
 use memmap2::Mmap;
 use std::{
     fs::{File, remove_file, rename},
@@ -33,20 +34,27 @@ impl<'a> BlobTable<'a> {
     ///
     /// Since [Writer::write] requires keys in ascending order, `blobs` is
     /// first sorted by key using external sorting (spilling to `workdir`
-    /// as needed), and only then written to `out`.
+    /// as needed), and only then written to `out`. `chunk_bytes` bounds
+    /// each external-sort chunk's in-memory size (and, in turn, how many
+    /// chunk files end up open at once during the final merge -- see
+    /// [crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES]); a blob's actual byte
+    /// size varies, so this is measured with [MemoryLimitedBufferBuilder]
+    /// rather than an item count. Callers that run several external sorts
+    /// concurrently (e.g. from sibling threads in the same
+    /// `thread::scope`) should divide their share of the budget
+    /// accordingly -- this function has no way to know how many others
+    /// are running alongside it.
     pub fn create(
         blobs: impl Iterator<Item = (u64, Vec<u8>)>,
         workdir: &Path,
         out: &Path,
+        chunk_bytes: u64,
     ) -> Result<BlobTable<'a>> {
         let mut writer = Writer::create(out)?;
-        let sorter: ExternalSorter<(u64, Vec<u8>), std::io::Error, LimitedBufferBuilder> =
+        let sorter: ExternalSorter<(u64, Vec<u8>), std::io::Error, MemoryLimitedBufferBuilder> =
             ExternalSorterBuilder::new()
                 .with_tmp_dir(workdir)
-                .with_buffer(LimitedBufferBuilder::new(
-                    128 * 1024,
-                    /* preallocate */ true,
-                ))
+                .with_buffer(MemoryLimitedBufferBuilder::new(chunk_bytes))
                 .build()?;
         let sorted = sorter.sort(blobs.map(std::io::Result::Ok))?;
         for s in sorted {
@@ -277,7 +285,12 @@ mod tests {
             (41, b"".to_vec()),
         ];
 
-        let table = BlobTable::create(blobs.into_iter(), workdir.path(), file.path())?;
+        let table = BlobTable::create(
+            blobs.into_iter(),
+            workdir.path(),
+            file.path(),
+            crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES as u64,
+        )?;
         assert_eq!(table.len(), 4);
         assert_eq!(table.lookup(0), None);
         assert_eq!(table.lookup(17), Some(b"bern".as_slice()));

--- a/src/tables/blob_table.rs
+++ b/src/tables/blob_table.rs
@@ -48,13 +48,13 @@ impl<'a> BlobTable<'a> {
         blobs: impl Iterator<Item = (u64, Vec<u8>)>,
         workdir: &Path,
         out: &Path,
-        chunk_bytes: u64,
+        chunk_bytes: usize,
     ) -> Result<BlobTable<'a>> {
         let mut writer = Writer::create(out)?;
         let sorter: ExternalSorter<(u64, Vec<u8>), std::io::Error, MemoryLimitedBufferBuilder> =
             ExternalSorterBuilder::new()
                 .with_tmp_dir(workdir)
-                .with_buffer(MemoryLimitedBufferBuilder::new(chunk_bytes))
+                .with_buffer(MemoryLimitedBufferBuilder::new(chunk_bytes as u64))
                 .build()?;
         let sorted = sorter.sort(blobs.map(std::io::Result::Ok))?;
         for s in sorted {
@@ -289,7 +289,7 @@ mod tests {
             blobs.into_iter(),
             workdir.path(),
             file.path(),
-            crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES as u64,
+            crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES,
         )?;
         assert_eq!(table.len(), 4);
         assert_eq!(table.lookup(0), None);

--- a/src/tables/coord_table.rs
+++ b/src/tables/coord_table.rs
@@ -81,7 +81,7 @@ impl<'a> CoordTable<'a> {
         coords: impl Iterator<Item = (u64, Coord)>,
         workdir: &Path,
         out: &Path,
-        chunk_bytes: u64,
+        chunk_bytes: usize,
     ) -> Result<CoordTable<'a>> {
         let mut writer = Writer::create(out)?;
         let coords_count = AtomicU64::new(0);
@@ -89,7 +89,7 @@ impl<'a> CoordTable<'a> {
             ExternalSorterBuilder::new()
                 .with_tmp_dir(workdir)
                 .with_buffer(LimitedBufferBuilder::new(
-                    chunk_bytes as usize / size_of::<(u64, u64)>(),
+                    chunk_bytes / size_of::<(u64, u64)>(),
                     /* preallocate */ true,
                 ))
                 .build()?;
@@ -320,7 +320,7 @@ mod tests {
             coords.into_iter(),
             workdir.path(),
             file.path(),
-            crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES as u64,
+            crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES,
         )?;
         assert_eq!(table.len(), 3);
         assert_eq!(table.get(0), None);

--- a/src/tables/coord_table.rs
+++ b/src/tables/coord_table.rs
@@ -85,11 +85,16 @@ impl<'a> CoordTable<'a> {
     ) -> Result<CoordTable<'a>> {
         let mut writer = Writer::create(out)?;
         let coords_count = AtomicU64::new(0);
-        let sorter: ExternalSorter<(u64, u64), std::io::Error, LimitedBufferBuilder> =
+        // Named as a local type alias, not repeated as a literal tuple, so
+        // the item type used to build the sorter and the one used to size
+        // its buffer can't silently drift apart under a future
+        // refactoring.
+        type Item = (u64, u64); // (key, packed_coord)
+        let sorter: ExternalSorter<Item, std::io::Error, LimitedBufferBuilder> =
             ExternalSorterBuilder::new()
                 .with_tmp_dir(workdir)
                 .with_buffer(LimitedBufferBuilder::new(
-                    chunk_bytes / size_of::<(u64, u64)>(),
+                    chunk_bytes / size_of::<Item>(),
                     /* preallocate */ true,
                 ))
                 .build()?;

--- a/src/tables/coord_table.rs
+++ b/src/tables/coord_table.rs
@@ -67,11 +67,21 @@ impl<'a> CoordTable<'a> {
     ///
     /// Since [Writer::write] requires keys in ascending order, `coords` is
     /// first sorted by key using external sorting (spilling to `workdir`
-    /// as needed), and only then written to `out`.
+    /// as needed), and only then written to `out`. `chunk_bytes` bounds
+    /// each external-sort chunk's in-memory size (and, in turn, how many
+    /// chunk files end up open at once during the final merge -- see
+    /// [crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES]); entries here are
+    /// fixed-size, so this is converted to an item count rather than
+    /// measured via [MemoryLimitedBufferBuilder]. Callers that run several
+    /// external sorts concurrently (e.g. from sibling threads in the same
+    /// `thread::scope`) should divide their share of the budget
+    /// accordingly -- this function has no way to know how many others
+    /// are running alongside it.
     pub fn create(
         coords: impl Iterator<Item = (u64, Coord)>,
         workdir: &Path,
         out: &Path,
+        chunk_bytes: u64,
     ) -> Result<CoordTable<'a>> {
         let mut writer = Writer::create(out)?;
         let coords_count = AtomicU64::new(0);
@@ -79,7 +89,7 @@ impl<'a> CoordTable<'a> {
             ExternalSorterBuilder::new()
                 .with_tmp_dir(workdir)
                 .with_buffer(LimitedBufferBuilder::new(
-                    16 * 1024 * 1024,
+                    chunk_bytes as usize / size_of::<(u64, u64)>(),
                     /* preallocate */ true,
                 ))
                 .build()?;
@@ -306,7 +316,12 @@ mod tests {
             ),
         ];
 
-        let table = CoordTable::create(coords.into_iter(), workdir.path(), file.path())?;
+        let table = CoordTable::create(
+            coords.into_iter(),
+            workdir.path(),
+            file.path(),
+            crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES as u64,
+        )?;
         assert_eq!(table.len(), 3);
         assert_eq!(table.get(0), None);
         assert!(almost_equal(

--- a/src/tables/geometry_table.rs
+++ b/src/tables/geometry_table.rs
@@ -40,7 +40,7 @@ impl<'a> GeometryTable<'a> {
         geometries: impl Iterator<Item = (u64, Geometry)>,
         workdir: &Path,
         out: &Path,
-        chunk_bytes: u64,
+        chunk_bytes: usize,
     ) -> Result<GeometryTable<'a>> {
         let blobs = BlobTable::create(
             geometries.map(|(key, geometry)| (key, encode_wkb(&geometry))),
@@ -115,7 +115,7 @@ mod tests {
             geometries.into_iter(),
             workdir.path(),
             file.path(),
-            crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES as u64,
+            crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES,
         )?;
         assert_eq!(table.len(), 3);
         assert_eq!(table.lookup(0), None);
@@ -152,7 +152,7 @@ mod tests {
             geometries.into_iter(),
             workdir.path(),
             file.path(),
-            crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES as u64,
+            crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES,
         )?;
 
         let table = GeometryTable::open(file.path())?;
@@ -178,7 +178,7 @@ mod tests {
             geometries.into_iter(),
             workdir.path(),
             file.path(),
-            crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES as u64,
+            crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES,
         )?;
 
         let table = GeometryTable::open(file.path())?;

--- a/src/tables/geometry_table.rs
+++ b/src/tables/geometry_table.rs
@@ -34,16 +34,19 @@ impl<'a> GeometryTable<'a> {
     ///
     /// Each geometry is encoded as a WKB blob and handed to the embedded
     /// [BlobTable], so the same ordering and external-sorting behavior as
-    /// [BlobTable::create] applies.
+    /// [BlobTable::create] applies -- including `chunk_bytes`, forwarded
+    /// straight through; see [BlobTable::create] for what it means.
     pub fn create(
         geometries: impl Iterator<Item = (u64, Geometry)>,
         workdir: &Path,
         out: &Path,
+        chunk_bytes: u64,
     ) -> Result<GeometryTable<'a>> {
         let blobs = BlobTable::create(
             geometries.map(|(key, geometry)| (key, encode_wkb(&geometry))),
             workdir,
             out,
+            chunk_bytes,
         )?;
         Ok(GeometryTable { blobs })
     }
@@ -108,7 +111,12 @@ mod tests {
             ),
         ];
 
-        let table = GeometryTable::create(geometries.into_iter(), workdir.path(), file.path())?;
+        let table = GeometryTable::create(
+            geometries.into_iter(),
+            workdir.path(),
+            file.path(),
+            crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES as u64,
+        )?;
         assert_eq!(table.len(), 3);
         assert_eq!(table.lookup(0), None);
         assert_eq!(
@@ -140,7 +148,12 @@ mod tests {
             vec![],
         );
         let geometries = vec![(1_u64, Geometry::Polygon(polygon.clone()))];
-        GeometryTable::create(geometries.into_iter(), workdir.path(), file.path())?;
+        GeometryTable::create(
+            geometries.into_iter(),
+            workdir.path(),
+            file.path(),
+            crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES as u64,
+        )?;
 
         let table = GeometryTable::open(file.path())?;
         assert_eq!(
@@ -161,7 +174,12 @@ mod tests {
             (42, Geometry::Point(Point::new(2.0, 2.0))),
             (17, Geometry::Point(Point::new(1.0, 1.0))),
         ];
-        GeometryTable::create(geometries.into_iter(), workdir.path(), file.path())?;
+        GeometryTable::create(
+            geometries.into_iter(),
+            workdir.path(),
+            file.path(),
+            crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES as u64,
+        )?;
 
         let table = GeometryTable::open(file.path())?;
         let entries: Vec<(u64, Geometry)> = table.iter().collect();

--- a/src/tables/graph.rs
+++ b/src/tables/graph.rs
@@ -39,6 +39,7 @@ use std::{
     collections::{BTreeMap, HashSet, VecDeque},
     fs::{File, remove_file, rename},
     io::{BufReader, BufWriter, Seek, SeekFrom, Write},
+    mem::size_of,
     ops::Range,
     path::{Path, PathBuf},
     sync::atomic::{AtomicU64, Ordering},
@@ -66,11 +67,21 @@ impl<'a> GraphTable<'a> {
     ///
     /// Since [Writer::write] requires edges in ascending `(child, parent)`
     /// order, `edges` is first sorted using external sorting (spilling to
-    /// `workdir` as needed), and only then written to `out`.
+    /// `workdir` as needed), and only then written to `out`. `chunk_bytes`
+    /// bounds each external-sort chunk's in-memory size (and, in turn, how
+    /// many chunk files end up open at once during the final merge -- see
+    /// [crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES]); `Edge` is fixed-size,
+    /// so this is converted to an item count rather than measured via
+    /// `MemoryLimitedBufferBuilder`. Callers that run several external
+    /// sorts concurrently (e.g. from sibling threads in the same
+    /// `thread::scope`) should divide their share of the budget
+    /// accordingly -- this function has no way to know how many others
+    /// are running alongside it.
     pub fn create(
         edges: impl Iterator<Item = Edge>,
         workdir: &Path,
         out: &Path,
+        chunk_bytes: u64,
     ) -> Result<GraphTable<'a>> {
         let mut writer = Writer::create(out)?;
         let num_edges = AtomicU64::new(0);
@@ -78,7 +89,7 @@ impl<'a> GraphTable<'a> {
             ExternalSorterBuilder::new()
                 .with_tmp_dir(workdir)
                 .with_buffer(LimitedBufferBuilder::new(
-                    16 * 1024 * 1024,
+                    chunk_bytes as usize / size_of::<Edge>(),
                     /* preallocate */ true,
                 ))
                 .build()?;
@@ -452,7 +463,12 @@ mod tests {
             .map(|(child, parent)| Edge { child, parent });
         let workdir = TempDir::new()?;
         let path = workdir.path().join("testgraph");
-        let graph = GraphTable::create(edges_iter, workdir.path(), &path)?;
+        let graph = GraphTable::create(
+            edges_iter,
+            workdir.path(),
+            &path,
+            crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES as u64,
+        )?;
         assert_eq!(graph.modified()?, std::fs::metadata(&path)?.modified()?);
         assert_eq!(
             graph.ancestors(1).collect::<Vec<u64>>(),
@@ -482,7 +498,12 @@ mod tests {
             .map(|(child, parent)| Edge { child, parent });
         let workdir = TempDir::new()?;
         let path = workdir.path().join("testgraph");
-        let graph = GraphTable::create(edges_iter, workdir.path(), &path)?;
+        let graph = GraphTable::create(
+            edges_iter,
+            workdir.path(),
+            &path,
+            crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES as u64,
+        )?;
         assert_eq!(graph.nodes().collect::<Vec<u64>>(), &[1, 2, 3, 4]);
         Ok(())
     }
@@ -493,7 +514,12 @@ mod tests {
         let edges_iter = std::iter::empty::<Edge>();
         let workdir = TempDir::new()?;
         let path = workdir.path().join("testgraph");
-        let graph = GraphTable::create(edges_iter, workdir.path(), &path)?;
+        let graph = GraphTable::create(
+            edges_iter,
+            workdir.path(),
+            &path,
+            crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES as u64,
+        )?;
         assert_eq!(graph.nodes().collect::<Vec<u64>>(), Vec::<u64>::new());
         Ok(())
     }
@@ -544,7 +570,12 @@ mod tests {
             .map(|(child, parent)| Edge { child, parent });
         let workdir = TempDir::new()?;
         let path = workdir.path().join("testgraph");
-        let graph = GraphTable::create(edges_iter, workdir.path(), &path)?;
+        let graph = GraphTable::create(
+            edges_iter,
+            workdir.path(),
+            &path,
+            crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES as u64,
+        )?;
         assert_eq!(graph.edge_count(), 3);
         Ok(())
     }
@@ -554,7 +585,12 @@ mod tests {
         let edges_iter = std::iter::empty::<Edge>();
         let workdir = TempDir::new()?;
         let path = workdir.path().join("testgraph");
-        let graph = GraphTable::create(edges_iter, workdir.path(), &path)?;
+        let graph = GraphTable::create(
+            edges_iter,
+            workdir.path(),
+            &path,
+            crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES as u64,
+        )?;
         assert_eq!(graph.edge_count(), 0);
         Ok(())
     }
@@ -577,7 +613,12 @@ mod tests {
             .map(|(child, parent)| Edge { child, parent });
         let workdir = TempDir::new()?;
         let path = workdir.path().join("testgraph");
-        let graph = GraphTable::create(edges_iter, workdir.path(), &path)?;
+        let graph = GraphTable::create(
+            edges_iter,
+            workdir.path(),
+            &path,
+            crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES as u64,
+        )?;
         // Nodes 1..6 and 21..23, nine in total.
         assert_eq!(graph.node_count(), 9);
         Ok(())
@@ -588,7 +629,12 @@ mod tests {
         let edges_iter = std::iter::empty::<Edge>();
         let workdir = TempDir::new()?;
         let path = workdir.path().join("testgraph");
-        let graph = GraphTable::create(edges_iter, workdir.path(), &path)?;
+        let graph = GraphTable::create(
+            edges_iter,
+            workdir.path(),
+            &path,
+            crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES as u64,
+        )?;
         assert_eq!(graph.node_count(), 0);
         Ok(())
     }
@@ -603,7 +649,12 @@ mod tests {
             .map(|(child, parent)| Edge { child, parent });
         let workdir = TempDir::new()?;
         let path = workdir.path().join("testgraph");
-        let graph = GraphTable::create(edges_iter, workdir.path(), &path)?;
+        let graph = GraphTable::create(
+            edges_iter,
+            workdir.path(),
+            &path,
+            crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES as u64,
+        )?;
         assert_eq!(graph.node_count(), 3);
         Ok(())
     }

--- a/src/tables/graph.rs
+++ b/src/tables/graph.rs
@@ -85,11 +85,15 @@ impl<'a> GraphTable<'a> {
     ) -> Result<GraphTable<'a>> {
         let mut writer = Writer::create(out)?;
         let num_edges = AtomicU64::new(0);
-        let sorter: ExternalSorter<Edge, std::io::Error, LimitedBufferBuilder> =
+        // Named as a local type alias, not spelled out twice, so the item
+        // type used to build the sorter and the one used to size its
+        // buffer can't silently drift apart under a future refactoring.
+        type Item = Edge;
+        let sorter: ExternalSorter<Item, std::io::Error, LimitedBufferBuilder> =
             ExternalSorterBuilder::new()
                 .with_tmp_dir(workdir)
                 .with_buffer(LimitedBufferBuilder::new(
-                    chunk_bytes / size_of::<Edge>(),
+                    chunk_bytes / size_of::<Item>(),
                     /* preallocate */ true,
                 ))
                 .build()?;

--- a/src/tables/graph.rs
+++ b/src/tables/graph.rs
@@ -81,7 +81,7 @@ impl<'a> GraphTable<'a> {
         edges: impl Iterator<Item = Edge>,
         workdir: &Path,
         out: &Path,
-        chunk_bytes: u64,
+        chunk_bytes: usize,
     ) -> Result<GraphTable<'a>> {
         let mut writer = Writer::create(out)?;
         let num_edges = AtomicU64::new(0);
@@ -89,7 +89,7 @@ impl<'a> GraphTable<'a> {
             ExternalSorterBuilder::new()
                 .with_tmp_dir(workdir)
                 .with_buffer(LimitedBufferBuilder::new(
-                    chunk_bytes as usize / size_of::<Edge>(),
+                    chunk_bytes / size_of::<Edge>(),
                     /* preallocate */ true,
                 ))
                 .build()?;
@@ -467,7 +467,7 @@ mod tests {
             edges_iter,
             workdir.path(),
             &path,
-            crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES as u64,
+            crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES,
         )?;
         assert_eq!(graph.modified()?, std::fs::metadata(&path)?.modified()?);
         assert_eq!(
@@ -502,7 +502,7 @@ mod tests {
             edges_iter,
             workdir.path(),
             &path,
-            crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES as u64,
+            crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES,
         )?;
         assert_eq!(graph.nodes().collect::<Vec<u64>>(), &[1, 2, 3, 4]);
         Ok(())
@@ -518,7 +518,7 @@ mod tests {
             edges_iter,
             workdir.path(),
             &path,
-            crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES as u64,
+            crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES,
         )?;
         assert_eq!(graph.nodes().collect::<Vec<u64>>(), Vec::<u64>::new());
         Ok(())
@@ -574,7 +574,7 @@ mod tests {
             edges_iter,
             workdir.path(),
             &path,
-            crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES as u64,
+            crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES,
         )?;
         assert_eq!(graph.edge_count(), 3);
         Ok(())
@@ -589,7 +589,7 @@ mod tests {
             edges_iter,
             workdir.path(),
             &path,
-            crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES as u64,
+            crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES,
         )?;
         assert_eq!(graph.edge_count(), 0);
         Ok(())
@@ -617,7 +617,7 @@ mod tests {
             edges_iter,
             workdir.path(),
             &path,
-            crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES as u64,
+            crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES,
         )?;
         // Nodes 1..6 and 21..23, nine in total.
         assert_eq!(graph.node_count(), 9);
@@ -633,7 +633,7 @@ mod tests {
             edges_iter,
             workdir.path(),
             &path,
-            crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES as u64,
+            crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES,
         )?;
         assert_eq!(graph.node_count(), 0);
         Ok(())
@@ -653,7 +653,7 @@ mod tests {
             edges_iter,
             workdir.path(),
             &path,
-            crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES as u64,
+            crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES,
         )?;
         assert_eq!(graph.node_count(), 3);
         Ok(())

--- a/src/tables/string_counts.rs
+++ b/src/tables/string_counts.rs
@@ -44,7 +44,7 @@
 //! mmap'd bytes.
 
 use anyhow::{Ok, Result};
-use ext_sort::{ExternalSorter, ExternalSorterBuilder, buffer::LimitedBufferBuilder};
+use ext_sort::{ExternalSorter, ExternalSorterBuilder, buffer::mem::MemoryLimitedBufferBuilder};
 use memmap2::Mmap;
 use std::{
     fs::{File, remove_file, rename},
@@ -81,21 +81,27 @@ impl<'a> StringCounts<'a> {
     ///
     /// Since [Writer::write] requires keys in ascending order, `counts` is
     /// first sorted by key using external sorting (spilling to `workdir`
-    /// as needed), and only then written to `out`.
+    /// as needed), and only then written to `out`. `chunk_bytes` bounds
+    /// each external-sort chunk's in-memory size (and, in turn, how many
+    /// chunk files end up open at once during the final merge -- see
+    /// [crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES]); keys vary in length,
+    /// so this is measured with [MemoryLimitedBufferBuilder] rather than
+    /// an item count. Callers that run several external sorts concurrently
+    /// (e.g. from sibling threads in the same `thread::scope`) should
+    /// divide their share of the budget accordingly -- this function has
+    /// no way to know how many others are running alongside it.
     pub fn create(
         counts: impl Iterator<Item = (String, u64)>,
         workdir: &Path,
         out: &Path,
+        chunk_bytes: u64,
     ) -> Result<StringCounts<'a>> {
         let mut writer = Writer::create(out)?;
         let entry_count = AtomicU64::new(0);
-        let sorter: ExternalSorter<(String, u64), std::io::Error, LimitedBufferBuilder> =
+        let sorter: ExternalSorter<(String, u64), std::io::Error, MemoryLimitedBufferBuilder> =
             ExternalSorterBuilder::new()
                 .with_tmp_dir(workdir)
-                .with_buffer(LimitedBufferBuilder::new(
-                    8 * 1024 * 1024,
-                    /* preallocate */ true,
-                ))
+                .with_buffer(MemoryLimitedBufferBuilder::new(chunk_bytes))
                 .build()?;
         let sorted = sorter.sort(counts.map(|entry| {
             entry_count.fetch_add(1, Ordering::SeqCst);
@@ -349,6 +355,7 @@ mod tests {
             entries.map(|(s, n)| (String::from(s), n)).into_iter(),
             workdir.path(),
             &path,
+            crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES as u64,
         )
         .expect("StringCounts::create() failed")
     });
@@ -375,6 +382,7 @@ mod tests {
             entries.map(|(s, n)| (String::from(s), n)).into_iter(),
             workdir.path(),
             &path,
+            crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES as u64,
         )?;
 
         let table = StringCounts::open(&path)?;

--- a/src/tables/string_counts.rs
+++ b/src/tables/string_counts.rs
@@ -94,14 +94,14 @@ impl<'a> StringCounts<'a> {
         counts: impl Iterator<Item = (String, u64)>,
         workdir: &Path,
         out: &Path,
-        chunk_bytes: u64,
+        chunk_bytes: usize,
     ) -> Result<StringCounts<'a>> {
         let mut writer = Writer::create(out)?;
         let entry_count = AtomicU64::new(0);
         let sorter: ExternalSorter<(String, u64), std::io::Error, MemoryLimitedBufferBuilder> =
             ExternalSorterBuilder::new()
                 .with_tmp_dir(workdir)
-                .with_buffer(MemoryLimitedBufferBuilder::new(chunk_bytes))
+                .with_buffer(MemoryLimitedBufferBuilder::new(chunk_bytes as u64))
                 .build()?;
         let sorted = sorter.sort(counts.map(|entry| {
             entry_count.fetch_add(1, Ordering::SeqCst);
@@ -355,7 +355,7 @@ mod tests {
             entries.map(|(s, n)| (String::from(s), n)).into_iter(),
             workdir.path(),
             &path,
-            crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES as u64,
+            crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES,
         )
         .expect("StringCounts::create() failed")
     });
@@ -382,7 +382,7 @@ mod tests {
             entries.map(|(s, n)| (String::from(s), n)).into_iter(),
             workdir.path(),
             &path,
-            crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES as u64,
+            crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES,
         )?;
 
         let table = StringCounts::open(&path)?;

--- a/src/tables/string_pool.rs
+++ b/src/tables/string_pool.rs
@@ -548,12 +548,16 @@ impl Writer {
         // concurrently, so this gets the full chunk-size budget; see
         // crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES. Entries are
         // fixed-size, so the budget is converted to an item count rather
-        // than measured via MemoryLimitedBufferBuilder.
-        let sorter: ExternalSorter<(u32, usize), std::io::Error, LimitedBufferBuilder> =
+        // than measured via MemoryLimitedBufferBuilder. Named as a local
+        // type alias, not repeated as a literal tuple, so the item type
+        // used to build the sorter and the one used to size its buffer
+        // can't silently drift apart under a future refactoring.
+        type Item = (u32, usize);
+        let sorter: ExternalSorter<Item, std::io::Error, LimitedBufferBuilder> =
             ExternalSorterBuilder::new()
                 .with_tmp_dir(workdir)
                 .with_buffer(LimitedBufferBuilder::new(
-                    crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES / size_of::<(u32, usize)>(),
+                    crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES / size_of::<Item>(),
                     /* preallocate */ true,
                 ))
                 .build()?;

--- a/src/tables/string_pool.rs
+++ b/src/tables/string_pool.rs
@@ -80,6 +80,7 @@ use std::{
     hash::{DefaultHasher, Hash, Hasher},
     io,
     io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write},
+    mem::size_of,
     path::{Path, PathBuf},
     time::SystemTime,
 };
@@ -542,11 +543,17 @@ impl Writer {
         let mut hash_values_writer =
             BufWriter::with_capacity(32 * 1024, File::create(&hash_values_path)?);
 
+        // StringPool::create has exactly one caller in the pipeline
+        // (assemble_strings), which never runs another external sort
+        // concurrently, so this gets the full chunk-size budget; see
+        // crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES. Entries are
+        // fixed-size, so the budget is converted to an item count rather
+        // than measured via MemoryLimitedBufferBuilder.
         let sorter: ExternalSorter<(u32, usize), std::io::Error, LimitedBufferBuilder> =
             ExternalSorterBuilder::new()
                 .with_tmp_dir(workdir)
                 .with_buffer(LimitedBufferBuilder::new(
-                    1024 * 1024,
+                    crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES / size_of::<(u32, usize)>(),
                     /* preallocate */ true,
                 ))
                 .build()?;

--- a/src/tables/u64_set.rs
+++ b/src/tables/u64_set.rs
@@ -47,12 +47,20 @@ impl U64Set {
     ///
     /// `elements` is sorted and deduplicated using external sorting
     /// (spilling to `workdir` as needed), and only then written to `out`.
+    /// `chunk_bytes` bounds each external-sort chunk's in-memory size
+    /// (and, in turn, how many chunk files end up open at once during the
+    /// final merge -- see [crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES]).
+    /// Callers that run several external sorts concurrently (e.g. from
+    /// sibling threads in the same `thread::scope`) should divide their
+    /// share of the budget accordingly -- this function has no way to
+    /// know how many others are running alongside it.
     pub fn create(
         elements: impl Iterator<Item = u64>,
         workdir: &Path,
         out: &Path,
+        chunk_bytes: u64,
     ) -> Result<U64Set> {
-        _ = writer::create(elements, workdir, out)?;
+        _ = writer::create(elements, workdir, out, chunk_bytes)?;
         Self::open(out)
     }
 
@@ -233,7 +241,12 @@ mod tests {
         let workdir = TempDir::new()?;
         let out = workdir.path().join("test.u64set");
 
-        let set = U64Set::create([42, 7, 23, 7].into_iter(), workdir.path(), &out)?;
+        let set = U64Set::create(
+            [42, 7, 23, 7].into_iter(),
+            workdir.path(),
+            &out,
+            crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES as u64,
+        )?;
         assert_eq!(set.len(), 3);
         assert!(set.contains(7));
         assert!(set.contains(23));
@@ -253,16 +266,23 @@ mod writer {
     use ext_sort::{ExternalSorter, ExternalSorterBuilder, buffer::LimitedBufferBuilder};
     use std::fs::File;
     use std::io::{BufWriter, Seek, SeekFrom, Write};
+    use std::mem::size_of;
     use std::path::{Path, PathBuf};
 
-    pub fn create(elements: impl Iterator<Item = u64>, workdir: &Path, out: &Path) -> Result<u64> {
+    pub fn create(
+        elements: impl Iterator<Item = u64>,
+        workdir: &Path,
+        out: &Path,
+        chunk_bytes: u64,
+    ) -> Result<u64> {
         let mut tmp_out = PathBuf::from(out);
         tmp_out.add_extension("tmp");
         let sorter: ExternalSorter<u64, std::io::Error, LimitedBufferBuilder> =
             ExternalSorterBuilder::new()
                 .with_tmp_dir(workdir)
                 .with_buffer(LimitedBufferBuilder::new(
-                    /* buffer_size */ 5_000_000, /* preallocate */ true,
+                    /* buffer_size */ chunk_bytes as usize / size_of::<u64>(),
+                    /* preallocate */ true,
                 ))
                 .build()?;
         let sorted = sorter.sort(elements.map(std::io::Result::Ok))?;
@@ -313,6 +333,7 @@ mod writer {
                 /* elements */ [42, 23, 23, 7777, 23].into_iter(),
                 /* workdir */ tmp.path(),
                 /* out */ &out,
+                crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES as u64,
             )?;
             assert_eq!(num_written, 3);
 
@@ -332,7 +353,12 @@ mod writer {
             let tmp = tempfile::TempDir::new()?;
             let out = tmp.path().join("test.u64_table");
 
-            let num_written = super::create([9].into_iter(), tmp.path(), &out)?;
+            let num_written = super::create(
+                [9].into_iter(),
+                tmp.path(),
+                &out,
+                crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES as u64,
+            )?;
             assert_eq!(num_written, 1);
 
             let table = U64Set::open(&out)?;
@@ -350,7 +376,12 @@ mod writer {
             let tmp = tempfile::TempDir::new()?;
             let out = tmp.path().join("test.u64_table");
 
-            let num_written = super::create([].into_iter(), tmp.path(), &out)?;
+            let num_written = super::create(
+                [].into_iter(),
+                tmp.path(),
+                &out,
+                crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES as u64,
+            )?;
             assert_eq!(num_written, 0);
 
             let table = U64Set::open(&out)?;

--- a/src/tables/u64_set.rs
+++ b/src/tables/u64_set.rs
@@ -58,7 +58,7 @@ impl U64Set {
         elements: impl Iterator<Item = u64>,
         workdir: &Path,
         out: &Path,
-        chunk_bytes: u64,
+        chunk_bytes: usize,
     ) -> Result<U64Set> {
         _ = writer::create(elements, workdir, out, chunk_bytes)?;
         Self::open(out)
@@ -245,7 +245,7 @@ mod tests {
             [42, 7, 23, 7].into_iter(),
             workdir.path(),
             &out,
-            crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES as u64,
+            crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES,
         )?;
         assert_eq!(set.len(), 3);
         assert!(set.contains(7));
@@ -273,7 +273,7 @@ mod writer {
         elements: impl Iterator<Item = u64>,
         workdir: &Path,
         out: &Path,
-        chunk_bytes: u64,
+        chunk_bytes: usize,
     ) -> Result<u64> {
         let mut tmp_out = PathBuf::from(out);
         tmp_out.add_extension("tmp");
@@ -281,7 +281,7 @@ mod writer {
             ExternalSorterBuilder::new()
                 .with_tmp_dir(workdir)
                 .with_buffer(LimitedBufferBuilder::new(
-                    /* buffer_size */ chunk_bytes as usize / size_of::<u64>(),
+                    /* buffer_size */ chunk_bytes / size_of::<u64>(),
                     /* preallocate */ true,
                 ))
                 .build()?;
@@ -333,7 +333,7 @@ mod writer {
                 /* elements */ [42, 23, 23, 7777, 23].into_iter(),
                 /* workdir */ tmp.path(),
                 /* out */ &out,
-                crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES as u64,
+                crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES,
             )?;
             assert_eq!(num_written, 3);
 
@@ -357,7 +357,7 @@ mod writer {
                 [9].into_iter(),
                 tmp.path(),
                 &out,
-                crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES as u64,
+                crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES,
             )?;
             assert_eq!(num_written, 1);
 
@@ -380,7 +380,7 @@ mod writer {
                 [].into_iter(),
                 tmp.path(),
                 &out,
-                crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES as u64,
+                crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES,
             )?;
             assert_eq!(num_written, 0);
 

--- a/src/tables/u64_set.rs
+++ b/src/tables/u64_set.rs
@@ -277,11 +277,15 @@ mod writer {
     ) -> Result<u64> {
         let mut tmp_out = PathBuf::from(out);
         tmp_out.add_extension("tmp");
-        let sorter: ExternalSorter<u64, std::io::Error, LimitedBufferBuilder> =
+        // Named as a local type alias, not spelled out twice, so the item
+        // type used to build the sorter and the one used to size its
+        // buffer can't silently drift apart under a future refactoring.
+        type Item = u64;
+        let sorter: ExternalSorter<Item, std::io::Error, LimitedBufferBuilder> =
             ExternalSorterBuilder::new()
                 .with_tmp_dir(workdir)
                 .with_buffer(LimitedBufferBuilder::new(
-                    /* buffer_size */ chunk_bytes / size_of::<u64>(),
+                    /* buffer_size */ chunk_bytes / size_of::<Item>(),
                     /* preallocate */ true,
                 ))
                 .build()?;


### PR DESCRIPTION
Closes #657.

## Why now

Motivated by a concrete problem: the pr665 Hetzner shakedown hit the
OS's open-file-descriptor limit during external sorting. `ext_sort`
keeps every spilled chunk's file open at once during its final merge, so
chunk count directly determines concurrently-open fds -- and chunk sizes
across this pipeline had grown ad hoc and were wildly uneven (128 KiB up
to 150 MB), several of them small enough to produce a lot of chunks at
planet scale. Consolidating onto one named, tunable constant
(`EXTERNAL_SORT_CHUNK_BYTES`) means there's now a single known knob to
raise if that happens again, instead of hunting down magic numbers
scattered across the codebase.

## What changed

- `BlobTable`, `GeometryTable`, `StringCounts` now take `chunk_bytes`
  explicitly and measure it in actual bytes (`MemoryLimitedBufferBuilder`,
  backed by `DeepSizeOf`) rather than an item count, since their items
  (blobs, strings) vary in size.
- `CoordTable`, `GraphTable`, `U64Set` also take `chunk_bytes`, converted
  to an item count for `LimitedBufferBuilder` since their items are
  fixed-size -- the same pattern `feature_index.rs` already established
  for its own two passes back in #656.
- Single-caller, never-concurrent sites (`StringPool`,
  `conflate::write_conflated`, `atp::import_atp`, `feature_index.rs`'s
  two sequential passes) just use `EXTERNAL_SORT_CHUNK_BYTES` directly --
  no parameter needed since there's nothing to divide it by.

## The part that isn't just a rename

While tracing every call site, I found several pipeline stages
(`prune_relations_pass_1`/`_2`, `prune_ways`, `prune_nodes`, one spot in
`assemble.rs`, and `suggest_edits`'s three output layers) run 2-3
external sorts concurrently on sibling threads within the same
`thread::scope`. Naively giving every call site the full constant would
have multiplied peak memory per stage instead of just cutting file
descriptors. So `EXTERNAL_SORT_CHUNK_BYTES` is treated as a
**per-thread-scope budget**: a lone sorter in its scope gets the full
value; concurrent ones divide it by however many run alongside them (a
local `CONCURRENT_SORTS` constant at each such call site, commented
inline with which sibling threads it's sharing with). This keeps
worst-case peak memory per pipeline stage bounded to roughly one
`EXTERNAL_SORT_CHUNK_BYTES`, regardless of how many sorters happen to run
inside it.

Because the affected table types (`BlobTable`, `CoordTable`, `GraphTable`,
`U64Set`, `StringCounts`) are reusable and called from several different
places with different concurrency, the caller -- who actually knows how
many sibling sorts are running alongside it -- decides how to split the
budget, rather than the table constructor guessing.

## Testing

`cargo build --locked --all-targets`, `cargo test --locked` (236 unit +
4 integration tests, including the full `test_pipeline` end-to-end run),
`cargo fmt --check`, `cargo clippy --locked --all-targets -- -D warnings`
all clean.
