### PR TITLE
edits.rs: fix dangling reference to a since-removed Place::to_geojson

### DIFF
--- a/src/pipeline/edits.rs
+++ b/src/pipeline/edits.rs
@@ -36,10 +36,9 @@ use std::time::Instant;
 use wkb::reader::read_wkb;
 
 /// One suggested change to an existing OpenStreetMap feature -- never a
-/// suggestion to create a new feature (see the TODO on
-/// `crate::places::Place::to_geojson`, which this mirrors for now: we
-/// only ever suggest edits for AllThePlaces features `conflate()` has
-/// matched to something that already exists in OSM).
+/// suggestion to create a new feature: we only ever suggest edits for
+/// AllThePlaces features `conflate()` has matched to something that
+/// already exists in OSM.
 ///
 /// `Ord`/`Eq` are implemented by hand (not derived) because they only
 /// need to compare `osm_id` -- that's the only thing `write_edits`'s


### PR DESCRIPTION
Found while auditing for stale/undocumented loose ends before the v0.7.0 release.

`SuggestedEdit`'s doc comment pointed at "the TODO on `crate::places::Place::to_geojson`" — that method doesn't exist anymore (`to_geojson` lives on `SuggestedEdit` itself now, per #655's pipeline rewrite). Just states the constraint directly instead of pointing at a comparison that no longer has a target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)