### PR TITLE
ci: add shellcheck as a CI gate

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2026 Sascha Brawer <sascha@brawer.ch>
+# SPDX-License-Identifier: MIT
+
+name: ShellCheck
+
+# Lints every shell script in the repo (scripts/, including
+# scripts/test-branch-on-hetzner/remote/) with shellcheck -- a hard gate,
+# same style as cargo-deny.yml: the job fails outright on any finding,
+# not just an informational annotation.
+
+on:
+  merge_group:
+  push:
+    branches: [ "main" ]
+    paths: [ "**/*.sh" ]
+  pull_request:
+    branches: [ "main" ]
+    paths: [ "**/*.sh" ]
+
+permissions: {}
+
+jobs:
+  shellcheck:
+    name: Lint shell scripts
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+    - name: Run shellcheck
+      run: |
+        shellcheck --version
+        find . -name "*.sh" -not -path "./target/*" -print0 \
+          | xargs -0 shellcheck


### PR DESCRIPTION
## What

Adds `shellcheck.yml`: lints every shell script in the repo (`scripts/`, including `scripts/test-branch-on-hetzner/remote/`) on PRs/pushes that touch `*.sh` files.

## Why now

Came up while discussing a recent PR — checked whether the repo was actually clean first, since a hard-fail gate on an already-dirty repo just means immediately suppressing a pile of findings rather than a real gate. It is: all 11 shell scripts already pass `shellcheck` with zero findings, verified locally before writing this workflow.

## Design notes

- **Path-filtered** (`paths: ["**/*.sh"]`), so it only runs when relevant.
- **Not added to the branch-protection required-checks list**, matching the existing convention `cargo-deny.yml`/`test-container.yml` already use for path-filtered workflows: this repo's required-status-checks are matched by plain context name, which expects a status on every PR — a path-filtered workflow can't guarantee that for PRs that don't touch the filtered paths, which is a known way to leave a PR stuck waiting on a check that never reports in. The job still fails hard on a real finding (a real gate, not just an annotation); it's just not formally required the way `test.yml` (unconditional, no path filter) is.

## Testing

- `actionlint .github/workflows/shellcheck.yml`: clean.
- Ran the exact command the workflow uses locally (`find ... | xargs -0 shellcheck`) against the current repo: exit 0, all 11 scripts clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)