### PR TITLE
Bump s2 to 0.2.0, fixing RUSTSEC-2026-0196/0197 (cgmath)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,15 +75,6 @@ checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "approx"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f2a05fd1bd10b2527e20a2cd32d8873d115b8b39fe219ee25f42a8aca6ba278"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
@@ -607,16 +598,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
-name = "cgmath"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a98d30140e3296250832bbaaff83b27dcd6fa3cc70fb6f1f3e5c9c0023b5317"
-dependencies = [
- "approx 0.4.0",
- "num-traits",
-]
-
-[[package]]
 name = "chacha20"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1128,15 +1109,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "float_extras"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b22b70f8649ea2315955f1a36d964b0e4da482dfaa5f0d04df0d1fb7c338ab7a"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "float_next_after"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1339,7 +1311,7 @@ version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "777d18aa0f12f8b285331cd867133ee14422b3f023f6d388034c47d43e28786a"
 dependencies = [
- "approx 0.5.1",
+ "approx",
  "num-traits",
  "rayon",
  "rstar 0.10.0",
@@ -2054,12 +2026,6 @@ dependencies = [
  "futures-util",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leaky-bucket"
@@ -3695,14 +3661,11 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s2"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a23f65853fad73749bd4cdc1a69b7a18f9af9a2aec1a162066110aef1f4f90a"
+checksum = "081105773b1c0ff138641d8d27206aa1ea08fe604736a17f5af7d3c49f1500d7"
 dependencies = [
  "bigdecimal",
- "cgmath",
- "float_extras",
- "lazy_static",
  "libm",
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ rayon = "1.12.0"
 reqwest = { version = "0.13.4", default-features = false, features = ["json", "rustls", "stream"] }
 rmp-serde = { version = "1.3.1", default-features = false }
 rustls = { version = "0.23.40", default-features = false, features = ["aws_lc_rs"] }
-s2 = "0.1.0"
+s2 = "0.2.0"
 s3 = { version = "0.1.36", default-features = false, features = ["blocking", "multipart", "rustls"] }
 serde = "1.0.228"
 serde_json = { version = "1.0.150", default-features = false, features = ["std"] }


### PR DESCRIPTION
s2 0.2.0 drops its dependency on cgmath entirely — the small Matrix3-based
"frame" abstraction (used for orthonormal-basis conversions) was replaced
with dot products against s2's own `Vector` type. See
[yjh0502/rust-s2#115](https://github.com/yjh0502/rust-s2/issues/115).

This removes `cgmath`, `approx`, `float_extras`, and `lazy_static` from the
dependency tree and clears both cgmath RUSTSEC advisories for good, rather
than just leaving them unreachable (`swap_columns` — the buggy API — was
never actually called by s2 or by us).

Pure dependency bump, no source changes needed on our side (`cargo update -p s2`
+ Cargo.toml version bump). Full test suite (245 unit + 4 integration tests)
passes, including S2-geometry-heavy pipeline code — a good real-world check
that the rewrite in s2 0.2.0 works correctly, not just that it compiles.

https://osv.dev/RUSTSEC-2026-0196
https://osv.dev/RUSTSEC-2026-0197

🤖 Generated with [Claude Code](https://claude.com/claude-code)