### PR TITLE
fix(osm): self-heal a missing .meta.json sidecar instead of erroring

### DIFF
--- a/src/pipeline/osm/fetch.rs
+++ b/src/pipeline/osm/fetch.rs
@@ -1,5 +1,5 @@
 use crate::make_download_bar;
-use anyhow::{Context, Ok, Result};
+use anyhow::{Ok, Result};
 use indicatif::MultiProgress;
 use librqbit::{AddTorrent, AddTorrentOptions, Session, SessionOptions};
 use std::path::{Path, PathBuf};
@@ -12,12 +12,16 @@ const OSM_TORRENT_URL: &str = "https://planet.openstreetmap.org/pbf/planet-lates
 pub fn fetch_planet(progress: &MultiProgress, workdir: &Path) -> Result<(PathBuf, OsmMetadata)> {
     let pbf_path: PathBuf = workdir.join(super::PLANET_PBF_FILENAME);
     if pbf_path.exists() {
-        let metadata = super::read_cached_metadata(workdir).with_context(|| {
-            format!(
-                "{} exists, but its metadata could not be read",
-                pbf_path.display()
-            )
-        })?;
+        if let Result::Ok(metadata) = super::read_cached_metadata(workdir) {
+            return Ok((pbf_path, metadata));
+        }
+        // The .pbf exists, but its .meta.json sidecar is missing or
+        // unreadable -- e.g. a regional extract dropped in for cloud
+        // testing (scripts/test-branch-on-hetzner), rather than a file
+        // this function downloaded itself. Compute the metadata now, the
+        // same way a fresh download does below, instead of failing or
+        // re-downloading a file that's already there.
+        let metadata = super::compute_and_persist_metadata(&pbf_path, workdir, progress)?;
         return Ok((pbf_path, metadata));
     }
 
@@ -101,4 +105,50 @@ async fn download_osm_planet(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pipeline::osm::{PLANET_PBF_FILENAME, read_cached_metadata};
+
+    fn test_data_path(filename: &str) -> PathBuf {
+        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        path.push("tests");
+        path.push("test_data");
+        path.push(filename);
+        path
+    }
+
+    #[test]
+    fn test_fetch_planet_computes_metadata_for_preexisting_pbf_without_sidecar() -> Result<()> {
+        // A .pbf dropped into the workdir without its .meta.json sidecar
+        // -- e.g. a regional extract fetched for cloud testing, rather
+        // than a file this function downloaded itself -- should have its
+        // metadata computed on the spot, not trigger a fresh download or
+        // a hard error.
+        let workdir = tempfile::tempdir()?;
+        let pbf_path = workdir.path().join(PLANET_PBF_FILENAME);
+        std::fs::copy(test_data_path("zugerland.osm.pbf"), &pbf_path)?;
+        assert!(read_cached_metadata(workdir.path()).is_err());
+
+        let progress = MultiProgress::new();
+        let (returned_path, metadata) = fetch_planet(&progress, workdir.path())?;
+
+        assert_eq!(returned_path, pbf_path);
+        // Must agree with what mod.rs's own test_read_header reports for
+        // the same fixture.
+        assert_eq!(
+            metadata.replication_timestamp,
+            time::UtcDateTime::from_unix_timestamp(1769501462)? // 2026-01-27T08:11:02Z
+        );
+        assert_eq!(metadata.source, None);
+        assert_eq!(metadata.writing_program, Some("osmx".to_owned()));
+        assert!(metadata.sha256.is_some());
+
+        // The sidecar should now exist on disk, matching what was returned.
+        assert_eq!(read_cached_metadata(workdir.path())?, metadata);
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
## What

If `planet-latest.osm.pbf` already exists in the workdir but its
`.meta.json` sidecar is missing or unreadable, `fetch_planet()` used
to hard-error via `.with_context(...)?` rather than recover. This
falls back to computing the metadata on the spot instead — the same
header-parse + SHA-256 pass a fresh BitTorrent download already goes
through (`compute_and_persist_metadata`) — rather than failing or
re-downloading a file that's already there.

## Why

Small prerequisite for #722 (cloud-testing tool on real Hetzner
hardware): the plan there drops a pre-fetched Geofabrik regional
extract into the workdir to skip the multi-hour BitTorrent download.
Without this fix, that would need a hand-fabricated `.meta.json`
sidecar; with it, the pipeline just computes its own metadata for
whatever valid `.pbf` shows up, exactly like it already does after a
real download.

No behavior change for the existing "no `.pbf` yet" or "valid sidecar
already present" paths — only the previously-hard-erroring case
(`.pbf` present, sidecar missing/corrupt) now recovers.

## Testing

- New unit test (`fetch::tests::test_fetch_planet_computes_metadata_for_preexisting_pbf_without_sidecar`)
  drops the existing `tests/test_data/zugerland.osm.pbf` fixture into
  a temp workdir with no sidecar, confirms `fetch_planet` succeeds,
  returns metadata matching the fixture's real header, and writes a
  sidecar that reads back identically.
- `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, and
  `cargo test` all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)