### PR TITLE
Clean up #[allow(unused)]: drop stale ones, delete dead code, keep modified()

### DIFF
--- a/src/pipeline/conflate/mod.rs
+++ b/src/pipeline/conflate/mod.rs
@@ -77,7 +77,6 @@ pub fn conflate(
     Ok(out_path)
 }
 
-#[allow(unused)]
 struct ConflatedFeature {
     atp: Option<Place>,
     osm: Option<Feature>,

--- a/src/pipeline/osm/assemble.rs
+++ b/src/pipeline/osm/assemble.rs
@@ -29,7 +29,6 @@ use std::{
 };
 use wkb::writer::{write_geometry, write_point};
 
-#[allow(unused)]
 pub struct Assembly<'a> {
     pub strings: StringPool<'a>,
     pub nodes: RecordReader,
@@ -373,7 +372,6 @@ struct AssembledLeafRelations<'a> {
 
     /// Geometry of leaf relations that are members in super relations,
     /// keyed by osm_id of the relation.
-    #[allow(unused)]
     leaf_relations_geometry: GeometryTable<'a>,
 
     /// FeatureToIndex protos for super relations, *not* yet ready

--- a/src/pipeline/osm/prune.rs
+++ b/src/pipeline/osm/prune.rs
@@ -18,7 +18,6 @@ use std::{
 };
 
 /// Which parts of OpenStreetMap we need for conflation.
-#[allow(unused)]
 pub struct Prunings<'a> {
     pub coords: CoordTable<'a>,
     pub strings: StringCounts<'a>,
@@ -161,27 +160,6 @@ impl<'a> Prunings<'a> {
             relation_members: rels_output.relation_members,
             relation_graph: rels_output.relation_graph,
         })
-    }
-
-    #[allow(unused)]
-    pub fn coord(&self, node_id: u64) -> Option<Coord> {
-        self.coords.get(node_id)
-    }
-
-    #[allow(unused)]
-    pub fn keep_way(&self, id: u64) -> bool {
-        self.keep_ways.contains(id)
-            || self
-                .relation_members
-                .contains(encode_feature_id(RelationMemberType::Way, id))
-    }
-
-    #[allow(unused)]
-    pub fn keep_relation(&self, id: u64) -> bool {
-        self.keep_relations.contains(id)
-            || self
-                .relation_members
-                .contains(encode_feature_id(RelationMemberType::Relation, id))
     }
 }
 

--- a/src/tables/blob_table.rs
+++ b/src/tables/blob_table.rs
@@ -5,7 +5,6 @@
 //! like serialized protobuf messages, WKB geeometry, or other opaque
 //! binary payloads.
 
-use crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES;
 use anyhow::{Ok, Result};
 use ext_sort::{ExternalSorter, ExternalSorterBuilder, buffer::mem::MemoryLimitedBufferBuilder};
 use memmap2::Mmap;
@@ -141,16 +140,6 @@ impl<'a> BlobTable<'a> {
 
     pub fn len(&self) -> usize {
         self.entries_count
-    }
-
-    /// Returns an iterator over all entries, in ascending order of key.
-    pub fn iter(&self) -> impl Iterator<Item = (u64, &'a [u8])> + '_ {
-        (0..self.entries_count).map(move |i| {
-            let key = u64::from_le(self.keys[i]);
-            let start = u64::from_le(self.starts[i]) as usize;
-            let end = u64::from_le(self.starts[i + 1]) as usize;
-            (key, &self.blob[start..end])
-        })
     }
 
     /// Returns the modification time of the backing file.
@@ -326,29 +315,6 @@ mod tests {
         assert_eq!(table.lookup(43), None);
         assert_eq!(table.lookup(44), Some(b"melbourne".as_slice()));
         assert_eq!(table.lookup(99), None);
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_iter() -> Result<()> {
-        let file = NamedTempFile::new()?;
-        let mut writer = Writer::create(file.path())?;
-        writer.write(17, b"bern")?;
-        writer.write(41, b"")?;
-        writer.write(42, b"ottawa")?;
-        writer.close()?;
-
-        let table = BlobTable::open(file.path())?;
-        let entries: Vec<(u64, &[u8])> = table.iter().collect();
-        assert_eq!(
-            entries,
-            vec![
-                (17, b"bern".as_slice()),
-                (41, b"".as_slice()),
-                (42, b"ottawa".as_slice()),
-            ]
-        );
 
         Ok(())
     }

--- a/src/tables/coord_table.rs
+++ b/src/tables/coord_table.rs
@@ -181,6 +181,10 @@ impl<'a> CoordTable<'a> {
     }
 
     /// Returns the modification time of the backing file.
+    ///
+    /// Currently unused -- part of the memoization surface every table in
+    /// this module exposes, but no pipeline stage's staleness check reads
+    /// it yet. See https://github.com/alltheplaces/osm-diffs/issues/704.
     #[allow(unused)]
     pub fn modified(&self) -> Result<SystemTime> {
         Ok(self.file.metadata()?.modified()?)

--- a/src/tables/geometry_store.rs
+++ b/src/tables/geometry_store.rs
@@ -149,23 +149,6 @@ impl GeometryStore {
         let err = format!("invalid WKB for key {} in {}", key, self.path.display());
         Ok(Some(read_wkb(&buf).expect(&err).to_geometry()))
     }
-
-    /// Returns whether `key` is present.
-    #[allow(unused)]
-    pub fn contains_key(&self, key: u64) -> bool {
-        self.index.contains_key(&key)
-    }
-
-    /// Returns the number of entries.
-    pub fn len(&self) -> usize {
-        self.index.len()
-    }
-
-    /// Returns whether the store has no entries.
-    #[allow(unused)]
-    pub fn is_empty(&self) -> bool {
-        self.index.is_empty()
-    }
 }
 
 fn encode_wkb(geometry: &Geometry) -> Vec<u8> {
@@ -234,25 +217,6 @@ mod tests {
             store.lookup(1)?,
             Some(Geometry::Point(point!(x: 2.0, y: 2.0)))
         );
-
-        assert_eq!(store.len(), 1);
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_len_and_is_empty_and_contains_key() -> Result<()> {
-        let file = NamedTempFile::new()?;
-        let mut store = GeometryStore::create(file.path())?;
-        assert!(store.is_empty());
-        assert_eq!(store.len(), 0);
-        assert!(!store.contains_key(1));
-
-        store.insert(1, &Geometry::Point(point!(x: 1.0, y: 1.0)))?;
-        assert!(!store.is_empty());
-        assert_eq!(store.len(), 1);
-        assert!(store.contains_key(1));
-        assert!(!store.contains_key(2));
 
         Ok(())
     }

--- a/src/tables/geometry_table.rs
+++ b/src/tables/geometry_table.rs
@@ -2,8 +2,8 @@
 //!
 //! `GeometryTable` wraps [BlobTable], adding geometry-specific encoding on
 //! top of it: values passed to [GeometryTable::create] and returned by
-//! [GeometryTable::lookup] and [GeometryTable::iter] are [geo::Geometry]
-//! values, not raw bytes. Internally, each geometry is stored as a WKB
+//! [GeometryTable::lookup] are [geo::Geometry] values, not raw bytes.
+//! Internally, each geometry is stored as a WKB
 //! (Well-Known Binary) blob in little-endian encoding, so on disk a
 //! `GeometryTable` is indistinguishable from a `BlobTable` of WKB blobs.
 //!
@@ -65,15 +65,11 @@ impl<'a> GeometryTable<'a> {
         self.blobs.len()
     }
 
-    /// Returns an iterator over all entries, in ascending order of key.
-    #[allow(unused)]
-    pub fn iter(&self) -> impl Iterator<Item = (u64, Geometry)> + '_ {
-        self.blobs
-            .iter()
-            .map(|(key, wkb)| (key, decode_wkb(key, wkb)))
-    }
-
     /// Returns the modification time of the backing file.
+    ///
+    /// Currently unused -- part of the memoization surface every table in
+    /// this module exposes, but no pipeline stage's staleness check reads
+    /// it yet. See https://github.com/alltheplaces/osm-diffs/issues/704.
     #[allow(unused)]
     pub fn modified(&self) -> Result<SystemTime> {
         self.blobs.modified()
@@ -95,7 +91,7 @@ fn decode_wkb(key: u64, wkb: &[u8]) -> Geometry {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use geo::{LineString, Point, Polygon, point};
+    use geo::{LineString, Polygon, point};
     use tempfile::{NamedTempFile, TempDir};
 
     #[test]
@@ -162,34 +158,6 @@ mod tests {
         );
         assert_eq!(table.len(), 1);
         assert_eq!(table.lookup(1), Some(Geometry::Polygon(polygon)));
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_iter_returns_entries_in_ascending_key_order() -> Result<()> {
-        let workdir = TempDir::new()?;
-        let file = NamedTempFile::new()?;
-        let geometries: Vec<(u64, Geometry)> = vec![
-            (42, Geometry::Point(Point::new(2.0, 2.0))),
-            (17, Geometry::Point(Point::new(1.0, 1.0))),
-        ];
-        GeometryTable::create(
-            geometries.into_iter(),
-            workdir.path(),
-            file.path(),
-            crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES,
-        )?;
-
-        let table = GeometryTable::open(file.path())?;
-        let entries: Vec<(u64, Geometry)> = table.iter().collect();
-        assert_eq!(
-            entries,
-            vec![
-                (17, Geometry::Point(Point::new(1.0, 1.0))),
-                (42, Geometry::Point(Point::new(2.0, 2.0))),
-            ]
-        );
 
         Ok(())
     }

--- a/src/tables/graph.rs
+++ b/src/tables/graph.rs
@@ -155,6 +155,10 @@ impl<'a> GraphTable<'a> {
     }
 
     /// Returns the modification time of the backing file.
+    ///
+    /// Currently unused -- part of the memoization surface every table in
+    /// this module exposes, but no pipeline stage's staleness check reads
+    /// it yet. See https://github.com/alltheplaces/osm-diffs/issues/704.
     #[allow(unused)]
     pub fn modified(&'a self) -> Result<SystemTime> {
         Ok(self.file.metadata()?.modified()?)

--- a/src/tables/mod.rs
+++ b/src/tables/mod.rs
@@ -12,15 +12,12 @@
 //! Arrow/Parquet instead (compressed, opened and decoded batch by
 //! batch, not mapped into memory).
 
-#[allow(unused)]
 mod blob_table;
 mod coord_table;
 mod feature_index;
-#[allow(unused)]
 mod geometry_store;
 mod geometry_table;
 mod graph;
-#[allow(unused)]
 mod records;
 mod sorted_u64_index;
 mod string_counts;
@@ -31,18 +28,15 @@ mod features {
     include!(concat!(env!("OUT_DIR"), "/tables.features.rs"));
 }
 
-#[allow(unused)]
 pub use blob_table::BlobTable;
 pub use coord_table::CoordTable;
 #[allow(unused)]
 pub use feature_index::LocalFeatureRef;
 pub use feature_index::{OsmFeatureIndex, OsmFeatures};
 pub use features::{Feature, FeatureToIndex, RelationMember};
-#[allow(unused)]
 pub use geometry_store::GeometryStore;
 pub use geometry_table::GeometryTable;
 pub use graph::{Edge, GraphTable};
-#[allow(unused)]
 pub use records::{RecordReader, RecordWriter};
 pub use string_counts::StringCounts;
 pub use string_pool::StringPool;

--- a/src/tables/records.rs
+++ b/src/tables/records.rs
@@ -67,11 +67,6 @@ impl RecordReader {
         self.count as usize
     }
 
-    /// Whether this spool file has no records.
-    pub fn is_empty(&self) -> bool {
-        self.count == 0
-    }
-
     /// Iterate over the records in this spool file.
     pub fn iter(&self) -> Result<impl Iterator<Item = Result<Vec<u8>>>> {
         let mut file = File::open(&self.path)
@@ -249,7 +244,6 @@ mod tests {
 
         let spool = RecordReader::open(path)?;
         assert_eq!(spool.len(), 2);
-        assert!(!spool.is_empty());
 
         let records: Result<Vec<Vec<u8>>> = spool.iter()?.collect();
         let records = records?;
@@ -271,7 +265,6 @@ mod tests {
 
         let spool = RecordReader::open(path)?;
         assert_eq!(spool.len(), 0);
-        assert!(spool.is_empty());
         assert_eq!(spool.iter()?.count(), 0);
 
         Ok(())

--- a/src/tables/string_pool.rs
+++ b/src/tables/string_pool.rs
@@ -91,7 +91,6 @@ use std::{
 pub struct StringPool<'a> {
     file: File,
     _mmap: Mmap,
-    len: usize,
     buckets: &'a [u32],
     hash_index: &'a [u32],
     hash_values: &'a [u16],
@@ -147,8 +146,6 @@ impl<'a> StringPool<'a> {
             let ptr = mmap.as_ptr() as *const u64;
             std::slice::from_raw_parts(ptr, HEADER_SIZE / size_of::<u64>())
         };
-        let len = usize::try_from(header[1])?;
-
         let buckets = {
             let offset = usize::try_from(header[2])?;
             let size = usize::try_from(header[3])?;
@@ -258,7 +255,6 @@ impl<'a> StringPool<'a> {
         Ok(StringPool {
             file,
             _mmap: mmap,
-            len,
             buckets,
             hash_index,
             hash_values,
@@ -270,19 +266,13 @@ impl<'a> StringPool<'a> {
     /// Returns the string that was written at index `idx` in
     /// [StringPool::create], in `O(1)`.
     ///
-    /// Panics if `idx >= self.len()`.
-    #[allow(unused)]
+    /// Panics if `idx` is out of range, i.e. no string was written at
+    /// that index in `create()`.
     pub fn get(&self, idx: usize) -> &'a str {
         let start = u64::from_le(self.starts[idx]) as usize;
         let end = u64::from_le(self.starts[idx + 1]) as usize;
         // SAFETY: Writer API only takes Rust strings, which are valid UTF-8.
         unsafe { str::from_utf8_unchecked(&self.chars[start..end]) }
-    }
-
-    /// Returns the number of entries in the table.
-    #[allow(unused)]
-    pub fn len(&self) -> usize {
-        self.len
     }
 
     /// Returns the modification time of the backing file.
@@ -297,7 +287,6 @@ impl<'a> StringPool<'a> {
     /// format" section above, rather than scanning every entry, so this
     /// is close to `O(1)` rather than `O(n)`. If `key` was written more
     /// than once, the smallest matching index is returned.
-    #[allow(unused)]
     pub fn lookup(&self, key: &str) -> Option<usize> {
         let hash_value: u32 = Self::hash(key);
         let bucket = (hash_value >> 16) as usize;
@@ -706,11 +695,6 @@ mod tests {
     }
 
     #[test]
-    fn test_len() {
-        assert_eq!(TEST_POOL.len(), 4);
-    }
-
-    #[test]
     fn test_lookup() {
         assert_eq!(TEST_POOL.lookup(""), None);
         assert_eq!(TEST_POOL.lookup("not in table"), None);
@@ -734,7 +718,6 @@ mod tests {
     #[test]
     fn test_empty_pool() {
         let pool = make_pool(&[]);
-        assert_eq!(pool.len(), 0);
         assert_eq!(pool.lookup(""), None);
         assert_eq!(pool.lookup("anything"), None);
     }
@@ -754,7 +737,6 @@ mod tests {
     #[test]
     fn test_duplicate_strings_lookup_returns_smallest_index() {
         let pool = make_pool(&["a", "b", "a", "c", "a", "b"]);
-        assert_eq!(pool.len(), 6);
         assert_eq!(pool.lookup("a"), Some(0));
         assert_eq!(pool.lookup("b"), Some(1));
         assert_eq!(pool.lookup("c"), Some(3));
@@ -782,7 +764,6 @@ mod tests {
         // which the small TEST_POOL above (4 entries) almost never hits.
         let entries: Vec<String> = (0..5000).map(|i| format!("string-{i}")).collect();
         let pool = make_pool(&entries.iter().map(String::as_str).collect::<Vec<_>>());
-        assert_eq!(pool.len(), 5000);
         for (i, s) in entries.iter().enumerate() {
             assert_eq!(pool.get(i), s.as_str());
             assert_eq!(pool.lookup(s), Some(i));

--- a/src/tables/u64_set.rs
+++ b/src/tables/u64_set.rs
@@ -124,6 +124,10 @@ impl U64Set {
     }
 
     /// Returns the modification time of the underlying file.
+    ///
+    /// Currently unused -- part of the memoization surface every table in
+    /// this module exposes, but no pipeline stage's staleness check reads
+    /// it yet. See https://github.com/alltheplaces/osm-diffs/issues/704.
     #[allow(unused)]
     pub fn modified(&self) -> Result<SystemTime> {
         Ok(self.file.metadata()?.modified()?)


### PR DESCRIPTION
Audited all 30 `#[allow(unused)]` in the codebase. Manual grepping for call sites turned out unreliable on its own (missed that a few module-level `#[allow(unused)]` on `mod` declarations were blanket-suppressing warnings for everything inside those files, and separately conflated a `strings.len()` call on `StringCounts` with one on `StringPool`) -- so this is based on temporarily stripping every attribute and reading `cargo check`'s actual dead-code output, not just grep.

**Stale attributes removed** -- item is genuinely used elsewhere, just deleting the now-pointless annotation: `ConflatedFeature`, `Assembly`, `Prunings`, `leaf_relations_geometry`, `StringPool::get`/`lookup`, and the module-level allows on `BlobTable`/`GeometryStore`/`RecordReader`.

**Dead code deleted** (and its test coverage, where a test existed solely to exercise it) -- no real caller anywhere, including tests:
- `Prunings::coord`/`keep_way`/`keep_relation` (callers use the fields directly instead)
- `BlobTable::iter`/`GeometryTable::iter`
- `GeometryStore::contains_key`/`len`/`is_empty`
- `RecordReader::is_empty`
- `StringPool::len` (and its now-unread backing field) -- notably, every *sibling* table's `len()` is genuinely used in production; this one only had test coverage.

**Kept, not deleted**: `modified()` on `CoordTable`/`BlobTable`/`GraphTable`/`U64Set`/`GeometryTable`. These back the pipeline's per-step memoization (staleness checks comparing input/output mtimes), and them being unused looks like a real gap in that memoization rather than dead code -- filed #704 to investigate, linked from each `#[allow(unused)]`.

**Left untouched**: `OsmFeatureIndex`'s `entries_count`/`id`/`len`/`is_empty`/`feature_id` and the `LocalFeatureRef` re-export -- explicitly documented in-code as scaffolding for `suggest_edits`' future move onto this index.

Verified: `cargo build`/`test`/`clippy`/`fmt` clean (245 lib + 2 bin + 4 integration tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)