### PR TITLE
Move geostats.rs into the geometry module

### DIFF
--- a/src/geometry/geostats.rs
+++ b/src/geometry/geostats.rs
@@ -42,6 +42,12 @@ impl GeoStatsAccumulatorFactory for CustomGeoStatsAccumulatorFactory {
     }
 }
 
+/// Installs [`CustomGeoStatsAccumulatorFactory`] as the process-wide
+/// `GeoStatsAccumulatorFactory` (see the module doc comment above for
+/// why this is needed at all). Global, `parquet`-crate-enforced state --
+/// must run once, before any Parquet file with a `GEOMETRY`/`GEOGRAPHY`
+/// column is written, which in practice means once at pipeline startup
+/// (see `pipeline::run_pipeline_steps`).
 pub fn init() -> Result<()> {
     let factory = Arc::new(CustomGeoStatsAccumulatorFactory {});
     init_geo_stats_accumulator_factory(factory)?;

--- a/src/geometry/mod.rs
+++ b/src/geometry/mod.rs
@@ -42,6 +42,7 @@ use geo::{
 
 mod geometry_builder;
 mod geometry_tally;
+mod geostats;
 #[cfg(test)]
 mod grid_tests;
 mod line_stitcher;
@@ -52,6 +53,7 @@ mod wkb_writer;
 
 pub use geometry_builder::{GeometryBuilder, PolygonFill};
 pub use geometry_tally::GeometryTally;
+pub use geostats::init as init_geospatial_stats;
 pub use line_stitcher::LineStitcher;
 pub use polygon_assembler::PolygonAssembler;
 pub use polygon_union::PolygonUnion;

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -32,7 +32,6 @@ pub(crate) const EXTERNAL_SORT_CHUNK_BYTES: usize = 512 * 1024 * 1024;
 mod atp;
 mod conflate;
 mod edits;
-mod geostats; // TODO: Move into crate::geometry?
 mod osm;
 
 // Only these re-exported crate-wide (rather than making all of
@@ -100,7 +99,7 @@ fn run_pipeline_steps(
     pipeline_start_time: UtcDateTime,
     progress: &indicatif::MultiProgress,
 ) -> Result<()> {
-    geostats::init()?;
+    crate::geometry::init_geospatial_stats()?;
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()?;


### PR DESCRIPTION
It's a helper that sets up how \`conflated.parquet\`'s GEOMETRY/GEOGRAPHY columns get their Parquet-native geospatial statistics computed — not a pipeline stage like assemble/prune/tiles/upload, which is what \`pipeline/\` is otherwise for. Already flagged with a \`// TODO: Move into crate::geometry?\` comment; this just does it.

Pure move: \`init()\` re-exported as \`crate::geometry::init_geospatial_stats\` (renamed from the bare \`init\` to be self-explanatory at the call site, now that it's not obviously pipeline-startup-related from its module path alone), \`pipeline::run_pipeline_steps\` updated to call it. Also added a doc comment to \`init()\` itself, since the reasoning for calling it once at startup was previously obvious from being colocated with \`run_pipeline_steps\` and isn't anymore.

Verified: \`cargo build\`/\`test\`/\`clippy --all-targets\`/\`fmt --check\` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)