### PR TITLE
README: don't commit to MapRoulette specifically, link to #696

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,11 @@ and up to date.
 
 At the moment, this is still work in progress; the pipeline does not
 yet run on a weekly basis. Once it does, the plan is to automatically
-feed edit proposals to [MapRoulette](https://maproulette.org/) where
-human users can manually check each edit before applying it to
-OpenStreetMap.
+feed edit proposals to tools such as
+[MapRoulette](https://maproulette.org/), where human users can
+manually check each edit before applying it to OpenStreetMap — which
+edits go where is still being worked out, see
+[#696](https://github.com/alltheplaces/osm-diffs/issues/696).
 
 New here? See [`docs/CONTRIBUTING.md`](docs/CONTRIBUTING.md) to get
 started, and [`docs/`](docs/) generally for testing, cutting a


### PR DESCRIPTION
Which edit-review tool(s) our output should actually target — and how to split/shard tasks so they're reviewable, and whether different kinds of edits belong on different tools (MapRoulette/Osmose vs. StreetComplete/Every Door) — isn't decided yet, per #696. The README shouldn't imply it's settled by naming MapRoulette specifically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)