### PR TITLE
GeometryTally::log: take target as an explicit parameter

### DIFF
--- a/src/geometry/geometry_tally.rs
+++ b/src/geometry/geometry_tally.rs
@@ -51,8 +51,18 @@ impl GeometryTally {
     /// INFO, as one structured record. `log::info!`'s field list has to
     /// be literal field names, so the indices below are hardcoded --
     /// they line up with [`WkbGeometryType::ALL`]'s declaration order.
-    pub fn log(&self, message: &str) {
+    ///
+    /// `target` is taken as an explicit parameter -- callers should pass
+    /// `module_path!()` -- rather than left to `log::info!`'s own
+    /// default, which would resolve to wherever this macro call is
+    /// physically written (i.e. always `geometry::geometry_tally`,
+    /// regardless of which caller's data is actually being logged).
+    /// `LOGGING.md` documents `target` as "which module logged it";
+    /// defeating that for every caller of a shared helper like this one
+    /// would make the field useless for exactly the callers who need it.
+    pub fn log(&self, target: &str, message: &str) {
         log::info!(
+            target: target,
             point = self.counts[0],
             line_string = self.counts[1],
             polygon = self.counts[2],

--- a/src/pipeline/conflate/writer.rs
+++ b/src/pipeline/conflate/writer.rs
@@ -406,10 +406,14 @@ impl ParquetWriter {
             self.write_row_group()?;
         }
 
-        self.atp_geometry_tally
-            .log("conflate.write: atp_geometry geometry types");
-        self.osm_geometry_tally
-            .log("conflate.write: osm_geometry geometry types");
+        self.atp_geometry_tally.log(
+            module_path!(),
+            "conflate.write: atp_geometry geometry types",
+        );
+        self.osm_geometry_tally.log(
+            module_path!(),
+            "conflate.write: osm_geometry geometry types",
+        );
 
         // Both of this file's key-value metadata entries are set here,
         // uniformly, via `append_key_value_metadata` -- rather than

--- a/src/places/writer.rs
+++ b/src/places/writer.rs
@@ -66,8 +66,10 @@ impl ParquetWriter {
 
     pub fn close(mut self) -> Result<()> {
         self.flush()?;
-        self.geometry_tally
-            .log("import_atp: alltheplaces.parquet geometry types");
+        self.geometry_tally.log(
+            module_path!(),
+            "import_atp: alltheplaces.parquet geometry types",
+        );
         self.writer.close()?;
         Ok(())
     }


### PR DESCRIPTION
Fixes a logging regression found during a post-release-prep audit (not by review comment).

## The bug

`GeometryTally::log()` called `log::info!()` without an explicit `target`, so it defaulted to wherever the macro is physically written — always `geometry::geometry_tally`, regardless of which caller (`pipeline::conflate::writer` vs. `places::writer`) is actually doing the logging. This came in as a side effect of moving `GeometryTally` from `pipeline::conflate::writer` into the shared `crate::geometry` module in #690/#692 — that move itself was correct, this is a follow-up fixing what came with it.

`docs/LOGGING.md` documents `target` as "which module logged it"; a shared helper silently defeated that for both of its current callers, collapsing two genuinely different log sources onto the same `target` value (the `message` text still differed, so this wasn't catastrophic, just a real loss of fidelity for anyone filtering/grepping logs by module).

## Fix

`GeometryTally::log(&self, target: &str, message: &str)` now takes `target` explicitly; both call sites pass `module_path!()`, exactly reproducing what `log::info!` would have resolved to if it were written directly at each call site (as it was, before the move).

## Verification

- `cargo build`/`test`/`clippy --all-targets`/`fmt --check` all clean.
- Empirically: ran the pipeline against the test fixtures and checked `pipeline.log` directly. Before this fix, both `conflate.write: ...` and `import_atp: ...` geometry-type log lines showed `"target":"osm_diffs::geometry::geometry_tally"`. After: `osm_diffs::pipeline::conflate::writer` and `osm_diffs::places::writer` respectively, matching their real callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)