### PR TITLE
conflated.parquet: make it valid GeoParquet 2.0-rc.1

### DIFF
--- a/docs/outputs/CONFLATED_PARQUET.md
+++ b/docs/outputs/CONFLATED_PARQUET.md
@@ -7,6 +7,13 @@ pairing the AllThePlaces feature with whichever OpenStreetMap feature
 it was matched to — or with no OpenStreetMap match at all, if none was
 found.
 
+This is a [GeoParquet 2.0-rc.1](https://github.com/opengeospatial/geoparquet/blob/v2.0.0-rc.1/format-specs/geoparquet.md)
+file (2.0 hasn’t had its final release yet, but this is the newest spec
+available, and the on-disk format isn’t expected to change again before
+it does). In practice that means any GeoParquet-aware tool — QGIS,
+kepler.gl, GeoPandas — can open it directly and will find both
+geometry columns on its own, without being told where to look.
+
 ## Schema
 
 ```text
@@ -15,7 +22,7 @@ atp                                          STRUCT, nullable
   fetched                                    STRUCT, non-null
     timestamp TIMESTAMP(ms, UTC)             non-null
     spider    UTF8                           non-null
-  geometry    BINARY (WKB)                   non-null
+atp_geometry  BINARY (WKB)                   nullable — null exactly when atp is null
 
 osm                                          STRUCT, nullable
   type        UTF8                           non-null ("node" | "way" | "relation")
@@ -30,7 +37,7 @@ osm                                          STRUCT, nullable
     type      UTF8                           non-null ("node" | "way" | "relation")
     id        UINT64                         non-null
     role      UTF8                           nullable — null if OSM gives the member no role
-  geometry    BINARY (WKB)                   non-null
+osm_geometry  BINARY (WKB)                   nullable — null exactly when osm is null
 ```
 
 A few things worth calling out that aren’t obvious from the above:
@@ -39,6 +46,14 @@ A few things worth calling out that aren’t obvious from the above:
   can happen for perfectly ordinary reasons — it doesn’t mean anything
   is wrong with the conflation pipeline; rather, it’s a signal that
   the feature may be missing from OpenStreetMap.
+- **`atp_geometry`/`osm_geometry` sit outside the `atp`/`osm` structs**,
+  at the top level of the file, rather than next to the rest of each
+  side’s data — GeoParquet requires geometry columns to live at the
+  schema root, which is what lets a generic GIS tool discover them on
+  its own instead of needing to be told where to look.
+  `osm_geometry` is the file’s designated primary geometry column,
+  since OpenStreetMap is the dataset a reviewer is actually meant to
+  correct.
 - **`atp.fetched` and `osm.modified` mirror each other on purpose**:
   both answer “who produced this side of the row, and when” —
   `atp.fetched` for AllThePlaces’ own scrape, `osm.modified` for
@@ -57,23 +72,26 @@ A few things worth calling out that aren’t obvious from the above:
 
 ## Geometry
 
-`atp.geometry`/`osm.geometry` are standard [OGC Simple
+`atp_geometry`/`osm_geometry` are standard [OGC Simple
 Features](https://postgis.net/workshops/postgis-intro/geometries.html)
 geometries — the same model QGIS, PostGIS, and most other GIS tools
-already use. `atp.geometry` is whatever AllThePlaces’ own scrape
-provides for that feature — nearly always a point, though a handful of
-sources provide lines or polygons instead. `osm.geometry` is the
-matched OpenStreetMap feature’s shape: a polygon for an area, a line
-for a way that isn’t an area, a point for a node.
+already use. Both columns use [OGC:CRS84](https://en.wikipedia.org/wiki/World_Geodetic_System)
+(WGS84 longitude/latitude, the same coordinates GPS uses) — GeoParquet’s
+default CRS, so it isn’t spelled out explicitly in the file. `atp_geometry`
+is whatever AllThePlaces’ own scrape provides for that feature — nearly
+always a point, though a handful of sources provide lines or polygons
+instead. `osm_geometry` is the matched OpenStreetMap feature’s shape: a
+polygon for an area, a line for a way that isn’t an area, a point for a
+node.
 
-`osm.geometry` isn’t always byte-for-byte what’s in OpenStreetMap,
+`osm_geometry` isn’t always byte-for-byte what’s in OpenStreetMap,
 though: we automatically repair certain geometry errors (like
 self-intersecting lines), and if a shape would otherwise end up with a
 very large number of coordinates, we simplify it — trading a small
 amount of positional accuracy for a smaller file, currently using a
 topology-preserving variant of the
 [Visvalingam–Whyatt algorithm](https://en.wikipedia.org/wiki/Visvalingam%E2%80%93Whyatt_algorithm)
-(this may change in the future). Treat `osm.geometry` as good enough
+(this may change in the future). Treat `osm_geometry` as good enough
 to display — e.g. to mark the affected OSM feature on a map — but not
 as a guaranteed-exact copy of OpenStreetMap’s own data. If you need to
 generate an actual edit against OpenStreetMap, use `way_members`/
@@ -92,7 +110,7 @@ sort key itself isn’t exposed as a column.
 ```sh
 duckdb -c "
 INSTALL spatial; LOAD spatial;
-SELECT osm.type, osm.id, atp.fetched.spider, ST_GeometryType(osm.geometry) AS osm_shape
+SELECT osm.type, osm.id, atp.fetched.spider, ST_GeometryType(osm_geometry) AS osm_shape
 FROM read_parquet('conflated.parquet')
 WHERE osm.id IS NOT NULL
 LIMIT 3;

--- a/docs/outputs/CONFLATED_PARQUET.md
+++ b/docs/outputs/CONFLATED_PARQUET.md
@@ -74,10 +74,11 @@ A few things worth calling out that aren’t obvious from the above:
 
 `atp_geometry`/`osm_geometry` are standard [OGC Simple
 Features](https://postgis.net/workshops/postgis-intro/geometries.html)
-geometries — the same model QGIS, PostGIS, and most other GIS tools
-already use. `atp_geometry` is whatever AllThePlaces’ own scrape
-provides for that feature — nearly always a point, though a handful of
-sources provide lines or polygons instead. `osm_geometry` is the
+geometries — the same model QGIS and PostGIS use, and that formats
+like GeoJSON and GeoPackage are built on too. `atp_geometry` is
+whatever AllThePlaces’ upstream source provides for that feature —
+nearly always a point, though a handful of sources provide lines or
+polygons instead. `osm_geometry` is the
 matched OpenStreetMap feature’s shape: a polygon for an area, a line
 for a way that isn’t an area, a point for a node. Both columns use
 [OGC:CRS84](https://en.wikipedia.org/wiki/World_Geodetic_System)
@@ -88,7 +89,10 @@ default CRS, so it isn’t spelled out explicitly in the file.
 though: we automatically repair certain geometry errors (like
 self-intersecting lines), and if a shape would otherwise end up with a
 very large number of coordinates, we simplify it — trading a small
-amount of positional accuracy for a smaller file, currently using a
+amount of positional accuracy so that you, the downstream client, get
+a geometry that’s directly usable for display without having to
+simplify it yourself first (say, before sending it to a mobile phone
+over a cellular connection). We currently do this using a
 topology-preserving variant of the
 [Visvalingam–Whyatt algorithm](https://en.wikipedia.org/wiki/Visvalingam%E2%80%93Whyatt_algorithm)
 (this may change in the future). Treat `osm_geometry` as good enough

--- a/docs/outputs/CONFLATED_PARQUET.md
+++ b/docs/outputs/CONFLATED_PARQUET.md
@@ -75,14 +75,14 @@ A few things worth calling out that aren’t obvious from the above:
 `atp_geometry`/`osm_geometry` are standard [OGC Simple
 Features](https://postgis.net/workshops/postgis-intro/geometries.html)
 geometries — the same model QGIS, PostGIS, and most other GIS tools
-already use. Both columns use [OGC:CRS84](https://en.wikipedia.org/wiki/World_Geodetic_System)
+already use. `atp_geometry` is whatever AllThePlaces’ own scrape
+provides for that feature — nearly always a point, though a handful of
+sources provide lines or polygons instead. `osm_geometry` is the
+matched OpenStreetMap feature’s shape: a polygon for an area, a line
+for a way that isn’t an area, a point for a node. Both columns use
+[OGC:CRS84](https://en.wikipedia.org/wiki/World_Geodetic_System)
 (WGS84 longitude/latitude, the same coordinates GPS uses) — GeoParquet’s
-default CRS, so it isn’t spelled out explicitly in the file. `atp_geometry`
-is whatever AllThePlaces’ own scrape provides for that feature — nearly
-always a point, though a handful of sources provide lines or polygons
-instead. `osm_geometry` is the matched OpenStreetMap feature’s shape: a
-polygon for an area, a line for a way that isn’t an area, a point for a
-node.
+default CRS, so it isn’t spelled out explicitly in the file.
 
 `osm_geometry` isn’t always byte-for-byte what’s in OpenStreetMap,
 though: we automatically repair certain geometry errors (like

--- a/docs/outputs/CONFLATED_PARQUET.md
+++ b/docs/outputs/CONFLATED_PARQUET.md
@@ -85,7 +85,7 @@ for a way that isn’t an area, a point for a node. Both columns use
 (WGS84 longitude/latitude, the same coordinates GPS uses) — GeoParquet’s
 default CRS, so it isn’t spelled out explicitly in the file.
 
-`osm_geometry` isn’t always byte-for-byte what’s in OpenStreetMap,
+`osm_geometry` isn’t always point-for-point what’s in OpenStreetMap,
 though: we automatically repair certain geometry errors (like
 self-intersecting lines), and if a shape would otherwise end up with a
 very large number of coordinates, we simplify it — trading a small

--- a/src/geometry/geometry_tally.rs
+++ b/src/geometry/geometry_tally.rs
@@ -1,0 +1,66 @@
+//! Bookkeeping for a WKB geometry column written to some output file:
+//! how many of each [`WkbGeometryType`] ended up in it, and the single
+//! largest geometry seen, by byte size.
+
+use super::{WkbGeometryType, wkb_geometry_type};
+
+/// Accumulated while writing one WKB geometry column: a count per
+/// [`WkbGeometryType`] (e.g. becomes a GeoParquet file's `geo` metadata
+/// `geometry_types`, or an INFO log line), and the single largest
+/// geometry seen so far, by byte size, together with a caller-supplied
+/// label identifying which row it came from (e.g. an OSM `type/id`
+/// string, or a spider name) -- so an unusually large geometry can be
+/// tracked down without having to scan the whole file.
+#[derive(Default)]
+pub struct GeometryTally {
+    counts: [u64; WkbGeometryType::ALL.len()],
+    largest_bytes: usize,
+    largest_label: String,
+}
+
+impl GeometryTally {
+    /// Records one geometry. `label` is only called -- so only pays for
+    /// whatever it allocates -- when `wkb` turns out to be the new
+    /// largest seen so far.
+    pub fn record(&mut self, wkb: &[u8], label: impl FnOnce() -> String) {
+        let index = WkbGeometryType::ALL
+            .iter()
+            .position(|t| *t == wkb_geometry_type(wkb))
+            .expect("WkbGeometryType::ALL covers every type wkb_geometry_type can return");
+        self.counts[index] += 1;
+        if wkb.len() > self.largest_bytes {
+            self.largest_bytes = wkb.len();
+            self.largest_label = label();
+        }
+    }
+
+    /// Distinct types actually seen, as GeoParquet `geometry_types`
+    /// strings -- e.g. `["Point"]`, or `["LineString", "Polygon"]`.
+    pub fn geoparquet_types(&self) -> Vec<&'static str> {
+        WkbGeometryType::ALL
+            .iter()
+            .zip(self.counts.iter())
+            .filter(|&(_, &count)| count > 0)
+            .map(|(t, _)| t.geoparquet_name())
+            .collect()
+    }
+
+    /// Logs this tally's per-type counts and largest geometry seen, at
+    /// INFO, as one structured record. `log::info!`'s field list has to
+    /// be literal field names, so the indices below are hardcoded --
+    /// they line up with [`WkbGeometryType::ALL`]'s declaration order.
+    pub fn log(&self, message: &str) {
+        log::info!(
+            point = self.counts[0],
+            line_string = self.counts[1],
+            polygon = self.counts[2],
+            multi_point = self.counts[3],
+            multi_line_string = self.counts[4],
+            multi_polygon = self.counts[5],
+            geometry_collection = self.counts[6],
+            largest_bytes = self.largest_bytes,
+            largest = self.largest_label.as_str();
+            "{}", message
+        );
+    }
+}

--- a/src/geometry/geometry_tally.rs
+++ b/src/geometry/geometry_tally.rs
@@ -1,6 +1,10 @@
 //! Bookkeeping for a WKB geometry column written to some output file:
 //! how many of each [`WkbGeometryType`] ended up in it, and the single
 //! largest geometry seen, by byte size.
+//!
+//! WKB is [Well-Known Binary](https://libgeos.org/specifications/wkb/),
+//! a standard binary encoding for geometries (points, lines, polygons,
+//! ...) used throughout this crate and the wider GIS world.
 
 use super::{WkbGeometryType, wkb_geometry_type};
 
@@ -9,8 +13,8 @@ use super::{WkbGeometryType, wkb_geometry_type};
 /// `geometry_types`, or an INFO log line), and the single largest
 /// geometry seen so far, by byte size, together with a caller-supplied
 /// label identifying which row it came from (e.g. an OSM `type/id`
-/// string, or a spider name) -- so an unusually large geometry can be
-/// tracked down without having to scan the whole file.
+/// string, or an AllThePlaces spider name) -- so an unusually large
+/// geometry can be tracked down without having to scan the whole file.
 #[derive(Default)]
 pub struct GeometryTally {
     counts: [u64; WkbGeometryType::ALL.len()],

--- a/src/geometry/mod.rs
+++ b/src/geometry/mod.rs
@@ -46,11 +46,13 @@ mod grid_tests;
 mod line_stitcher;
 mod polygon_assembler;
 mod polygon_union;
+mod wkb_type;
 
 pub use geometry_builder::{GeometryBuilder, PolygonFill};
 pub use line_stitcher::LineStitcher;
 pub use polygon_assembler::PolygonAssembler;
 pub use polygon_union::PolygonUnion;
+pub use wkb_type::{WkbGeometryType, wkb_geometry_type};
 
 // =======================================================================
 // build_points

--- a/src/geometry/mod.rs
+++ b/src/geometry/mod.rs
@@ -41,6 +41,7 @@ use geo::{
 };
 
 mod geometry_builder;
+mod geometry_tally;
 #[cfg(test)]
 mod grid_tests;
 mod line_stitcher;
@@ -49,6 +50,7 @@ mod polygon_union;
 mod wkb_type;
 
 pub use geometry_builder::{GeometryBuilder, PolygonFill};
+pub use geometry_tally::GeometryTally;
 pub use line_stitcher::LineStitcher;
 pub use polygon_assembler::PolygonAssembler;
 pub use polygon_union::PolygonUnion;

--- a/src/geometry/wkb_type.rs
+++ b/src/geometry/wkb_type.rs
@@ -40,7 +40,10 @@ impl WkbGeometryType {
     ];
 
     /// The GeoParquet `geometry_types` string for this type, e.g.
-    /// `"Point"`, `"MultiPolygon"`.
+    /// `"Point"`, `"MultiPolygon"` -- see "geometry_types" in the
+    /// [GeoParquet 2.0-rc.1 spec](https://geoparquet.org/releases/v2.0.0-rc.1/)
+    /// (that page has no anchor links yet to point at the section
+    /// directly).
     pub fn geoparquet_name(&self) -> &'static str {
         match self {
             Self::Point => "Point",

--- a/src/geometry/wkb_type.rs
+++ b/src/geometry/wkb_type.rs
@@ -1,0 +1,144 @@
+//! Reads a WKB buffer's geometry type straight off its header, without
+//! decoding any coordinates -- used for GeoParquet's `geometry_types`
+//! metadata (see `pipeline::conflate::writer::GEO_METADATA_KEY`) and for
+//! logging what kinds of geometry ended up in `conflated.parquet`,
+//! without paying for a full `geo::Geometry` decode just to find out.
+
+use std::fmt;
+
+/// The seven basic OGC Simple Features geometry types, ignoring Z/M
+/// dimensionality and SRID -- the only distinction GeoParquet's
+/// `geometry_types` metadata (or a log line tallying what we wrote)
+/// needs. `std::mem::discriminant` was considered instead of a plain
+/// enum for the same purpose, but it isn't `Debug`/`Display`-printable,
+/// which would make both the metadata and the log output harder to
+/// follow for no real benefit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum WkbGeometryType {
+    Point,
+    LineString,
+    Polygon,
+    MultiPoint,
+    MultiLineString,
+    MultiPolygon,
+    GeometryCollection,
+}
+
+impl WkbGeometryType {
+    /// All seven variants, in declaration order -- lets a caller build a
+    /// zero-initialized tally of every type up front, so a log line's
+    /// set of fields stays the same across runs even when a type never
+    /// occurs.
+    pub const ALL: [WkbGeometryType; 7] = [
+        Self::Point,
+        Self::LineString,
+        Self::Polygon,
+        Self::MultiPoint,
+        Self::MultiLineString,
+        Self::MultiPolygon,
+        Self::GeometryCollection,
+    ];
+
+    /// The GeoParquet `geometry_types` string for this type, e.g.
+    /// `"Point"`, `"MultiPolygon"`.
+    pub fn geoparquet_name(&self) -> &'static str {
+        match self {
+            Self::Point => "Point",
+            Self::LineString => "LineString",
+            Self::Polygon => "Polygon",
+            Self::MultiPoint => "MultiPoint",
+            Self::MultiLineString => "MultiLineString",
+            Self::MultiPolygon => "MultiPolygon",
+            Self::GeometryCollection => "GeometryCollection",
+        }
+    }
+}
+
+impl fmt::Display for WkbGeometryType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.geoparquet_name())
+    }
+}
+
+/// Reads the geometry type straight off a WKB buffer's header (byte 0 =
+/// byte order, bytes 1..5 = geometry-type code) -- no validation or
+/// decoding of any coordinates.
+///
+/// Only handles what this pipeline's own WKB writer
+/// (`pipeline::conflate::writer::wkb`) ever produces: little-endian,
+/// plain 2-D, no SRID flag. Panics on anything else -- we only ever
+/// read WKB we wrote ourselves, so there's no reason to carry decoder
+/// complexity (big-endian, Z/M dimensions, EWKB SRID) for encodings
+/// that can't occur in this pipeline.
+pub fn wkb_geometry_type(wkb: &[u8]) -> WkbGeometryType {
+    assert!(
+        wkb.len() >= 5,
+        "WKB buffer too short for a header: {} bytes",
+        wkb.len()
+    );
+    assert_eq!(
+        wkb[0], 1,
+        "expected little-endian WKB (byte order 1), got {}",
+        wkb[0]
+    );
+    let code = u32::from_le_bytes(wkb[1..5].try_into().unwrap());
+    match code {
+        1 => WkbGeometryType::Point,
+        2 => WkbGeometryType::LineString,
+        3 => WkbGeometryType::Polygon,
+        4 => WkbGeometryType::MultiPoint,
+        5 => WkbGeometryType::MultiLineString,
+        6 => WkbGeometryType::MultiPolygon,
+        7 => WkbGeometryType::GeometryCollection,
+        other => panic!("unsupported WKB geometry type code {other}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Cross-checked against the `wkb` crate's own writer
+    /// (`wkb::common::WkbType::as_geometry_code`): byte 0 is `1` for
+    /// little-endian, and a plain 2-D geometry's type code is exactly
+    /// 1..=7 (no `Dimension` offset), so these minimal headers are
+    /// exactly what `pipeline::conflate::writer::wkb` actually emits.
+    #[test]
+    fn reads_all_seven_base_types() {
+        for (code, expected) in [
+            (1u32, WkbGeometryType::Point),
+            (2, WkbGeometryType::LineString),
+            (3, WkbGeometryType::Polygon),
+            (4, WkbGeometryType::MultiPoint),
+            (5, WkbGeometryType::MultiLineString),
+            (6, WkbGeometryType::MultiPolygon),
+            (7, WkbGeometryType::GeometryCollection),
+        ] {
+            let mut buf = vec![1u8]; // little-endian
+            buf.extend_from_slice(&code.to_le_bytes());
+            assert_eq!(wkb_geometry_type(&buf), expected);
+            assert_eq!(expected.geoparquet_name(), expected.to_string());
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "expected little-endian")]
+    fn rejects_big_endian() {
+        wkb_geometry_type(&[0, 0, 0, 0, 1]);
+    }
+
+    #[test]
+    #[should_panic(expected = "unsupported WKB geometry type code")]
+    fn rejects_unknown_type_code() {
+        wkb_geometry_type(&[1, 99, 0, 0, 0]);
+    }
+
+    #[test]
+    fn all_matches_geoparquet_name_uniquely() {
+        let names: std::collections::HashSet<_> = WkbGeometryType::ALL
+            .iter()
+            .map(|t| t.geoparquet_name())
+            .collect();
+        assert_eq!(names.len(), WkbGeometryType::ALL.len());
+    }
+}

--- a/src/pipeline/conflate/writer.rs
+++ b/src/pipeline/conflate/writer.rs
@@ -19,7 +19,6 @@ use parquet::{
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::{
-    collections::BTreeSet,
     fs::File,
     num::{NonZeroU32, NonZeroU64},
     path::{Path, PathBuf},
@@ -27,7 +26,12 @@ use std::{
 };
 
 use super::ConflatedFeature;
-use crate::{matchers::OsmCandidate, tables::StringPool, utils::UtcTimestamp};
+use crate::{
+    geometry::{WkbGeometryType, wkb_geometry_type},
+    matchers::OsmCandidate,
+    tables::StringPool,
+    utils::UtcTimestamp,
+};
 
 pub struct ParquetWriter {
     path: PathBuf,
@@ -37,6 +41,9 @@ pub struct ParquetWriter {
     last_s2_cell_id: u64,
     rows_in_group: usize,
     max_rows_per_group: usize,
+    // Set aside in `create()`, written out (together with `geo`) only in
+    // `close()` -- see `close()`'s doc comment.
+    provenance_bom: String,
 
     atp_present: NullBufferBuilder,
     atp_tags: MapBuilder<StringBuilder, StringBuilder>,
@@ -45,12 +52,11 @@ pub struct ParquetWriter {
     atp_fetched_timestamps: TimestampMillisecondBuilder,
     atp_fetched_spiders: StringBuilder,
     atp_geometries: BinaryBuilder,
-    // Distinct WKB geometry types seen on this side so far (e.g.
-    // "Point", "Polygon") -- becomes this column's `geometry_types` in
-    // the GeoParquet `geo` metadata written in `close()`. A `BTreeSet`,
-    // not a `HashSet`, so the metadata's array is written in a
-    // deterministic order across runs.
-    atp_geometry_types: BTreeSet<&'static str>,
+    // Per-type counts and largest-geometry tracking for this column,
+    // across the whole file -- becomes this column's `geometry_types` in
+    // the GeoParquet `geo` metadata, and an INFO summary, both written
+    // in `close()`.
+    atp_geometry_tally: GeometryTally,
 
     osm_present: NullBufferBuilder,
     osm_types: StringBuilder,
@@ -62,8 +68,8 @@ pub struct ParquetWriter {
     osm_way_members: ListBuilder<UInt64Builder>,
     osm_relation_members: ListBuilder<StructBuilder>,
     osm_geometries: BinaryBuilder,
-    // See `atp_geometry_types` above.
-    osm_geometry_types: BTreeSet<&'static str>,
+    // See `atp_geometry_tally` above.
+    osm_geometry_tally: GeometryTally,
 }
 
 /// A single row in the conflated parquet file.
@@ -131,10 +137,72 @@ const PROVENANCE_KEY: &str = "org.cyclonedx.bom";
 /// geometries actually ended up in the file.
 const GEO_METADATA_KEY: &str = "geo";
 
+/// Per-column bookkeeping accumulated while writing one of the two
+/// geometry columns: how many of each [`WkbGeometryType`] were written
+/// (becomes the GeoParquet `geo` metadata's `geometry_types`, and an
+/// INFO log line), and the single largest geometry seen so far, by byte
+/// size (also logged, together with a caller-supplied label identifying
+/// which row it came from -- e.g. "way/608979139" for OSM, a spider name
+/// for ATP -- so an unusually large geometry can be tracked down without
+/// having to scan the whole file).
+#[derive(Default)]
+struct GeometryTally {
+    counts: [u64; WkbGeometryType::ALL.len()],
+    largest_bytes: usize,
+    largest_label: String,
+}
+
+impl GeometryTally {
+    fn record(&mut self, wkb: &[u8], label: impl FnOnce() -> String) {
+        let index = WkbGeometryType::ALL
+            .iter()
+            .position(|t| *t == wkb_geometry_type(wkb))
+            .expect("WkbGeometryType::ALL covers every type wkb_geometry_type can return");
+        self.counts[index] += 1;
+        if wkb.len() > self.largest_bytes {
+            self.largest_bytes = wkb.len();
+            self.largest_label = label();
+        }
+    }
+
+    /// Distinct types actually seen, as GeoParquet `geometry_types`
+    /// strings -- e.g. `["Point"]`, or `["LineString", "Polygon"]`.
+    fn geoparquet_types(&self) -> Vec<&'static str> {
+        WkbGeometryType::ALL
+            .iter()
+            .zip(self.counts.iter())
+            .filter(|&(_, &count)| count > 0)
+            .map(|(t, _)| t.geoparquet_name())
+            .collect()
+    }
+
+    /// Logs this tally's per-type counts and largest geometry seen, at
+    /// INFO, as one structured record. `log::info!`'s field list has to
+    /// be literal field names, so the indices below are hardcoded --
+    /// they line up with [`WkbGeometryType::ALL`]'s declaration order.
+    fn log(&self, message: &str) {
+        log::info!(
+            point = self.counts[0],
+            line_string = self.counts[1],
+            polygon = self.counts[2],
+            multi_point = self.counts[3],
+            multi_line_string = self.counts[4],
+            multi_polygon = self.counts[5],
+            geometry_collection = self.counts[6],
+            largest_bytes = self.largest_bytes,
+            largest = self.largest_label.as_str();
+            "{}", message
+        );
+    }
+}
+
 impl ParquetWriter {
     /// `provenance_bom` is the CycloneDX document from `crate::provenance`,
     /// already serialized to a JSON string -- embedded verbatim as this
-    /// file's `PROVENANCE_KEY` key-value metadata.
+    /// file's `PROVENANCE_KEY` key-value metadata once `close()` writes
+    /// it out (see `close()`'s own doc comment for why this is deferred
+    /// rather than passed to `WriterProperties` here, even though the
+    /// value itself is already known at this point).
     pub fn create(
         path: &Path,
         max_rows_per_group: usize,
@@ -146,10 +214,6 @@ impl ParquetWriter {
         let properties = WriterProperties::builder()
             .set_compression(Compression::ZSTD(ZstdLevel::try_new(22)?))
             .set_max_row_group_row_count(Some(max_rows_per_group))
-            .set_key_value_metadata(Some(vec![KeyValue::new(
-                PROVENANCE_KEY.to_string(),
-                provenance_bom.to_string(),
-            )]))
             .set_column_bloom_filter_enabled(Self::column_path("atp.fetched.spider"), true)
             .set_column_bloom_filter_enabled(Self::column_path("atp.tags.key_value.key"), true)
             .set_column_bloom_filter_enabled(Self::column_path("atp.tags.key_value.value"), true)
@@ -170,6 +234,7 @@ impl ParquetWriter {
             last_s2_cell_id: 0,
             rows_in_group: 0,
             max_rows_per_group,
+            provenance_bom: provenance_bom.to_string(),
 
             atp_present: NullBufferBuilder::new(max_rows_per_group),
             atp_tags: Self::new_key_value_map_builder(max_rows_per_group),
@@ -184,7 +249,7 @@ impl ParquetWriter {
                 /* item_capacity */ max_rows_per_group,
                 /* data_capacity */ max_rows_per_group * 21,
             ),
-            atp_geometry_types: BTreeSet::new(),
+            atp_geometry_tally: GeometryTally::default(),
 
             osm_present: NullBufferBuilder::new(max_rows_per_group),
             // TODO: Use dictionary instead of string for osm_types?
@@ -215,7 +280,7 @@ impl ParquetWriter {
                 /* item_capacity */ max_rows_per_group,
                 /* data_capacity */ max_rows_per_group * 21,
             ),
-            osm_geometry_types: BTreeSet::new(),
+            osm_geometry_tally: GeometryTally::default(),
         })
     }
 
@@ -286,10 +351,14 @@ impl ParquetWriter {
                     .expect("atp_fetched")
                     .unix_timestamp_millis(),
             );
-            self.atp_fetched_spiders.append_value(atp_spider);
             self.atp_geometries.append_value(&row.atp_shape_wkb);
-            self.atp_geometry_types
-                .insert(wkb_geometry_type_name(&row.atp_shape_wkb)?);
+            // ATP doesn't have stable feature IDs (unlike OSM), so the
+            // spider is the best clue we can log if this geometry turns
+            // out to be the largest one written -- borrow it for that
+            // before handing it to `append_value` below.
+            self.atp_geometry_tally
+                .record(&row.atp_shape_wkb, || atp_spider.clone());
+            self.atp_fetched_spiders.append_value(atp_spider);
         } else {
             self.atp_present.append_null();
             self.atp_tags.append(false)?;
@@ -300,13 +369,15 @@ impl ParquetWriter {
 
         if let Some(osm_id) = row.osm_id {
             self.osm_present.append_non_null();
-            self.osm_types.append_value(match osm_id.get() % 10 {
+            let osm_type_str = match osm_id.get() % 10 {
                 1 => "node",
                 2 => "way",
                 3 => "relation",
                 _ => panic!("osm_id {} with unexpected last digit", osm_id.get()),
-            });
-            self.osm_ids.append_value(osm_id.get() / 10);
+            };
+            let osm_plain_id = osm_id.get() / 10;
+            self.osm_types.append_value(osm_type_str);
+            self.osm_ids.append_value(osm_plain_id);
 
             for (key, value) in row.osm_tags.iter() {
                 self.osm_tags.keys().append_value(key);
@@ -372,8 +443,9 @@ impl ParquetWriter {
             }
 
             self.osm_geometries.append_value(&row.osm_shape_wkb);
-            self.osm_geometry_types
-                .insert(wkb_geometry_type_name(&row.osm_shape_wkb)?);
+            self.osm_geometry_tally.record(&row.osm_shape_wkb, || {
+                format!("{osm_type_str}/{osm_plain_id}")
+            });
         } else {
             self.osm_present.append_null();
             self.osm_types.append_value("");
@@ -395,10 +467,27 @@ impl ParquetWriter {
         if self.rows_in_group > 0 {
             self.write_row_group()?;
         }
-        // Only knowable now that every row has been written (see
-        // `GEO_METADATA_KEY`) -- `append_key_value_metadata` folds this
-        // into the footer `writer.close()` is about to flush, same as
-        // if it had been passed to `WriterProperties` up front.
+
+        self.atp_geometry_tally
+            .log("conflate.write: atp_geometry geometry types");
+        self.osm_geometry_tally
+            .log("conflate.write: osm_geometry geometry types");
+
+        // Both of this file's key-value metadata entries are set here,
+        // uniformly, via `append_key_value_metadata` -- rather than
+        // `provenance_bom` going through `WriterProperties` up front and
+        // only `geo` being added here -- even though `provenance_bom`
+        // itself is known before the first row is written. `geo` has to
+        // be added late regardless (see `GEO_METADATA_KEY`: its
+        // `geometry_types` isn't known until every row has been
+        // written), so setting both the same way keeps there from being
+        // two different places in this file where output metadata gets
+        // set, which would otherwise force a reader to know which one
+        // applies to which key.
+        self.writer.append_key_value_metadata(KeyValue::new(
+            PROVENANCE_KEY.to_string(),
+            self.provenance_bom.clone(),
+        ));
         self.writer.append_key_value_metadata(KeyValue::new(
             GEO_METADATA_KEY.to_string(),
             self.geo_metadata_json(),
@@ -418,21 +507,24 @@ impl ParquetWriter {
     /// `new_geo_field` requests for the columns' native Parquet
     /// `GEOGRAPHY` logical type -- so the two stay consistent (both
     /// resolving to OGC:CRS84) without having to spell out a PROJJSON
-    /// object here. (Empirically, `parquet`-rs 59.2 doesn't actually
-    /// carry that requested `crs` through to the native logical type's
-    /// own `crs` sub-field -- `parquet-tools meta`/DuckDB both show it
-    /// unset there, even though it does show up correctly in the
-    /// Arrow-extension `ARROW:schema` metadata. Doesn't affect
-    /// conformance here, since "unset" already means OGC:CRS84 on both
-    /// sides, but if a future `parquet`/`parquet-geospatial` upgrade
-    /// starts requesting a non-default CRS, this comment -- and
-    /// whether `gpio check spec`/`gpio check all` still pass -- is
-    /// worth revisiting.)
+    /// object here.
+    ///
+    /// (`parquet-tools meta`/DuckDB show the native logical type's own
+    /// `crs`/`algorithm` sub-fields as unset, which looked like a
+    /// `parquet`-rs bug at first glance -- but it isn't: per
+    /// `parquet::arrow::schema::extension::logical_type_for_binary`
+    /// (`parquet` 59.2), a lon/lat CRS and `Spherical` edges are each
+    /// canonicalized to `None` *because* those are themselves the
+    /// Parquet spec's own defaults for `GEOGRAPHY` -- the same
+    /// omit-if-default encoding GeoParquet's own `geo` metadata uses
+    /// for `crs`. Confirmed with an isolated repro against plain
+    /// `arrow`/`parquet`/`parquet-geospatial`, independent of this
+    /// pipeline, before concluding that -- no bug to report upstream.)
     fn geo_metadata_json(&self) -> String {
-        let column_metadata = |geometry_types: &BTreeSet<&'static str>| {
+        let column_metadata = |tally: &GeometryTally| {
             json!({
                 "encoding": "WKB",
-                "geometry_types": geometry_types.iter().collect::<Vec<_>>(),
+                "geometry_types": tally.geoparquet_types(),
                 "edges": "spherical",
             })
         };
@@ -440,8 +532,8 @@ impl ParquetWriter {
             "version": "2.0.0",
             "primary_column": "osm_geometry",
             "columns": {
-                "osm_geometry": column_metadata(&self.osm_geometry_types),
-                "atp_geometry": column_metadata(&self.atp_geometry_types),
+                "osm_geometry": column_metadata(&self.osm_geometry_tally),
+                "atp_geometry": column_metadata(&self.atp_geometry_tally),
             },
         })
         .to_string()
@@ -727,27 +819,6 @@ fn wkb(shape: &geo::Geometry<f64>) -> Vec<u8> {
     };
     wkb::writer::write_geometry(&mut buf, shape, &opts).expect("wkb encoding failed");
     buf
-}
-
-/// The GeoParquet `geometry_types` name for a WKB-encoded geometry
-/// (e.g. `"Point"`, `"Polygon"`, `"MultiPolygon"`) -- read straight off
-/// the WKB header (byte order + type code) via `wkb::reader`, without
-/// decoding any coordinates.
-fn wkb_geometry_type_name(wkb: &[u8]) -> Result<&'static str> {
-    use ::wkb::reader::GeometryType;
-    let geometry_type = ::wkb::reader::read_wkb(wkb)
-        .context("failed to read WKB header for geometry_types")?
-        .geometry_type();
-    Ok(match geometry_type {
-        GeometryType::Point => "Point",
-        GeometryType::LineString => "LineString",
-        GeometryType::Polygon => "Polygon",
-        GeometryType::MultiPoint => "MultiPoint",
-        GeometryType::MultiLineString => "MultiLineString",
-        GeometryType::MultiPolygon => "MultiPolygon",
-        GeometryType::GeometryCollection => "GeometryCollection",
-        other => anyhow::bail!("unsupported WKB geometry type {other:?}"),
-    })
 }
 
 mod schema {

--- a/src/pipeline/conflate/writer.rs
+++ b/src/pipeline/conflate/writer.rs
@@ -27,10 +27,7 @@ use std::{
 
 use super::ConflatedFeature;
 use crate::{
-    geometry::{WkbGeometryType, wkb_geometry_type},
-    matchers::OsmCandidate,
-    tables::StringPool,
-    utils::UtcTimestamp,
+    geometry::GeometryTally, matchers::OsmCandidate, tables::StringPool, utils::UtcTimestamp,
 };
 
 pub struct ParquetWriter {
@@ -136,65 +133,6 @@ const PROVENANCE_KEY: &str = "org.cyclonedx.bom";
 /// `close()` -- because `geometry_types` below depends on what
 /// geometries actually ended up in the file.
 const GEO_METADATA_KEY: &str = "geo";
-
-/// Per-column bookkeeping accumulated while writing one of the two
-/// geometry columns: how many of each [`WkbGeometryType`] were written
-/// (becomes the GeoParquet `geo` metadata's `geometry_types`, and an
-/// INFO log line), and the single largest geometry seen so far, by byte
-/// size (also logged, together with a caller-supplied label identifying
-/// which row it came from -- e.g. "way/608979139" for OSM, a spider name
-/// for ATP -- so an unusually large geometry can be tracked down without
-/// having to scan the whole file).
-#[derive(Default)]
-struct GeometryTally {
-    counts: [u64; WkbGeometryType::ALL.len()],
-    largest_bytes: usize,
-    largest_label: String,
-}
-
-impl GeometryTally {
-    fn record(&mut self, wkb: &[u8], label: impl FnOnce() -> String) {
-        let index = WkbGeometryType::ALL
-            .iter()
-            .position(|t| *t == wkb_geometry_type(wkb))
-            .expect("WkbGeometryType::ALL covers every type wkb_geometry_type can return");
-        self.counts[index] += 1;
-        if wkb.len() > self.largest_bytes {
-            self.largest_bytes = wkb.len();
-            self.largest_label = label();
-        }
-    }
-
-    /// Distinct types actually seen, as GeoParquet `geometry_types`
-    /// strings -- e.g. `["Point"]`, or `["LineString", "Polygon"]`.
-    fn geoparquet_types(&self) -> Vec<&'static str> {
-        WkbGeometryType::ALL
-            .iter()
-            .zip(self.counts.iter())
-            .filter(|&(_, &count)| count > 0)
-            .map(|(t, _)| t.geoparquet_name())
-            .collect()
-    }
-
-    /// Logs this tally's per-type counts and largest geometry seen, at
-    /// INFO, as one structured record. `log::info!`'s field list has to
-    /// be literal field names, so the indices below are hardcoded --
-    /// they line up with [`WkbGeometryType::ALL`]'s declaration order.
-    fn log(&self, message: &str) {
-        log::info!(
-            point = self.counts[0],
-            line_string = self.counts[1],
-            polygon = self.counts[2],
-            multi_point = self.counts[3],
-            multi_line_string = self.counts[4],
-            multi_polygon = self.counts[5],
-            geometry_collection = self.counts[6],
-            largest_bytes = self.largest_bytes,
-            largest = self.largest_label.as_str();
-            "{}", message
-        );
-    }
-}
 
 impl ParquetWriter {
     /// `provenance_bom` is the CycloneDX document from `crate::provenance`,

--- a/src/pipeline/conflate/writer.rs
+++ b/src/pipeline/conflate/writer.rs
@@ -17,7 +17,9 @@ use parquet::{
     schema::types::ColumnPath,
 };
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 use std::{
+    collections::BTreeSet,
     fs::File,
     num::{NonZeroU32, NonZeroU64},
     path::{Path, PathBuf},
@@ -43,6 +45,12 @@ pub struct ParquetWriter {
     atp_fetched_timestamps: TimestampMillisecondBuilder,
     atp_fetched_spiders: StringBuilder,
     atp_geometries: BinaryBuilder,
+    // Distinct WKB geometry types seen on this side so far (e.g.
+    // "Point", "Polygon") -- becomes this column's `geometry_types` in
+    // the GeoParquet `geo` metadata written in `close()`. A `BTreeSet`,
+    // not a `HashSet`, so the metadata's array is written in a
+    // deterministic order across runs.
+    atp_geometry_types: BTreeSet<&'static str>,
 
     osm_present: NullBufferBuilder,
     osm_types: StringBuilder,
@@ -54,6 +62,8 @@ pub struct ParquetWriter {
     osm_way_members: ListBuilder<UInt64Builder>,
     osm_relation_members: ListBuilder<StructBuilder>,
     osm_geometries: BinaryBuilder,
+    // See `atp_geometry_types` above.
+    osm_geometry_types: BTreeSet<&'static str>,
 }
 
 /// A single row in the conflated parquet file.
@@ -109,6 +119,18 @@ pub struct ParquetRow {
 /// `org.cyclonedx.bom` follows that same reverse-DNS-style namespacing.
 const PROVENANCE_KEY: &str = "org.cyclonedx.bom";
 
+/// Key under which this file's [GeoParquet](https://geoparquet.org/)
+/// metadata is stored -- required by the spec to be named exactly
+/// `geo`. Targets [GeoParquet 2.0-rc.1](https://github.com/opengeospatial/geoparquet/blob/v2.0.0-rc.1/format-specs/geoparquet.md),
+/// the newest available at the time this was written (2.0.0 hasn't
+/// had a final release yet, but the RC's on-disk format is what the
+/// eventual 2.0.0 will also expect -- the `version` field itself is a
+/// fixed `"2.0.0"` string in both). Unlike `PROVENANCE_KEY` above,
+/// this can't be built until every row has been written -- see
+/// `close()` -- because `geometry_types` below depends on what
+/// geometries actually ended up in the file.
+const GEO_METADATA_KEY: &str = "geo";
+
 impl ParquetWriter {
     /// `provenance_bom` is the CycloneDX document from `crate::provenance`,
     /// already serialized to a JSON string -- embedded verbatim as this
@@ -162,6 +184,7 @@ impl ParquetWriter {
                 /* item_capacity */ max_rows_per_group,
                 /* data_capacity */ max_rows_per_group * 21,
             ),
+            atp_geometry_types: BTreeSet::new(),
 
             osm_present: NullBufferBuilder::new(max_rows_per_group),
             // TODO: Use dictionary instead of string for osm_types?
@@ -192,6 +215,7 @@ impl ParquetWriter {
                 /* item_capacity */ max_rows_per_group,
                 /* data_capacity */ max_rows_per_group * 21,
             ),
+            osm_geometry_types: BTreeSet::new(),
         })
     }
 
@@ -264,6 +288,8 @@ impl ParquetWriter {
             );
             self.atp_fetched_spiders.append_value(atp_spider);
             self.atp_geometries.append_value(&row.atp_shape_wkb);
+            self.atp_geometry_types
+                .insert(wkb_geometry_type_name(&row.atp_shape_wkb)?);
         } else {
             self.atp_present.append_null();
             self.atp_tags.append(false)?;
@@ -346,6 +372,8 @@ impl ParquetWriter {
             }
 
             self.osm_geometries.append_value(&row.osm_shape_wkb);
+            self.osm_geometry_types
+                .insert(wkb_geometry_type_name(&row.osm_shape_wkb)?);
         } else {
             self.osm_present.append_null();
             self.osm_types.append_value("");
@@ -367,9 +395,56 @@ impl ParquetWriter {
         if self.rows_in_group > 0 {
             self.write_row_group()?;
         }
+        // Only knowable now that every row has been written (see
+        // `GEO_METADATA_KEY`) -- `append_key_value_metadata` folds this
+        // into the footer `writer.close()` is about to flush, same as
+        // if it had been passed to `WriterProperties` up front.
+        self.writer.append_key_value_metadata(KeyValue::new(
+            GEO_METADATA_KEY.to_string(),
+            self.geo_metadata_json(),
+        ));
         self.writer.close()?;
         std::fs::rename(self.tmp_path, self.path)?;
         Ok(())
+    }
+
+    /// Builds this file's [GeoParquet `geo`
+    /// metadata](https://github.com/opengeospatial/geoparquet/blob/v2.0.0-rc.1/format-specs/geoparquet.md#metadata),
+    /// naming `osm_geometry` as the `primary_column` -- OpenStreetMap is
+    /// the dataset a reader is actually meant to correct, so it's the
+    /// more natural default geometry for a GeoParquet-aware tool to
+    /// display. `crs` is deliberately omitted on both columns: it
+    /// defaults to OGC:CRS84 per spec, which is the same CRS
+    /// `new_geo_field` requests for the columns' native Parquet
+    /// `GEOGRAPHY` logical type -- so the two stay consistent (both
+    /// resolving to OGC:CRS84) without having to spell out a PROJJSON
+    /// object here. (Empirically, `parquet`-rs 59.2 doesn't actually
+    /// carry that requested `crs` through to the native logical type's
+    /// own `crs` sub-field -- `parquet-tools meta`/DuckDB both show it
+    /// unset there, even though it does show up correctly in the
+    /// Arrow-extension `ARROW:schema` metadata. Doesn't affect
+    /// conformance here, since "unset" already means OGC:CRS84 on both
+    /// sides, but if a future `parquet`/`parquet-geospatial` upgrade
+    /// starts requesting a non-default CRS, this comment -- and
+    /// whether `gpio check spec`/`gpio check all` still pass -- is
+    /// worth revisiting.)
+    fn geo_metadata_json(&self) -> String {
+        let column_metadata = |geometry_types: &BTreeSet<&'static str>| {
+            json!({
+                "encoding": "WKB",
+                "geometry_types": geometry_types.iter().collect::<Vec<_>>(),
+                "edges": "spherical",
+            })
+        };
+        json!({
+            "version": "2.0.0",
+            "primary_column": "osm_geometry",
+            "columns": {
+                "osm_geometry": column_metadata(&self.osm_geometry_types),
+                "atp_geometry": column_metadata(&self.atp_geometry_types),
+            },
+        })
+        .to_string()
     }
 
     fn write_row_group(&mut self) -> Result<()> {
@@ -401,10 +476,17 @@ impl ParquetWriter {
             vec![
                 Arc::new(self.atp_tags.finish()) as ArrayRef,
                 Arc::new(atp_fetched_struct) as ArrayRef,
-                Arc::new(self.atp_geometries.finish()) as ArrayRef,
             ],
             self.atp_present.finish(),
         )?;
+        // Top-level, not nested inside `atp_struct` -- GeoParquet
+        // requires geometry columns to live at the schema root (see
+        // `GEO_METADATA_KEY`'s doc comment). Its own null buffer
+        // already mirrors "ATP present on this row" -- `write()` calls
+        // `append_null()`/`append_value()` on this builder in lockstep
+        // with `atp_present` above, so no null buffer needs to be
+        // shared between the two.
+        let atp_geometry = self.atp_geometries.finish();
 
         let osm_fields = match self.schema.field_with_name("osm")?.data_type() {
             DataType::Struct(fields) => fields,
@@ -439,16 +521,19 @@ impl ParquetWriter {
                 Arc::new(modified_struct) as ArrayRef,
                 Arc::new(self.osm_way_members.finish()) as ArrayRef,
                 Arc::new(self.osm_relation_members.finish()) as ArrayRef,
-                Arc::new(self.osm_geometries.finish()) as ArrayRef,
             ],
             self.osm_present.finish(),
         )?;
+        // See `atp_geometry` above.
+        let osm_geometry = self.osm_geometries.finish();
 
         let batch = RecordBatch::try_new(
             self.schema.clone(),
             vec![
                 Arc::new(atp_struct) as ArrayRef,
+                Arc::new(atp_geometry) as ArrayRef,
                 Arc::new(osm_struct) as ArrayRef,
+                Arc::new(osm_geometry) as ArrayRef,
             ],
         )?;
 
@@ -644,6 +729,27 @@ fn wkb(shape: &geo::Geometry<f64>) -> Vec<u8> {
     buf
 }
 
+/// The GeoParquet `geometry_types` name for a WKB-encoded geometry
+/// (e.g. `"Point"`, `"Polygon"`, `"MultiPolygon"`) -- read straight off
+/// the WKB header (byte order + type code) via `wkb::reader`, without
+/// decoding any coordinates.
+fn wkb_geometry_type_name(wkb: &[u8]) -> Result<&'static str> {
+    use ::wkb::reader::GeometryType;
+    let geometry_type = ::wkb::reader::read_wkb(wkb)
+        .context("failed to read WKB header for geometry_types")?
+        .geometry_type();
+    Ok(match geometry_type {
+        GeometryType::Point => "Point",
+        GeometryType::LineString => "LineString",
+        GeometryType::Polygon => "Polygon",
+        GeometryType::MultiPoint => "MultiPoint",
+        GeometryType::MultiLineString => "MultiLineString",
+        GeometryType::MultiPolygon => "MultiPolygon",
+        GeometryType::GeometryCollection => "GeometryCollection",
+        other => anyhow::bail!("unsupported WKB geometry type {other:?}"),
+    })
+}
+
 mod schema {
     use arrow_schema::{DataType, Field, Fields, Schema, TimeUnit};
     use parquet_geospatial::{WkbEdges, WkbMetadata, WkbType};
@@ -662,15 +768,14 @@ mod schema {
             NOT_NULLABLE,
         );
 
-        let atp = Field::new_struct(
-            "atp",
-            vec![
-                new_key_value_field("tags"),
-                fetched,
-                new_geo_field("geometry", NOT_NULLABLE),
-            ],
-            NULLABLE,
-        );
+        let atp = Field::new_struct("atp", vec![new_key_value_field("tags"), fetched], NULLABLE);
+
+        // Top-level, not nested inside `atp`/`osm` -- GeoParquet
+        // requires geometry columns to live at the schema root (a
+        // geometry MUST NOT be a group field or nested in a group).
+        // Nullable, mirroring `atp`/`osm`'s own nullability: a row with
+        // no OSM match leaves `osm_geometry` null, and vice versa.
+        let atp_geometry = new_geo_field("atp_geometry", NULLABLE);
 
         let modified = Field::new_struct(
             "modified",
@@ -703,12 +808,12 @@ mod schema {
                     ),
                     NULLABLE,
                 ),
-                new_geo_field("geometry", NOT_NULLABLE),
             ],
             NULLABLE,
         );
+        let osm_geometry = new_geo_field("osm_geometry", NULLABLE);
 
-        Schema::new(vec![atp, osm])
+        Schema::new(vec![atp, atp_geometry, osm, osm_geometry])
     }
 
     /// Fields of one `osm.relation_members` list entry: the member's own
@@ -738,8 +843,14 @@ mod schema {
         )
     }
 
+    /// `"OGC:CRS84"`, not `"EPSG:4326"`: the two describe the same
+    /// datum, but `OGC:CRS84` is also GeoParquet's own default CRS when
+    /// a column's `geo` metadata omits `crs` (see `geo_metadata_json`)
+    /// -- using it here too means the native Parquet `GEOGRAPHY`
+    /// logical type and the GeoParquet metadata agree without having to
+    /// spell out a PROJJSON object in the latter.
     fn new_geo_field(name: &str, nullable: bool) -> Field {
-        let metadata = WkbMetadata::new(Some("EPSG:4326"), Some(WkbEdges::Spherical));
+        let metadata = WkbMetadata::new(Some("OGC:CRS84"), Some(WkbEdges::Spherical));
         Field::new(name, DataType::Binary, nullable)
             .with_extension_type(WkbType::new(Some(metadata)))
     }

--- a/src/pipeline/edits.rs
+++ b/src/pipeline/edits.rs
@@ -289,7 +289,10 @@ fn extract_conflated_row(batch: &RecordBatch, row: usize) -> Result<Option<Confl
         osm_tags: get_tags(osm, "tags", row)?,
         osm_changeset: get_u64(modified, "changeset", row)?,
         osm_version: get_u32(modified, "version", row)?,
-        osm_geometry_wkb: get_binary(osm, "geometry", row)?,
+        // Top-level, not nested inside `osm` -- GeoParquet 2.0 requires
+        // geometry columns to live at the schema root (see
+        // `pipeline::conflate::writer::GEO_METADATA_KEY`'s doc comment).
+        osm_geometry_wkb: get_batch_binary(batch, "osm_geometry", row)?,
     }))
 }
 
@@ -338,12 +341,18 @@ fn get_u32(s: &StructArray, name: &str, row: usize) -> Result<u32> {
         .value(row))
 }
 
-fn get_binary(s: &StructArray, name: &str, row: usize) -> Result<Vec<u8>> {
-    Ok(s.column_by_name(name)
-        .with_context(|| format!("missing field '{name}'"))?
+/// Reads a top-level `RecordBatch` column -- `osm_geometry`/`atp_geometry`
+/// live at the schema root, not nested inside the `osm`/`atp` structs
+/// (see `pipeline::conflate::writer::GEO_METADATA_KEY`'s doc comment),
+/// so this doesn't go through `StructArray` the way the `get_*` helpers
+/// above do.
+fn get_batch_binary(batch: &RecordBatch, name: &str, row: usize) -> Result<Vec<u8>> {
+    Ok(batch
+        .column_by_name(name)
+        .with_context(|| format!("missing column '{name}'"))?
         .as_any()
         .downcast_ref::<BinaryArray>()
-        .with_context(|| format!("field '{name}' is not binary"))?
+        .with_context(|| format!("column '{name}' is not binary"))?
         .value(row)
         .to_vec())
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -107,6 +107,15 @@ fn assert_conflated_parquet(path: &Path) -> Result<()> {
             .as_any()
             .downcast_ref::<StructArray>()
             .context("'osm' is not a struct")?;
+        // Top-level, not nested inside `osm` -- GeoParquet 2.0 requires
+        // geometry columns to live at the schema root (see
+        // `pipeline::conflate::writer::GEO_METADATA_KEY`'s doc comment).
+        let osm_geometry = batch
+            .column_by_name("osm_geometry")
+            .context("missing 'osm_geometry' column")?
+            .as_any()
+            .downcast_ref::<BinaryArray>()
+            .context("'osm_geometry' is not binary")?;
         for row in 0..batch.num_rows() {
             if osm.is_null(row) {
                 continue;
@@ -123,11 +132,7 @@ fn assert_conflated_parquet(path: &Path) -> Result<()> {
                 .context("'type' is not a string")?
                 .value(row)
                 .to_string();
-            let wkb = get("geometry")?
-                .as_any()
-                .downcast_ref::<BinaryArray>()
-                .context("'geometry' is not binary")?
-                .value(row);
+            let wkb = osm_geometry.value(row);
             let is_polygon = matches!(
                 wkb::reader::read_wkb(wkb)?.to_geometry(),
                 geo::Geometry::Polygon(_)


### PR DESCRIPTION
Fixes #663.

## What changed

- `atp.geometry`/`osm.geometry` move out of the `atp`/`osm` structs into top-level `atp_geometry`/`osm_geometry` columns. GeoParquet requires geometry columns to live at the schema root, not nested inside structs — this was the core ask in #663.
- Adds the file-level `geo` key-value metadata GeoParquet 2.0 itself requires (this repo didn't write it at all before, for any output file): `version`, `primary_column` (`osm_geometry` — OpenStreetMap is the dataset a reviewer is actually meant to correct), and per-column `encoding`/`geometry_types`/`edges`.
- `geometry_types` is computed for real, not left as an empty "unknown" array. New `src/geometry/wkb_type.rs` adds a `WkbGeometryType` enum and a `wkb_geometry_type()` reader that peeks a WKB buffer's header (byte order + type code) without decoding coordinates. `GeometryTally` (in `writer.rs`) tracks a real per-type count for each column across the whole file, plus the single largest geometry seen (bytes + a lazily-computed label — OSM `type/id`, ATP spider — only formatted when a row actually becomes the new largest) — both the counts and the largest-geometry info are logged at INFO in `close()`, one record each for `atp_geometry`/`osm_geometry`.
- `crs` is deliberately omitted from the `geo` metadata on both columns: it defaults to `OGC:CRS84` per spec, which is also what the columns' native Parquet `GEOGRAPHY` logical type now requests (switched from `EPSG:4326` to `OGC:CRS84`), so the two stay consistent without spelling out a PROJJSON object.
- `edits.rs`'s `suggest_edits` also reads `conflated.parquet` and needed the same top-level-column fix for `osm_geometry`.
- `docs/outputs/CONFLATED_PARQUET.md` updated: schema, the "quick look" query, a new intro paragraph stating this is a GeoParquet 2.0-rc.1 file with a link to the spec, and some editorial fixes from review (GeoJSON/GeoPackage mentioned as formats not tools, geometry simplification reframed around the downstream client's benefit).
- `PROVENANCE_KEY` and `GEO_METADATA_KEY` are now both set the same way, via `append_key_value_metadata` in `close()`, rather than one going through `WriterProperties` up front and the other appended late.

## Why 2.0-rc.1, not 1.1

GeoParquet 2.0 hasn't had a final release yet (`v2.0.0-rc.1`, July 2026, is the newest tag), but its on-disk format — including the file-level metadata's `version` field, which is a fixed `"2.0.0"` string — isn't expected to change again before the final release. Targeting 1.1 would mean re-doing this work again once 2.0 actually ships, and 1.1's classic `BYTE_ARRAY`-only columns wouldn't get us the native `GEOMETRY`/`GEOGRAPHY` Parquet logical type this repo already uses (`parquet-geospatial`), so 2.0-rc.1 is the right target now.

## Verification

Ran the pipeline against the test fixtures to produce a real `conflated.parquet`, then:

- [`gpio`](https://geoparquet.io/guide/check/) (the `geoparquet-io` CLI validator): `gpio check spec` and `gpio check all` both report **49 passed, 0 warnings, 0 failed**.
- Cross-checked the raw Parquet metadata directly via `parquet-tools meta` and DuckDB's `parquet_schema()`/`DESCRIBE`, confirming the native logical type, geospatial statistics, and the embedded `geo` JSON all match what's documented above.
- Checked `pipeline.log` directly for the new `conflate.write: atp_geometry geometry types` / `conflate.write: osm_geometry geometry types` records.
- `cargo test`, `cargo clippy --all-targets`, `cargo fmt --check` all clean.

One nuance investigated during review, not a bug: `parquet-tools meta`/DuckDB show the native Parquet `GEOGRAPHY` logical type's own `crs`/`algorithm` sub-fields as unset. Built an isolated repro against plain `arrow`/`parquet`/`parquet-geospatial` (no dependency on this pipeline) and traced it into `parquet`'s own source (`logical_type_for_binary`, `parquet` 59.2): a lon/lat CRS and `Spherical` edges are deliberately canonicalized to `None` there, because those are themselves the Parquet spec's own defaults for `GEOGRAPHY` — the same omit-if-default encoding GeoParquet's own `geo` metadata uses for `crs`. So this is the correct, intentional encoding of exactly the `OGC:CRS84`/spherical values requested, not data loss — no bug report needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
