### PR TITLE
fix(ci): auto-label docs: PRs as documentation

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -30,11 +30,11 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # Derives the enhancement/bug/breaking-change label from the PR title so it
-  # doesn't have to be kept in sync by hand -- these feed .github/release.yml's
-  # auto-generated release-note categories. Only ever adds a label, never
-  # removes one, so a title edit won't strip a label a human applied for an
-  # unrelated reason (e.g. good first issue).
+  # Derives the enhancement/bug/breaking-change/documentation label from the
+  # PR title so it doesn't have to be kept in sync by hand -- these feed
+  # .github/release.yml's auto-generated release-note categories. Only ever
+  # adds a label, never removes one, so a title edit won't strip a label a
+  # human applied for an unrelated reason (e.g. good first issue).
   #
   # Note: "!" here means the PR breaks osm-diffs' OUTPUT SCHEMA
   # (conflated.parquet), not that it breaks some public API -- see
@@ -75,6 +75,8 @@ jobs:
             label="enhancement"
           elif [[ "$type" == "fix" ]]; then
             label="bug"
+          elif [[ "$type" == "docs" ]]; then
+            label="documentation"
           else
             label=""
           fi


### PR DESCRIPTION
## What

`pr-title-lint.yml`'s auto-label step only ever mapped `feat`/`fix`/breaking (`!`) to `enhancement`/`bug`/`breaking-change`. A `docs:` PR — like #733 — never got labeled, even though `.github/release.yml` already defines a real "📚 Documentation" category keyed on exactly that `documentation` label.

## Why this one specifically, not the other five unmapped types

`style`/`refactor`/`perf`/`test`/`build`/`ci`/`chore` have no dedicated category in `.github/release.yml` — they correctly fall through to the "🚧 Maintenance" catch-all as-is. `docs` was the one genuine gap: a real category exists and is actively used for categorized release notes, it just never got populated automatically.

## Testing

- `actionlint` on the changed workflow file: clean.
- Manually exercised the label-derivation logic (extracted the same regex/if-chain) against sample titles, including #733's actual title — confirms `docs(release): ...` now maps to `documentation`, `feat`/`fix!`/`chore` continue to behave as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)