### PR TITLE
docs(release): bump minor, not major, for breaking changes before 1.0.0

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -43,6 +43,23 @@ clients read is still a patch release. A release that changes the output
 schema in a breaking way is a major release even if the code diff is
 tiny.
 
+**Before 1.0.0, a schema-breaking release bumps *minor*, not *major*.**
+SemVer’s own spec is explicit that this is fine: [§4](https://semver.org/#spec-item-4)
+says a `0.y.z` major version is for initial development, where “anything
+MAY change at any time” and the public interface “SHOULD NOT be
+considered stable” — SemVer deliberately leaves how `0.y.z` itself
+increments up to the project. We use the common convention of treating
+`0.MINOR.PATCH` the way `MAJOR.MINOR.PATCH` works post-1.0: a
+schema-breaking release bumps `MINOR` (not `MAJOR`, which stays `0`),
+anything else bumps `PATCH`. This isn’t just a convention we picked —
+it’s the same rule `cargo`/crates.io itself uses for `0.x` dependency
+resolution (a `^0.2.0` requirement excludes `0.3.0`, treating that
+minor-version bump as the breaking one), so it’s already how our own
+build tooling reasons about pre-1.0 versions. We’ll move to `MAJOR`
+bumps for breaking changes once there’s an actual 1.0.0 to break
+compatibility with — i.e. once this pipeline has real downstream
+consumers depending on schema stability, not before.
+
 `cut-release.sh` gives you one piece of help with this call, not a
 replacement for it: it scans merged PR titles since the last tag for a
 Conventional Commits `!` marker (see

--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -113,9 +113,27 @@ if [ -n "$LAST_TAG" ]; then
     echo "$BREAKING_COMMITS" | sed 's/^/  - /'
     CUR_MAJOR="${CURRENT_VERSION%%.*}"
     NEW_MAJOR="${VERSION%%.*}"
-    if [ "$NEW_MAJOR" -le "$CUR_MAJOR" ]; then
+    # Before 1.0.0, a breaking release bumps MINOR instead of MAJOR (see
+    # "Choosing the version number" in docs/RELEASING.md) -- MAJOR stays
+    # 0 throughout initial development (SemVer #4), so requiring a MAJOR
+    # bump here would never be satisfiable pre-1.0.
+    if [ "$CUR_MAJOR" -ge 1 ]; then
+      BREAKING_SLOT_BUMPED=$([ "$NEW_MAJOR" -gt "$CUR_MAJOR" ] && echo yes || echo no)
+    else
+      CUR_MINOR="${CURRENT_VERSION#*.}"
+      CUR_MINOR="${CUR_MINOR%%.*}"
+      NEW_MINOR="${VERSION#*.}"
+      NEW_MINOR="${NEW_MINOR%%.*}"
+      if [ "$NEW_MAJOR" -gt "$CUR_MAJOR" ] || [ "$NEW_MINOR" -gt "$CUR_MINOR" ]; then
+        BREAKING_SLOT_BUMPED=yes
+      else
+        BREAKING_SLOT_BUMPED=no
+      fi
+    fi
+    if [ "$BREAKING_SLOT_BUMPED" = "no" ]; then
       echo
-      echo "WARNING: the above suggests a major bump, but ${TAG} isn't one."
+      echo "WARNING: the above suggests a breaking-version bump (major once"
+      echo "  past 1.0.0, minor for now), but ${TAG} isn't one."
       echo "  This is only a suggestion from PR titles, not a schema diff --"
       echo "  double-check against 'Choosing the version number' in"
       echo "  docs/RELEASING.md before continuing."


### PR DESCRIPTION
## What

Codifies that before `1.0.0`, a schema-breaking release bumps `MINOR` instead of `MAJOR` — `MAJOR` stays `0` until there's an actual `1.0.0` with real downstream consumers depending on schema stability.

## Why

SemVer's own spec ([§4](https://semver.org/#spec-item-4)) explicitly leaves how `0.y.z` itself increments up to the project during initial development. We adopt the common convention — also how `cargo`/crates.io itself treats `0.x` dependency resolution (a `^0.2.0` requirement excludes `0.3.0`) — of using `0.MINOR.PATCH` the way `MAJOR.MINOR.PATCH` works post-1.0.

## What changes

- `docs/RELEASING.md`: new paragraph under "Choosing the version number" stating the policy.
- `scripts/cut-release.sh`: its own "did you forget a major bump" warning previously required `NEW_MAJOR > CUR_MAJOR` unconditionally — unsatisfiable pre-1.0, so it would have false-positived on every breaking release before 1.0.0 (including v0.8.0, which just went out). Now checks the minor-version slot instead while `CUR_MAJOR` is `0`, falling back to the original major-version check once past `1.0.0`.

## Testing

- `sh -n scripts/cut-release.sh` (syntax check) and `shellcheck` both clean.
- Manually verified the new comparison logic against 5 cases (pre-1.0 breaking, pre-1.0 patch-only, crossing into 1.0.0, post-1.0 non-major, post-1.0 real major) — all produced the expected yes/no.

🤖 Generated with [Claude Code](https://claude.com/claude-code)