### PR TITLE
Consolidate the osm_id*10+{type} encode/decode into shared helpers

### DIFF
--- a/src/pipeline/conflate/writer.rs
+++ b/src/pipeline/conflate/writer.rs
@@ -27,8 +27,13 @@ use std::{
 
 use super::ConflatedFeature;
 use crate::{
-    geometry::GeometryTally, matchers::OsmCandidate, tables::StringPool, utils::UtcTimestamp,
+    geometry::GeometryTally,
+    matchers::OsmCandidate,
+    pipeline::{decode_feature_id, osm_type_str},
+    tables::StringPool,
+    utils::UtcTimestamp,
 };
+use osm_pbf_iter::RelationMemberType;
 
 pub struct ParquetWriter {
     path: PathBuf,
@@ -307,14 +312,10 @@ impl ParquetWriter {
 
         if let Some(osm_id) = row.osm_id {
             self.osm_present.append_non_null();
-            let osm_type_str = match osm_id.get() % 10 {
-                1 => "node",
-                2 => "way",
-                3 => "relation",
-                _ => panic!("osm_id {} with unexpected last digit", osm_id.get()),
-            };
-            let osm_plain_id = osm_id.get() / 10;
-            self.osm_types.append_value(osm_type_str);
+            let (osm_member_type, osm_plain_id) = decode_feature_id(osm_id.get())
+                .unwrap_or_else(|| panic!("osm_id {} with unexpected last digit", osm_id.get()));
+            let osm_type = osm_type_str(osm_member_type);
+            self.osm_types.append_value(osm_type);
             self.osm_ids.append_value(osm_plain_id);
 
             for (key, value) in row.osm_tags.iter() {
@@ -381,9 +382,8 @@ impl ParquetWriter {
             }
 
             self.osm_geometries.append_value(&row.osm_shape_wkb);
-            self.osm_geometry_tally.record(&row.osm_shape_wkb, || {
-                format!("{osm_type_str}/{osm_plain_id}")
-            });
+            self.osm_geometry_tally
+                .record(&row.osm_shape_wkb, || format!("{osm_type}/{osm_plain_id}"));
         } else {
             self.osm_present.append_null();
             self.osm_types.append_value("");
@@ -573,20 +573,18 @@ impl ParquetWriter {
     }
 }
 
-/// Decodes a `Feature.id`-encoded value (`osm_id * 10 + {1,2,3}`) into
-/// `(type, osm_id)`. Same encoding `feature_to_osm_id` in
-/// `pipeline::osm::assemble` decodes -- not shared with it (that
-/// function is private to a different module, and this crate hasn't
-/// consolidated the encode/decode helpers yet, see
-/// alltheplaces/osm-diffs#662's discussion) -- but mirrors the `% 10`
-/// dispatch already used a few lines below for `osm.type` itself.
+/// Decodes a relation member's `Feature.id`-encoded `id` into
+/// `(type, osm_id)`, as `&'static str`/`u64` -- the shape
+/// `osm_relation_members` (below) needs for its `member_type` column.
+/// A thin wrapper around `pipeline::osm`'s shared
+/// `decode_feature_id`/`osm_type_str` (which operate on the OSM-domain
+/// `RelationMemberType`, not a string), kept as its own function mainly
+/// so this call site's `unwrap_or_else` panic message can say "relation
+/// member id" specifically.
 fn decode_member_id(id: u64) -> (&'static str, u64) {
-    match id % 10 {
-        1 => ("node", id / 10),
-        2 => ("way", id / 10),
-        3 => ("relation", id / 10),
-        _ => panic!("relation member id {id} with unexpected last digit"),
-    }
+    let (member_type, osm_id) = decode_feature_id(id)
+        .unwrap_or_else(|| panic!("relation member id {id} with unexpected last digit"));
+    (osm_type_str(member_type), osm_id)
 }
 
 impl ParquetRow {
@@ -679,8 +677,11 @@ impl ParquetRow {
                 })
                 .collect();
 
-            osm_way_members = (feature.id % 10 == 2).then(|| feature.way_members.clone());
-            osm_relation_members = (feature.id % 10 == 3).then(|| {
+            let (feature_type, _) = decode_feature_id(feature.id)
+                .unwrap_or_else(|| panic!("feature id {} with unexpected last digit", feature.id));
+            osm_way_members =
+                (feature_type == RelationMemberType::Way).then(|| feature.way_members.clone());
+            osm_relation_members = (feature_type == RelationMemberType::Relation).then(|| {
                 feature
                     .relation_members
                     .iter()

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -41,8 +41,13 @@ mod osm;
 // rest of atp's/osm's API (import_atp, BlobReader, Node/Way/Relation,
 // import_osm, ...). atp's own `read_cached_metadata` is re-exported
 // under a different name here since osm already has one of its own.
+// decode_feature_id/osm_type_str are for pipeline::conflate::writer,
+// which decodes the same `Feature.id` encoding osm::assemble/prune
+// produce -- see decode_feature_id's own doc comment.
 pub(crate) use atp::{AtpMetadata, read_cached_metadata as read_cached_atp_metadata};
-pub(crate) use osm::{OsmMetadata, PLANET_PBF_FILENAME, read_cached_metadata};
+pub(crate) use osm::{
+    OsmMetadata, PLANET_PBF_FILENAME, decode_feature_id, osm_type_str, read_cached_metadata,
+};
 mod tiles;
 mod upload;
 

--- a/src/pipeline/osm/assemble.rs
+++ b/src/pipeline/osm/assemble.rs
@@ -1,4 +1,4 @@
-use super::{BlobReader, Prunings};
+use super::{BlobReader, Prunings, decode_feature_id, encode_feature_id, osm_type_str};
 use crate::{
     geometry::{GeometryBuilder, PolygonFill, build_line, build_ring},
     make_progress_bar,
@@ -177,7 +177,7 @@ fn assemble_nodes(
                     if let Primitive::Node(node) = primitive
                         && keep_nodes.contains(node.id)
                     {
-                        let feature_id = make_feature_id(RelationMemberType::Node, node.id);
+                        let feature_id = encode_feature_id(RelationMemberType::Node, node.id);
                         let mut fti = assemble_feature(feature_id, &node.info);
                         let point = geo::Point::new(node.lon, node.lat); // x = longitude, y = latitude
                         if let Some(feature) = &mut fti.feature {
@@ -254,7 +254,7 @@ fn assemble_ways<'a>(
                 let block = PrimitiveBlock::parse(&data);
                 for primitive in block.primitives() {
                     if let Primitive::Way(way) = primitive {
-                        let feature_id = make_feature_id(RelationMemberType::Way, way.id);
+                        let feature_id = encode_feature_id(RelationMemberType::Way, way.id);
                         let is_interesting = prunings.keep_ways.contains(way.id);
                         let is_relation_member = prunings.relation_members.contains(feature_id);
                         if !is_interesting && !is_relation_member {
@@ -444,7 +444,8 @@ fn assemble_leaf_relations<'a>(
                 let block = PrimitiveBlock::parse(&data);
                 for primitive in block.primitives() {
                     if let Primitive::Relation(relation) = primitive {
-                        let feature_id = make_feature_id(RelationMemberType::Relation, relation.id);
+                        let feature_id =
+                            encode_feature_id(RelationMemberType::Relation, relation.id);
                         let is_interesting = prunings.keep_relations.contains(relation.id);
                         let is_relation_member = prunings.relation_members.contains(feature_id);
                         if !is_interesting && !is_relation_member {
@@ -618,10 +619,11 @@ fn assemble_super_relations(
                 let rel_geometry = {
                     let feature = fti.feature.as_ref().expect("feature");
                     let relation_type = relation_type_from_feature_tags(&feature.tags, strings);
-                    let rel_members = feature
-                        .relation_members
-                        .iter()
-                        .map(|m| feature_to_osm_id(m.id));
+                    let rel_members = feature.relation_members.iter().map(|m| {
+                        decode_feature_id(m.id).unwrap_or_else(|| {
+                            panic!("unexpected osm_type for feature_id={}", m.id)
+                        })
+                    });
                     assemble_relation_geometry(
                         relation_type,
                         rel_members,
@@ -771,13 +773,14 @@ fn s2_cell_id_for_point(p: &geo::Point) -> CellID {
     s2::cellid::CellID::from(s2_lat_lng)
 }
 
-/// Helper for [assemble_tags].
+/// Helper for [assemble_tags]. Doesn't panic on a malformed `id` (unlike
+/// [`decode_feature_id`]) -- this exists specifically to build a
+/// message for a *different* panic, so it must never itself panic and
+/// obscure that original message.
 fn debug_id_str(id: u64) -> String {
-    match id % 10 {
-        1 => format!("node/{}", id / 10),
-        2 => format!("way/{}", id / 10),
-        3 => format!("relation/{}", id / 10),
-        _ => format!("unknown-feature-type/{}", id),
+    match decode_feature_id(id) {
+        Some((member_type, osm_id)) => format!("{}/{}", osm_type_str(member_type), osm_id),
+        None => format!("unknown-feature-type/{id}"),
     }
 }
 
@@ -826,27 +829,6 @@ fn is_super_relation(rel: &osm_pbf_iter::Relation<'_>) -> bool {
     false
 }
 
-/// Encodes an OpenStreetMap object's `(member_type, id)` as a `Feature.id`
-/// — `id * 10 + 1` for nodes, `+ 2` for ways, `+ 3` for relations. Inverse
-/// of [`feature_to_osm_id`]. See `Feature.id` in `feature.proto`.
-fn make_feature_id(member_type: RelationMemberType, id: u64) -> u64 {
-    match member_type {
-        RelationMemberType::Node => id * 10 + 1,
-        RelationMemberType::Way => id * 10 + 2,
-        RelationMemberType::Relation => id * 10 + 3,
-    }
-}
-
-fn feature_to_osm_id(fid: u64) -> (RelationMemberType, u64) {
-    let osm_id = fid / 10;
-    match fid % 10 {
-        1 => (RelationMemberType::Node, osm_id),
-        2 => (RelationMemberType::Way, osm_id),
-        3 => (RelationMemberType::Relation, osm_id),
-        _ => panic!("unexpected osm_type for feature_id={}", fid),
-    }
-}
-
 fn assemble_relation_members(
     rel: &osm_pbf_iter::Relation<'_>,
     strings: &StringPool,
@@ -866,7 +848,7 @@ fn assemble_relation_members(
         });
         let member = RelationMember {
             role: role_id as u32,
-            id: make_feature_id(member_type, id),
+            id: encode_feature_id(member_type, id),
         };
         feature.relation_members.push(member);
     }

--- a/src/pipeline/osm/mod.rs
+++ b/src/pipeline/osm/mod.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Ok, Result, anyhow};
 use aws_lc_rs::digest::{Context as DigestContext, SHA256};
 use indicatif::MultiProgress;
-use osm_pbf_iter::{Blob, Primitive, PrimitiveBlock};
+use osm_pbf_iter::{Blob, Primitive, PrimitiveBlock, RelationMemberType};
 use protobuf_iter::MessageIter;
 use serde::{Deserialize, Serialize};
 use std::fs::File;
@@ -23,6 +23,44 @@ mod index;
 mod prune;
 
 use prune::Prunings;
+
+/// Encodes an OpenStreetMap element's `(type, id)` as a `Feature.id` --
+/// `id * 10 + 1` for nodes, `+ 2` for ways, `+ 3` for relations. The same
+/// encoding is also used for relation member references
+/// (`RelationMember.id`) -- see `feature.proto`. Inverse of
+/// [`decode_feature_id`].
+pub(crate) fn encode_feature_id(member_type: RelationMemberType, id: u64) -> u64 {
+    match member_type {
+        RelationMemberType::Node => id * 10 + 1,
+        RelationMemberType::Way => id * 10 + 2,
+        RelationMemberType::Relation => id * 10 + 3,
+    }
+}
+
+/// Decodes a `Feature.id`-encoded value into `(type, id)` -- `None` if
+/// `fid`'s last decimal digit isn't 1/2/3, which should never happen for
+/// a value this pipeline produced itself. Inverse of
+/// [`encode_feature_id`].
+pub(crate) fn decode_feature_id(fid: u64) -> Option<(RelationMemberType, u64)> {
+    let id = fid / 10;
+    match fid % 10 {
+        1 => Some((RelationMemberType::Node, id)),
+        2 => Some((RelationMemberType::Way, id)),
+        3 => Some((RelationMemberType::Relation, id)),
+        _ => None,
+    }
+}
+
+/// `"node"`/`"way"`/`"relation"` -- the string OSM's own API and tag
+/// conventions use for this element type (e.g. `conflated.parquet`'s
+/// `osm.type` column).
+pub(crate) fn osm_type_str(member_type: RelationMemberType) -> &'static str {
+    match member_type {
+        RelationMemberType::Node => "node",
+        RelationMemberType::Way => "way",
+        RelationMemberType::Relation => "relation",
+    }
+}
 
 pub fn import_osm<'a>(progress: &MultiProgress, workdir: &Path) -> Result<OsmFeatures<'a>> {
     assert!(workdir.exists());
@@ -461,6 +499,31 @@ mod tests {
     use super::*;
     use std::io::Cursor;
     use std::path::PathBuf;
+
+    #[test]
+    fn test_encode_decode_feature_id_round_trip() {
+        for (member_type, id) in [
+            (RelationMemberType::Node, 123),
+            (RelationMemberType::Way, 608979139),
+            (RelationMemberType::Relation, 999_999_999),
+        ] {
+            let fid = encode_feature_id(member_type.clone(), id);
+            assert_eq!(decode_feature_id(fid), Some((member_type, id)));
+        }
+    }
+
+    #[test]
+    fn test_decode_feature_id_rejects_bad_last_digit() {
+        assert_eq!(decode_feature_id(1230), None);
+        assert_eq!(decode_feature_id(1234), None);
+    }
+
+    #[test]
+    fn test_osm_type_str() {
+        assert_eq!(osm_type_str(RelationMemberType::Node), "node");
+        assert_eq!(osm_type_str(RelationMemberType::Way), "way");
+        assert_eq!(osm_type_str(RelationMemberType::Relation), "relation");
+    }
     use std::sync::mpsc::sync_channel;
 
     #[test]

--- a/src/pipeline/osm/prune.rs
+++ b/src/pipeline/osm/prune.rs
@@ -1,4 +1,4 @@
-use super::BlobReader;
+use super::{BlobReader, decode_feature_id, encode_feature_id};
 use crate::{
     make_progress_bar,
     matchers::MatchMask,
@@ -170,12 +170,18 @@ impl<'a> Prunings<'a> {
 
     #[allow(unused)]
     pub fn keep_way(&self, id: u64) -> bool {
-        self.keep_ways.contains(id) || self.relation_members.contains(id * 10 + 2)
+        self.keep_ways.contains(id)
+            || self
+                .relation_members
+                .contains(encode_feature_id(RelationMemberType::Way, id))
     }
 
     #[allow(unused)]
     pub fn keep_relation(&self, id: u64) -> bool {
-        self.keep_relations.contains(id) || self.relation_members.contains(id * 10 + 3)
+        self.keep_relations.contains(id)
+            || self
+                .relation_members
+                .contains(encode_feature_id(RelationMemberType::Relation, id))
     }
 }
 
@@ -329,14 +335,10 @@ fn prune_relations_pass_2<'a>(
                     if let Primitive::Relation(rel) = primitive
                         && graph.ancestors(rel.id).any(|id| keep_1.contains(id))
                     {
-                        keep_tx.send(rel.id * 10 + 3)?;
+                        keep_tx.send(encode_feature_id(RelationMemberType::Relation, rel.id))?;
                         for (role_name, member_id, member_type) in rel.members() {
                             strings_tx.send((String::from(role_name), 1))?;
-                            match member_type {
-                                RelationMemberType::Node => keep_tx.send(member_id * 10 + 1)?,
-                                RelationMemberType::Way => keep_tx.send(member_id * 10 + 2)?,
-                                RelationMemberType::Relation => keep_tx.send(member_id * 10 + 3)?,
-                            }
+                            keep_tx.send(encode_feature_id(member_type, member_id))?;
                         }
                         for (tag_key, tag_value) in rel.tags() {
                             strings_tx.send((String::from(tag_key), 1))?;
@@ -435,7 +437,7 @@ fn prune_ways<'a>(
                             mask.add_tag(key, value);
                         }
 
-                        let way_feature_id = way.id * 10 + 2;
+                        let way_feature_id = encode_feature_id(RelationMemberType::Way, way.id);
                         if !mask.is_empty() || relation_members.contains(way_feature_id) {
                             ways_tx.send(way.id)?;
                             for node_id in way.refs() {
@@ -458,8 +460,7 @@ fn prune_ways<'a>(
         // We need the coordinates of all nodes that participate in any relation.
         let rel_member_collector = s.spawn(move || {
             for member_id in rels_output.relation_members.iter() {
-                if member_id % 10 == 1 {
-                    let node_id = member_id / 10;
+                if let Some((RelationMemberType::Node, node_id)) = decode_feature_id(member_id) {
                     coords_tx.send(node_id)?;
                 }
             }


### PR DESCRIPTION
Found during a post-release-prep audit, filed as no issue existed for it (a code comment on \`decode_member_id\` cited #662, but #662 turned out to be about something unrelated — a centroid pre-check idea).

## The problem

\`Feature.id\`'s encoding (\`osm_id * 10 + {1=node, 2=way, 3=relation}\`) was independently reimplemented in at least six places — \`assemble.rs\`'s \`make_feature_id\`/\`feature_to_osm_id\`/\`debug_id_str\`, \`prune.rs\`'s several inline \`id * 10 + N\`/\`id % 10\` sites, and \`conflate/writer.rs\`'s inline match plus its own \`decode_member_id\`. Same encoding, same magic numbers, six chances to get it wrong.

## What changed

New shared helpers in \`pipeline::osm\` (\`encode_feature_id\`, \`decode_feature_id\`, \`osm_type_str\`), re-exported crate-wide the same way \`OsmMetadata\`/\`read_cached_metadata\` already are, for \`conflate::writer\` to use. \`decode_feature_id\` returns \`Option\` rather than panicking, so callers choose their own panic message (or, for \`assemble.rs\`'s \`debug_id_str\`, a safe non-panicking fallback — it exists specifically to build the message for a *different* panic, so it must never itself panic and obscure that).

\`assemble.rs\`/\`prune.rs\`/\`conflate/writer.rs\` all updated to call the shared helpers instead of reimplementing the encoding.

No behavior change — verified empirically, not just by inspection: ran the pipeline against the test fixtures before and after, and \`conflated.parquet\`'s OSM rows (type, id, way/relation member counts) came out byte-identical.

## Verification

- \`cargo build\`/\`test\`/\`clippy --all-targets\`/\`fmt --check\` all clean (249 lib tests, including 3 new ones for the shared helpers themselves, + 4 integration tests — all pre-existing pinned assertions on real fixture data still pass unchanged).
- Ran the real pipeline against the test fixtures and checked \`conflated.parquet\`'s OSM rows and \`gpio check spec\` (still 49 passed/0 warnings/0 failed).

Independent of #693 (the logging-target fix) — separate branches off \`main\`, no shared history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)