### PR TITLE
chore: adopt Conventional Commits for PR titles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,10 +10,19 @@ updates:
       cargo:
         patterns:
           - "*"
+    # "chore" so these are valid Conventional Commits titles (see
+    # docs/CONTRIBUTING.md and .github/workflows/pr-title-lint.yml) but never
+    # trigger the auto-label job's breaking/enhancement/bug labels.
+    commit-message:
+      prefix: "chore"
+      include: "scope"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "daily"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -22,3 +31,5 @@ updates:
       codeql:
         patterns:
           - "github/codeql-action/*"
+    commit-message:
+      prefix: "chore(ci)"

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,89 @@
+name: Lint PR title
+
+# Enforces the Conventional Commits PR-title convention documented in
+# docs/CONTRIBUTING.md. Since PRs are squash-merged with the PR title as the
+# squash commit's title (see the "squash merge" note in docs/CONTRIBUTING.md),
+# this is what actually lands in main's history -- and what
+# scripts/cut-release.sh's breaking-change scan reads.
+#
+# pull_request_target (not pull_request) so this also runs for PRs from
+# forks: it only reads the PR title from the base repo's workflow config, it
+# doesn't need write access to or run any code from the fork.
+on:
+  pull_request_target:
+    types: [opened, edited, reopened]
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  lint-pr-title:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+    - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50  # v6.1.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Derives the enhancement/bug/breaking-change label from the PR title so it
+  # doesn't have to be kept in sync by hand -- these feed .github/release.yml's
+  # auto-generated release-note categories. Only ever adds a label, never
+  # removes one, so a title edit won't strip a label a human applied for an
+  # unrelated reason (e.g. good first issue).
+  #
+  # Note: "!" here means the PR breaks osm-diffs' OUTPUT SCHEMA
+  # (conflated.parquet), not that it breaks some public API -- see
+  # docs/CONTRIBUTING.md and docs/RELEASING.md's "Choosing the version
+  # number". It's a hint for scripts/cut-release.sh, not a substitute for the
+  # human judgment call that document asks for.
+  #
+  # No third-party action for this: the one commonly suggested for it
+  # (bcoe/conventional-release-labels) only detects breaking changes via a
+  # multi-line "BREAKING CHANGE:" footer, which a one-line PR title can't
+  # contain -- it would silently never fire for us.
+  auto-label:
+    name: Auto-label from PR title
+    runs-on: ubuntu-latest
+    needs: [lint-pr-title]
+    permissions:
+      pull-requests: write
+    steps:
+    - name: Derive and apply label from Conventional Commits type
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # Passed via env, never interpolated into the script body: this
+        # title comes from pull_request_target, i.e. it can be attacker-
+        # controlled text from a fork. Templating it directly into `run:`
+        # would be a shell-injection hole; reading it as an env var is inert
+        # data instead.
+        PR_TITLE: ${{ github.event.pull_request.title }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        REPO: ${{ github.repository }}
+      run: |
+        set -euo pipefail
+        if [[ "$PR_TITLE" =~ ^([a-z]+)(\([a-zA-Z0-9_./-]+\))?(!)?:[[:space:]] ]]; then
+          type="${BASH_REMATCH[1]}"
+          breaking="${BASH_REMATCH[3]}"
+          if [[ -n "$breaking" ]]; then
+            label="breaking-change"
+          elif [[ "$type" == "feat" ]]; then
+            label="enhancement"
+          elif [[ "$type" == "fix" ]]; then
+            label="bug"
+          else
+            label=""
+          fi
+          if [[ -n "$label" ]]; then
+            echo "Applying label: $label"
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "$label"
+          else
+            echo "Type '$type' has no auto-label mapping; leaving as-is."
+          fi
+        else
+          echo "Title doesn't parse as Conventional Commits; leaving as-is (lint-pr-title should already be failing this PR)."
+        fi

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -23,6 +23,37 @@ Running them locally first saves a round-trip through CI — see
 [`TESTING.md`](https://github.com/alltheplaces/osm-diffs/blob/main/docs/TESTING.md)
 for what else CI checks.
 
+## PR titles: Conventional Commits
+
+PRs are squash-merged, and the PR title becomes the commit message on
+`main` — so give it the shape of a
+[Conventional Commit](https://www.conventionalcommits.org/):
+
+```
+<type>[optional scope][!]: <description>
+```
+
+`type` is one of `feat`, `fix`, `docs`, `style`, `refactor`, `perf`,
+`test`, `build`, `ci`, or `chore`. A bot
+([`pr-title-lint.yml`](https://github.com/alltheplaces/osm-diffs/blob/main/.github/workflows/pr-title-lint.yml))
+checks this on every PR and applies an `enhancement`/`bug`/`breaking-change`
+label from it, which feeds
+[`.github/release.yml`](https://github.com/alltheplaces/osm-diffs/blob/main/.github/release.yml)'s
+categorized release notes — so getting the type right saves the
+maintainer a manual labeling step, it's not just a style nit.
+
+**The `!` marker is special here.** Normally it means "breaks the public
+API." `osm-diffs` doesn't have one client code links against — what it
+has is an **output schema** (`conflated.parquet`), and that's what
+matters to everyone downstream. So on this project, `!` means *this PR
+breaks the output schema*, per the rules in
+[`RELEASING.md`](https://github.com/alltheplaces/osm-diffs/blob/main/docs/RELEASING.md#choosing-the-version-number)
+— not that some function signature changed. A `refactor!:` or `chore!:`
+that happens to rename a Parquet column is exactly as `!` as a `feat!:`
+that removes one; a `feat:` CLI flag that doesn't touch the schema isn't
+`!` at all. `cut-release.sh` reads these markers to *suggest* a version
+floor, but the actual version is still your call, per `RELEASING.md`.
+
 ## Where to go next
 
 - [`docs/TESTING.md`](https://github.com/alltheplaces/osm-diffs/blob/main/docs/TESTING.md)

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -43,6 +43,16 @@ clients read is still a patch release. A release that changes the output
 schema in a breaking way is a major release even if the code diff is
 tiny.
 
+`cut-release.sh` gives you one piece of help with this call, not a
+replacement for it: it scans merged PR titles since the last tag for a
+Conventional Commits `!` marker (see
+[`CONTRIBUTING.md`](CONTRIBUTING.md#pr-titles-conventional-commits) — on
+this project `!` means *output-schema-breaking*, not API-breaking) and
+prints what it finds before asking you to confirm the version. Treat it
+as a “did you forget something” prompt: false positives and false
+negatives are both possible, since a PR’s type is chosen by whoever wrote
+the title, not by inspecting the schema diff.
+
 ## What happens automatically, step by step
 
 Once you run `cut-release.sh vX.Y.Z`:

--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -27,6 +27,10 @@
 #   major - output schema changed in a client-breaking way
 #   minor - output schema evolved in a backward-compatible way
 #   patch - bugfixes only, no schema changes
+# Before asking for confirmation, this script scans merged PR titles since
+# the last tag for a Conventional Commits "!" and suggests a version floor
+# from that -- see docs/CONTRIBUTING.md and docs/RELEASING.md. It's a hint,
+# not authoritative: the version is still your call.
 #
 # Requirements: git, cargo, gh (authenticated -- run `gh auth login` first)
 
@@ -90,6 +94,39 @@ HIGHEST="$(printf '%s\n%s\n' "$CURRENT_VERSION" "$VERSION" | sort -t. -k1,1n -k2
 if [ "$HIGHEST" != "$VERSION" ] || [ "$VERSION" = "$CURRENT_VERSION" ]; then
   echo "ERROR: ${VERSION} is not newer than Cargo.toml's current version (${CURRENT_VERSION})" >&2
   exit 1
+fi
+
+# ── scan for Conventional-Commits breaking markers since the last release ───
+# This is a hint, not a rule: choosing the version is still your call (see
+# "Choosing the version number" in docs/RELEASING.md). Reminder, since it's
+# easy to reach for the usual meaning by reflex: on osm-diffs, "!" flags a
+# commit that breaks the OUTPUT SCHEMA (conflated.parquet), not one that
+# breaks some public API -- see docs/CONTRIBUTING.md.
+LAST_TAG="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+if [ -n "$LAST_TAG" ]; then
+  BREAKING_COMMITS="$(git log "${LAST_TAG}..HEAD" --format='%s' \
+    | grep -E '^[a-z]+(\([a-zA-Z0-9_./-]+\))?!:' || true)"
+  if [ -n "$BREAKING_COMMITS" ]; then
+    echo "Breaking-change ('!') commits since ${LAST_TAG} -- remember, here"
+    echo "'!' means OUTPUT-SCHEMA-breaking, not API-breaking (see"
+    echo "docs/CONTRIBUTING.md):"
+    echo "$BREAKING_COMMITS" | sed 's/^/  - /'
+    CUR_MAJOR="${CURRENT_VERSION%%.*}"
+    NEW_MAJOR="${VERSION%%.*}"
+    if [ "$NEW_MAJOR" -le "$CUR_MAJOR" ]; then
+      echo
+      echo "WARNING: the above suggests a major bump, but ${TAG} isn't one."
+      echo "  This is only a suggestion from PR titles, not a schema diff --"
+      echo "  double-check against 'Choosing the version number' in"
+      echo "  docs/RELEASING.md before continuing."
+      printf "Continue with %s anyway? [y/N] " "$VERSION"
+      read -r REPLY || REPLY=""
+      case "$REPLY" in
+        [yY]*) ;;
+        *) echo "Aborted." >&2; exit 1 ;;
+      esac
+    fi
+  fi
 fi
 
 echo "Checking latest CI status on main..."


### PR DESCRIPTION
Adds `pr-title-lint.yml` (enforces the format on PR titles, which become
squash-commit messages on `main`) and an auto-label job that derives
`enhancement`/`bug`/`breaking-change` from the type — feeding the existing
`.github/release.yml` release-notes categories, which today require
labeling by hand.

**`!` is redefined for this project**: it flags an OUTPUT-SCHEMA-breaking
change (`conflated.parquet`), not an API-breaking one, since nobody links
against `osm-diffs` — see `docs/CONTRIBUTING.md` and the "Choosing the
version number" section of `docs/RELEASING.md`. `cut-release.sh` now scans
merged PR titles since the last tag for that marker and prints a suggested
version floor before asking for confirmation; it's a hint, not a
replacement for the human judgment call `RELEASING.md` already asks for.

Also:
- Updates `dependabot.yml` so its PRs get a `chore`/`chore(ci)` commit-
  message prefix (its default titles don't parse as Conventional Commits).
- Created the `breaking-change` label.
- Flipped the repo's squash-merge-title setting to `PR_TITLE`, so a
  single-commit PR's squash title can't silently diverge from what the
  lint checked (previously `COMMIT_OR_PR_TITLE`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)