### PR TITLE
fix(release): give cut-release.sh's bump PR a Conventional Commits title

### DIFF
--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -161,11 +161,11 @@ mv Cargo.toml.new Cargo.toml
 cargo check --quiet
 
 git add Cargo.toml Cargo.lock
-git commit -q -m "Bump version to ${VERSION}"
+git commit -q -m "chore(release): bump version to ${VERSION}"
 git push -q -u origin "$BUMP_BRANCH"
 
 PR_URL="$(gh pr create \
-  --title "Bump version to ${VERSION}" \
+  --title "chore(release): bump version to ${VERSION}" \
   --body "Version bump ahead of releasing ${TAG}. Opened by scripts/cut-release.sh." \
   --base main)"
 echo "Opened ${PR_URL}"


### PR DESCRIPTION
The version-bump PR/commit that `cut-release.sh` opens used the plain
title "Bump version to X.Y.Z", which fails `pr-title-lint.yml`'s
Conventional Commits check (see #720721 lint failure:
https://github.com/alltheplaces/osm-diffs/actions/runs/32274785739).

Prefixes both the commit message and PR title with `chore(release): ` so
it satisfies the lint and gets no auto-label (a version bump alone
doesn't change `enhancement`/`bug`/`breaking-change` categorization).

🤖 Generated with [Claude Code](https://claude.com/claude-code)