### PR TITLE
Bump version to 0.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2946,7 +2946,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "osm-diffs"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "osm-diffs"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
Version bump ahead of releasing v0.7.1. Opened by scripts/cut-release.sh.