### PR TITLE
feat(scripts): adopt uv real dependencies + tests for test-branch-on-hetzner

### DIFF
--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2026 Sascha Brawer <sascha@brawer.ch>
+# SPDX-License-Identifier: MIT
+
+name: Test scripts
+
+# Runs pytest over scripts/ -- currently just
+# scripts/test-branch-on-hetzner/tests/, see #737. Path-filtered and not
+# added to the branch protection required-checks list, same reasoning as
+# shellcheck.yml: a plain context-name-matched required check expects a
+# status on every PR, which a path-filtered workflow can't guarantee for
+# PRs that don't touch scripts/ -- the job still fails hard on a real
+# test failure, it's just not formally required the way test.yml is.
+
+on:
+  merge_group:
+  push:
+    branches: [ "main" ]
+    paths: [ "scripts/**" ]
+  pull_request:
+    branches: [ "main" ]
+    paths: [ "scripts/**" ]
+
+permissions: {}
+
+jobs:
+  test-scripts:
+    name: Run scripts/ tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+    - name: Install uv
+      uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
+      with:
+        working-directory: scripts
+        enable-cache: true
+    - name: Run pytest
+      working-directory: scripts
+      run: uv run pytest

--- a/scripts/pyproject.toml
+++ b/scripts/pyproject.toml
@@ -9,4 +9,12 @@ license = { text = "MIT" }
 authors = [{ name = "Sascha Brawer", email = "sascha@brawer.ch" }]
 description = "Helper scripts internal to this project"
 requires-python = ">=3.12"
-dependencies = []
+dependencies = [
+    "boto3>=1.43.75",
+    "duckdb>=1.5.5",
+]
+
+[dependency-groups]
+dev = [
+    "pytest>=9.1.1",
+]

--- a/scripts/test-branch-on-hetzner/README.md
+++ b/scripts/test-branch-on-hetzner/README.md
@@ -68,13 +68,19 @@ real disk, isn't something you can determine by reading the code.
 - An SSH key already uploaded to that Hetzner project (`hcloud ssh-key
   list`) -- its *name*, not the key file itself, is what you pass to
   this tool.
-- Nothing else for a `--branch` deploy or a bare/`--containerized` run
-  without `--bucket-name`: both scripts only use the Python standard
-  library (no `pip install` needed); `cloud_test.py` shells out to
-  `hcloud`/`ssh`/`scp` for everything it does beyond that.
+- [`uv`](https://docs.astral.sh/uv/) -- run `uv sync` once from
+  `scripts/` to install `cloud_test.py`'s real dependencies (`boto3`
+  for the S3 test-bucket lifecycle, `duckdb` for `validate`). `hcloud`/
+  `ssh`/`scp`/`podman` are still shelled out to directly, not wrapped
+  in a library -- what you see echoed to stderr is exactly what runs.
 - `HETZNER_TEST_S3_ACCESS_KEY_ID`/`HETZNER_TEST_S3_ACCESS_KEY_SECRET` in
   your own environment, only if using `--bucket-name` (see
   "Containerized runs, regional extracts" below).
+
+Changing `cloud_test.py`? Run `uv run pytest` from `scripts/` first --
+`tests/test_cloud_test.py` covers the pure logic (label sanitization,
+S3/bucket calls, command construction) without touching real
+Hetzner/S3, and is also enforced in CI (`test-scripts.yml`).
 
 ## Quick start
 

--- a/scripts/test-branch-on-hetzner/cloud_test.py
+++ b/scripts/test-branch-on-hetzner/cloud_test.py
@@ -7,7 +7,9 @@ including prerequisites and a worked example.
 
 Every `hcloud`/`ssh`/`scp` command this runs is echoed to stderr first,
 so a flag mismatch against your installed `hcloud` version should be
-easy to spot and fix.
+easy to spot and fix. S3 (test bucket) operations go through boto3
+instead of a shelled-out CLI -- see s3_client()'s docstring for why --
+so those are logged as a one-line summary instead of an echoed command.
 """
 
 import argparse
@@ -19,6 +21,10 @@ import sys
 import tempfile
 import time
 from pathlib import Path
+
+import boto3
+from botocore.client import Config as BotoConfig
+from botocore.exceptions import ClientError
 
 DEFAULT_IMAGE = "debian-13"
 DEFAULT_LOCATION = "hel1"
@@ -116,22 +122,27 @@ def s3_credentials():
     return access_key, secret_key
 
 
-# `mc`'s own alias name for the Hetzner Object Storage account -- arbitrary,
-# just needs to match between `mc alias set` and every later `mc` call.
-MC_ALIAS = "containertest"
-
-
-def mc_alias_set(region):
-    """Not sh(): that echoes the full command line, which for `mc alias
-    set` would print the secret key in plain text to stderr (terminal
-    scrollback, a copy-pasted debugging session, ...). Echoes a redacted
-    form instead, same audit-trail intent as sh() without the leak."""
+def s3_client(region):
+    """A boto3 client against Hetzner Object Storage's S3-compatible
+    endpoint -- not `mc`: credentials become Python function arguments
+    here, never a subprocess command-line string, so there's no
+    equivalent of `sh()`'s command-echoing accidentally printing a
+    secret to stderr to guard against in the first place. boto3 is
+    AWS's own SDK, but works against any S3-compatible endpoint via
+    `endpoint_url` -- standard practice for non-AWS providers.
+    `addressing_style="path"` because Hetzner's endpoint needs
+    path-style bucket addressing, not the AWS-default virtual-hosted
+    style."""
     access_key, secret_key = s3_credentials()
-    endpoint = s3_endpoint(region)
-    cmd = ["mc", "alias", "set", MC_ALIAS, endpoint, access_key, secret_key]
-    redacted = ["mc", "alias", "set", MC_ALIAS, endpoint, access_key, "***"]
-    print(f"+ {' '.join(shlex.quote(c) for c in redacted)}", file=sys.stderr)
-    subprocess.run(cmd, check=True)
+    print(f"+ boto3 s3 client, endpoint={s3_endpoint(region)}", file=sys.stderr)
+    return boto3.client(
+        "s3",
+        endpoint_url=s3_endpoint(region),
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_key,
+        region_name=region,
+        config=BotoConfig(s3={"addressing_style": "path"}),
+    )
 
 
 def server_ip(name):
@@ -456,8 +467,8 @@ def cmd_destroy(args):
 
 
 def cmd_bucket_create(args):
-    mc_alias_set(args.region)
-    sh(["mc", "mb", f"{MC_ALIAS}/{args.name}"])
+    client = s3_client(args.region)
+    client.create_bucket(Bucket=args.name)
     print(f"\nBucket {args.name} created in {args.region}.")
     print(f"  S3_ENDPOINT: {s3_endpoint(args.region)}")
     print(f"  S3_BUCKET:   {args.name}")
@@ -474,9 +485,18 @@ def cmd_bucket_destroy(args):
         if reply.strip().lower() != "y":
             print("Aborted.", file=sys.stderr)
             return
-    mc_alias_set(args.region)
-    subprocess.run(["mc", "rm", "--recursive", "--force", f"{MC_ALIAS}/{args.name}"])
-    subprocess.run(["mc", "rb", f"{MC_ALIAS}/{args.name}"])
+    client = s3_client(args.region)
+    # Same "don't let a partial failure block teardown" resilience
+    # cmd_destroy already has for the VM/volume -- e.g. the bucket
+    # might already be empty, or already gone from an earlier retry.
+    try:
+        paginator = client.get_paginator("list_objects_v2")
+        for page in paginator.paginate(Bucket=args.name):
+            for obj in page.get("Contents", []):
+                client.delete_object(Bucket=args.name, Key=obj["Key"])
+        client.delete_bucket(Bucket=args.name)
+    except ClientError as e:
+        print(f"Warning: {e}", file=sys.stderr)
 
 
 def cmd_list(_args):

--- a/scripts/test-branch-on-hetzner/tests/conftest.py
+++ b/scripts/test-branch-on-hetzner/tests/conftest.py
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2026 Sascha Brawer <sascha@brawer.ch>
+# SPDX-License-Identifier: MIT
+
+# cloud_test.py is a standalone script, not a package -- puts its
+# directory on sys.path so test_cloud_test.py can `import cloud_test`
+# directly, the same way it'd be run from the command line.
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))

--- a/scripts/test-branch-on-hetzner/tests/test_cloud_test.py
+++ b/scripts/test-branch-on-hetzner/tests/test_cloud_test.py
@@ -1,0 +1,290 @@
+# SPDX-FileCopyrightText: 2026 Sascha Brawer <sascha@brawer.ch>
+# SPDX-License-Identifier: MIT
+
+"""Committed tests for cloud_test.py -- replaces the throwaway
+monkey-patched verification scripts that had to be rewritten from
+scratch for every PR against this tool (see #737). Nothing here makes
+real network/Hetzner/S3 calls: `boto3`, `ssh_cmd`, `scp_to` are all
+mocked, so this suite runs the same everywhere, no credentials needed.
+"""
+
+import argparse
+from pathlib import Path
+from unittest.mock import MagicMock, call
+
+import cloud_test as ct
+import pytest
+
+Args = argparse.Namespace
+
+
+# ── label_flags ──────────────────────────────────────────────────────
+
+
+def test_label_flags_sanitizes_branch_slash():
+    flags = ct.label_flags("myname", branch="feature/foo")
+    assert flags == [
+        "--label",
+        "osm-diffs-test=true",
+        "--label",
+        "osm-diffs-test-owner=myname",
+        "--label",
+        "osm-diffs-test-branch=feature--foo",
+    ]
+
+
+def test_label_flags_sanitizes_image_slash_and_colon():
+    flags = ct.label_flags("myname", image="ghcr.io/alltheplaces/osm-diffs:v1.2.3")
+    assert flags[-1] == "osm-diffs-test-image=ghcr.io--alltheplaces--osm-diffs--v1.2.3"
+
+
+def test_label_flags_no_branch_or_image():
+    flags = ct.label_flags("myname")
+    assert flags == ["--label", "osm-diffs-test=true", "--label", "osm-diffs-test-owner=myname"]
+
+
+# ── s3_credentials / s3_endpoint / s3_client ─────────────────────────
+
+
+def test_s3_credentials_missing_exits(monkeypatch):
+    monkeypatch.delenv("HETZNER_TEST_S3_ACCESS_KEY_ID", raising=False)
+    monkeypatch.delenv("HETZNER_TEST_S3_ACCESS_KEY_SECRET", raising=False)
+    with pytest.raises(SystemExit):
+        ct.s3_credentials()
+
+
+def test_s3_endpoint_format():
+    assert ct.s3_endpoint("fsn1") == "https://fsn1.your-objectstorage.com"
+
+
+def test_s3_client_uses_path_style_addressing(monkeypatch):
+    monkeypatch.setenv("HETZNER_TEST_S3_ACCESS_KEY_ID", "AKIA_TEST")
+    monkeypatch.setenv("HETZNER_TEST_S3_ACCESS_KEY_SECRET", "supersecret")
+    mock_factory = MagicMock()
+    monkeypatch.setattr(ct.boto3, "client", mock_factory)
+
+    ct.s3_client("fsn1")
+
+    args, kwargs = mock_factory.call_args
+    assert args == ("s3",)
+    assert kwargs["endpoint_url"] == "https://fsn1.your-objectstorage.com"
+    assert kwargs["aws_access_key_id"] == "AKIA_TEST"
+    assert kwargs["aws_secret_access_key"] == "supersecret"
+    assert kwargs["config"].s3["addressing_style"] == "path"
+
+
+# ── bucket create/destroy ────────────────────────────────────────────
+
+
+def test_cmd_bucket_create(monkeypatch):
+    mock_client = MagicMock()
+    monkeypatch.setattr(ct, "s3_client", lambda region: mock_client)
+
+    ct.cmd_bucket_create(Args(name="testbucket1", region="fsn1"))
+
+    mock_client.create_bucket.assert_called_once_with(Bucket="testbucket1")
+
+
+def test_cmd_bucket_destroy_empties_before_deleting(monkeypatch):
+    mock_client = MagicMock()
+    monkeypatch.setattr(ct, "s3_client", lambda region: mock_client)
+    mock_paginator = MagicMock()
+    mock_paginator.paginate.return_value = [
+        {"Contents": [{"Key": "conflated.parquet"}, {"Key": "pipeline.log"}]}
+    ]
+    mock_client.get_paginator.return_value = mock_paginator
+
+    ct.cmd_bucket_destroy(Args(name="testbucket1", region="fsn1", yes=True))
+
+    mock_client.delete_object.assert_has_calls(
+        [
+            call(Bucket="testbucket1", Key="conflated.parquet"),
+            call(Bucket="testbucket1", Key="pipeline.log"),
+        ],
+        any_order=True,
+    )
+    mock_client.delete_bucket.assert_called_once_with(Bucket="testbucket1")
+
+
+def test_cmd_bucket_destroy_yes_skips_prompt(monkeypatch):
+    """No input() call means no hang -- the real regression this
+    guards against is --yes accidentally not being wired through."""
+    monkeypatch.setattr(ct, "s3_client", lambda region: MagicMock())
+
+    def fail_if_called(*a, **kw):
+        raise AssertionError("input() should not be called when --yes is set")
+
+    monkeypatch.setattr("builtins.input", fail_if_called)
+    ct.cmd_bucket_destroy(Args(name="testbucket1", region="fsn1", yes=True))
+
+
+def test_cmd_bucket_destroy_prompts_without_yes(monkeypatch):
+    mock_client = MagicMock()
+    monkeypatch.setattr(ct, "s3_client", lambda region: mock_client)
+    monkeypatch.setattr("builtins.input", lambda prompt: "n")
+
+    ct.cmd_bucket_destroy(Args(name="testbucket1", region="fsn1", yes=False))
+
+    mock_client.delete_bucket.assert_not_called()
+
+
+# ── containerized_run_command ────────────────────────────────────────
+
+
+def test_containerized_run_command_basic_flags(monkeypatch):
+    monkeypatch.setattr(ct, "ssh_cmd", lambda ip, cmd, **kw: None)
+    monkeypatch.setattr(ct, "scp_to", lambda ip, local, remote: None)
+    args = Args(
+        regional_extract=None, bucket_name=None, bucket_region=None, mem_limit="4g", cpu_limit="2", run_id=None
+    )
+
+    cmd = ct.containerized_run_command(args, "1.2.3.4", "/workdir")
+
+    assert "podman run --rm --read-only" in cmd
+    assert "--memory=4g" in cmd
+    assert "--cpus=2" in cmd
+    assert "-v /workdir:/workdir" in cmd
+    assert "osm-diffs-test run --workdir /workdir" in cmd
+    assert "--run_id" not in cmd
+
+
+def test_containerized_run_command_with_run_id(monkeypatch):
+    monkeypatch.setattr(ct, "ssh_cmd", lambda ip, cmd, **kw: None)
+    monkeypatch.setattr(ct, "scp_to", lambda ip, local, remote: None)
+    args = Args(
+        regional_extract=None, bucket_name=None, bucket_region=None, mem_limit="4g", cpu_limit="2", run_id="42"
+    )
+    cmd = ct.containerized_run_command(args, "1.2.3.4", "/workdir")
+    assert cmd.endswith("--run_id 42")
+
+
+def test_containerized_run_command_fetches_regional_extract(monkeypatch):
+    calls = []
+    monkeypatch.setattr(ct, "ssh_cmd", lambda ip, cmd, **kw: calls.append(("ssh", cmd)))
+    monkeypatch.setattr(ct, "scp_to", lambda ip, local, remote: calls.append(("scp", str(local), remote)))
+    args = Args(
+        regional_extract="europe/switzerland",
+        bucket_name=None,
+        bucket_region=None,
+        mem_limit="4g",
+        cpu_limit="2",
+        run_id=None,
+    )
+
+    ct.containerized_run_command(args, "1.2.3.4", "/workdir")
+
+    scp_calls = [c for c in calls if c[0] == "scp"]
+    ssh_calls = [c for c in calls if c[0] == "ssh"]
+    assert any("fetch_test_extract.sh" in c[1] for c in scp_calls)
+    assert any("fetch_test_extract.sh europe/switzerland /workdir" in c[1] for c in ssh_calls)
+    assert any("chown -R 1000:1000 /workdir" in c[1] for c in ssh_calls)
+
+
+def test_containerized_run_command_s3_env_file(monkeypatch):
+    ssh_calls = []
+    scp_files = {}
+
+    def fake_scp(ip, local, remote):
+        if remote.endswith("s3.env"):
+            scp_files["s3.env"] = Path(local).read_text()
+
+    monkeypatch.setattr(ct, "ssh_cmd", lambda ip, cmd, **kw: ssh_calls.append(cmd))
+    monkeypatch.setattr(ct, "scp_to", fake_scp)
+    monkeypatch.setenv("HETZNER_TEST_S3_ACCESS_KEY_ID", "AKIA_TEST")
+    monkeypatch.setenv("HETZNER_TEST_S3_ACCESS_KEY_SECRET", "supersecret")
+    args = Args(
+        regional_extract=None,
+        bucket_name="b1",
+        bucket_region="fsn1",
+        mem_limit="8g",
+        cpu_limit="4",
+        run_id=None,
+    )
+
+    cmd = ct.containerized_run_command(args, "1.2.3.4", "/workdir")
+
+    assert "--env-file /root/osm-diffs/s3.env" in cmd
+    env_content = scp_files["s3.env"]
+    assert "S3_ENDPOINT=https://fsn1.your-objectstorage.com" in env_content
+    assert "S3_BUCKET=b1" in env_content
+    assert "S3_ACCESS_KEY_ID=AKIA_TEST" in env_content
+    assert "S3_ACCESS_KEY_SECRET=supersecret" in env_content
+    assert any("chmod 600" in c for c in ssh_calls)
+
+
+def test_containerized_run_command_missing_s3_credentials_exits(monkeypatch):
+    monkeypatch.delenv("HETZNER_TEST_S3_ACCESS_KEY_ID", raising=False)
+    monkeypatch.delenv("HETZNER_TEST_S3_ACCESS_KEY_SECRET", raising=False)
+    args = Args(
+        regional_extract=None,
+        bucket_name="b1",
+        bucket_region="fsn1",
+        mem_limit="8g",
+        cpu_limit="4",
+        run_id=None,
+    )
+    with pytest.raises(SystemExit):
+        ct.containerized_run_command(args, "1.2.3.4", "/workdir")
+
+
+# ── cmd_start validation ─────────────────────────────────────────────
+
+
+def test_cmd_start_containerized_requires_mem_and_cpu_limit():
+    args = Args(
+        containerized=True, mem_limit=None, cpu_limit=None, bucket_name=None, bucket_region=None
+    )
+    with pytest.raises(SystemExit, match="mem-limit"):
+        ct.cmd_start(args)
+
+
+def test_cmd_start_bucket_name_requires_bucket_region():
+    args = Args(
+        containerized=True, mem_limit="4g", cpu_limit="2", bucket_name="b1", bucket_region=None
+    )
+    with pytest.raises(SystemExit, match="bucket-region"):
+        ct.cmd_start(args)
+
+
+def test_cmd_start_validation_happens_before_any_network_call():
+    """server_ip()/workdir_for() aren't monkeypatched here on purpose --
+    if validation didn't happen first, this test would hit a real
+    (failing) hcloud call instead of the expected SystemExit."""
+    args = Args(
+        containerized=True, mem_limit=None, cpu_limit=None, bucket_name=None, bucket_region=None
+    )
+    with pytest.raises(SystemExit):
+        ct.cmd_start(args)
+
+
+# ── cmd_deploy: branch vs image ──────────────────────────────────────
+
+
+def test_cmd_deploy_image_path(monkeypatch):
+    calls = []
+    monkeypatch.setattr(ct, "server_ip", lambda name: "1.2.3.4")
+    monkeypatch.setattr(ct, "ssh_cmd", lambda ip, cmd, **kw: calls.append(("ssh", cmd)))
+    monkeypatch.setattr(ct, "scp_to", lambda ip, local, remote: calls.append(("scp", str(local))))
+
+    ct.cmd_deploy(Args(name="t", image="ghcr.io/x:v1", branch=None, repo="ignored"))
+
+    scp_names = [c[1] for c in calls if c[0] == "scp"]
+    ssh_cmds = [c[1] for c in calls if c[0] == "ssh"]
+    assert any("pull.sh" in s for s in scp_names)
+    assert not any("build.sh" in s for s in scp_names)
+    assert any("pull.sh ghcr.io/x:v1" in c for c in ssh_cmds)
+
+
+def test_cmd_deploy_branch_path(monkeypatch):
+    calls = []
+    monkeypatch.setattr(ct, "server_ip", lambda name: "1.2.3.4")
+    monkeypatch.setattr(ct, "ssh_cmd", lambda ip, cmd, **kw: calls.append(("ssh", cmd)))
+    monkeypatch.setattr(ct, "scp_to", lambda ip, local, remote: calls.append(("scp", str(local))))
+
+    ct.cmd_deploy(Args(name="t", image=None, branch="my/feature", repo="https://example/repo.git"))
+
+    scp_names = [c[1] for c in calls if c[0] == "scp"]
+    ssh_cmds = [c[1] for c in calls if c[0] == "ssh"]
+    assert any("build.sh" in s for s in scp_names)
+    assert not any("pull.sh" in s for s in scp_names)
+    assert any("build.sh" in c and "my/feature" in c for c in ssh_cmds)

--- a/scripts/uv.lock
+++ b/scripts/uv.lock
@@ -1,0 +1,195 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "boto3"
+version = "1.43.75"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/dd/b93be617dd5d1c6a3a248066030a450e62d211c0af0f49ed3a0d761383c9/boto3-1.43.75.tar.gz", hash = "sha256:86da93d3d5b46a58b03fa51b598ffa4aeaff485a3000affacf78491c105e44f0", size = 112673, upload-time = "2026-08-19T19:54:17.236Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/89/d0baf1269e57ac548387c11e5d9ba78d1e118ceb43f1e5e5114bdd2e8391/boto3-1.43.75-py3-none-any.whl", hash = "sha256:08a79edb68e6a0d65d305eb90188639313650e155aed015e86eef59d8475dde0", size = 140026, upload-time = "2026-08-19T19:54:15.509Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.43.75"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/80/5e39eda5dfb66df691d71212799a9f9d35aa9e447511604030447a00e9d6/botocore-1.43.75.tar.gz", hash = "sha256:e8ed6b0f3cd398dfb9e08d7ca3a0b964152166a317a04e89c45ec91003327ffe", size = 15973868, upload-time = "2026-08-19T19:54:12.318Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/46/19d3178e70f37fda251f3d9560f29654f09c6eedbe1c8b790adeee84da49/botocore-1.43.75-py3-none-any.whl", hash = "sha256:121abc8b0b529bc4e29a28d1e8b096b20f26708cabe3d5ae4b3446747712aece", size = 15667237, upload-time = "2026-08-19T19:54:08.802Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "duckdb"
+version = "1.5.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/19/e57151753576373c6696a12022648546cca6038e8833fda2908ee2342d9b/duckdb-1.5.5.tar.gz", hash = "sha256:72f33ee57ca7595b23957671a2cc7f7fe2be0ecc2d68f63abedcfcaa3a5c1238", size = 18066741, upload-time = "2026-07-22T10:55:17.819Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/40/2e05d324400fdaa5656c9f48d6298da421cb034d85e509fa0e6e325cf04b/duckdb-1.5.5-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d4dd65f8941a604b947e0b9b4b4f7165988e29a23ec0b69b4038520956d9933e", size = 32753858, upload-time = "2026-07-22T10:54:05.514Z" },
+    { url = "https://files.pythonhosted.org/packages/79/15/5ceb58ffb5bb8a62b3fd7abb39c41467cdf94850ece02e6d88664dfc75ce/duckdb-1.5.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:33db46679b071f108d57139493dee2d37e1f5efcf5c5c039c2969eed11a6c8a7", size = 17368293, upload-time = "2026-07-22T10:54:09.139Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/5c/bf02da0b354fe83cca4f95a4fbf762181af466f7d551ab2a093f7698882a/duckdb-1.5.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f0b88535a5d86fdd63dba6ea02ab68c003dfb9e4892b11256ef24c4da208baae", size = 15509131, upload-time = "2026-07-22T10:54:12.228Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/a9/5f1f09da421d8e930e0b063d11c1b3f90363f40ede74438cd188afdd13a2/duckdb-1.5.5-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f316eae2323d9a851883fdf2dee91c1f9efe251ab33e14a2272f82a913422ed6", size = 19391959, upload-time = "2026-07-22T10:54:15.551Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/98/6549769f158126fa64fd6c1ac2eb59a18282146c939867a3eb31b7c1db07/duckdb-1.5.5-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7a6d2d11859d82a936ebdcb30ce3d8a1cbb3e990bff05c12abb9b54c44fa7bd1", size = 21510909, upload-time = "2026-07-22T10:54:19.681Z" },
+    { url = "https://files.pythonhosted.org/packages/af/b7/5753b41d3124838f868f9f523362812d9fc45409e9e4dd70dcbb0a25826e/duckdb-1.5.5-cp312-cp312-win_amd64.whl", hash = "sha256:ddfbdb096c11d51ee22492397d342c90a82e62c5d09961477895934d0a25372f", size = 13168544, upload-time = "2026-07-22T10:54:22.789Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/28/44b679c7d46245f8398feae7edac959d1b83d4eb143e25b3fce0630b78bd/duckdb-1.5.5-cp312-cp312-win_arm64.whl", hash = "sha256:2725d2b9ace3a4e75d72fc5a239f6a44b502c580edadb8fb2676db772c5f9282", size = 13988684, upload-time = "2026-07-22T10:54:26.003Z" },
+    { url = "https://files.pythonhosted.org/packages/47/37/4a38116e7700720fd152c666292214fd3abdf916496991296d8d1f66efbf/duckdb-1.5.5-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:cd98829b67788609017e65c761bd42a5dd0f9129441bed8bda4d6881ccf819f0", size = 32754294, upload-time = "2026-07-22T10:54:29.822Z" },
+    { url = "https://files.pythonhosted.org/packages/66/42/7d392f1ba1eee0eaf4ab4c8c7a604bfe3536cd63f979cf5c98798664f807/duckdb-1.5.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:feead93c56679b79592d437c62975d39cb67adedffa7592c763baf8160ac7366", size = 17368211, upload-time = "2026-07-22T10:54:33.359Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/a5/0a6f4fa60562faa615e55e15bd1953a2f2b17a8edd8105e5cda215e43457/duckdb-1.5.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:49c963d9469373d7aba8d750d9ea565ab823e94166efed953f184dd9b169b98c", size = 15509136, upload-time = "2026-07-22T10:54:36.369Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/cb/023c89f51978545b9fab318581bba0c457a58e7530d2d933e54ae7d8647c/duckdb-1.5.5-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a736217825461732b5442d05a220f3da2e23a0dae114efbf08c9bf171b53098a", size = 19392147, upload-time = "2026-07-22T10:54:39.551Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/c5/41bef391fb8b23dbc133c9f2ba016e7a7a8124513d2cc1b430f1897d87e4/duckdb-1.5.5-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:078e6a60dd8eedde5832f45422ca5c4a6b8c837aeabd8a56ca0b7d933f588053", size = 21511060, upload-time = "2026-07-22T10:54:42.788Z" },
+    { url = "https://files.pythonhosted.org/packages/07/9f/c44dfc1f924ac29b3252dc1b91393c01d009dbfe9f8ed33f10b986151bd1/duckdb-1.5.5-cp313-cp313-win_amd64.whl", hash = "sha256:6826504277dba513c0c5d71d828456c94d729c9d2482f94b2e289f90a9167e28", size = 13168028, upload-time = "2026-07-22T10:54:46.127Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/88/591384b2cd59abddd6f5dc175e60374f9abae6064429f0c4402854c10f44/duckdb-1.5.5-cp313-cp313-win_arm64.whl", hash = "sha256:baa9c5702002fabb559ded2a39008f9f421fcbc7237d388b8213eff1e08858de", size = 13989955, upload-time = "2026-07-22T10:54:49.262Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/56/12c65bfa2d2605b81981b264788891bcf11ec72227889554cead5d8d13b9/duckdb-1.5.5-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8e6413dd40facb7b8ab21bd844450cd8f549b29e138635be9cf090ef4d2049e2", size = 32761946, upload-time = "2026-07-22T10:54:53.412Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/46/682ce155f17e0d2822d4f13ee3db9ca4b5b7c2da61b841b2629035e1f4bc/duckdb-1.5.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:64078acfd16541132ac6e191eb81b2845554444a0305cc1aa581ba107e514aa8", size = 17375069, upload-time = "2026-07-22T10:54:57.269Z" },
+    { url = "https://files.pythonhosted.org/packages/39/ce/a24bcbd3289c8f305a430759c5fc12242740b4af3e17f7593f3a34e333d2/duckdb-1.5.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8c11775cc99a447618d5f1840126db17f2652f3eae05529df4f81f40e2df7151", size = 15519791, upload-time = "2026-07-22T10:55:00.681Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/76/3a01afbc615c1d418c0de58a6b68ac5ce2a8563232c0464bfbc2ce552398/duckdb-1.5.5-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:77bbc1e6ba12e1e06f9020117bdf848627ecfdf36f907550e62e008e6109dece", size = 19398251, upload-time = "2026-07-22T10:55:04.168Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/43/3a5e81d1728f4d234c79bfe385808ee7c04834f7c37a4b5c257459c25614/duckdb-1.5.5-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fbf0f2d48b43c6c304d00463b463c27ead6c4b01c3c1816b750f728decf71afe", size = 21513851, upload-time = "2026-07-22T10:55:07.864Z" },
+    { url = "https://files.pythonhosted.org/packages/91/41/fc7c829172c60ca22485251eab285f4f1a0d87b486a024c726f21471d86e/duckdb-1.5.5-cp314-cp314-win_amd64.whl", hash = "sha256:9dc826c4b50e64f6c4e4d07a3a9cb075ef70ba3899dc43ec5493dc3d7b04b353", size = 13691858, upload-time = "2026-07-22T10:55:11.181Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2c/95d9216b79e9273689d7ebce125a54503ed0c9bd7da931f0265888e99779/duckdb-1.5.5-cp314-cp314-win_arm64.whl", hash = "sha256:63e48d4b74b15aeacd688976432a7225163df8c226eddeb8536bba2d4d4ff433", size = 14470180, upload-time = "2026-07-22T10:55:14.445Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.21.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/2e/ced460408999b33da6b31b0021b0f37d329e202d4169aeb164493778f25b/pygments-2.21.0.tar.gz", hash = "sha256:610ca751c9bc2492b38eb9a38a7fbc93edbbb2d7182edaf34e66ae493dee5c8c", size = 5005329, upload-time = "2026-08-17T08:02:48.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/46/17f022dd3e953bf20a04a028a21ec746d942f8d2af30fa0f124fa0e6a684/pygments-2.21.0-py3-none-any.whl", hash = "sha256:2363c69b61c4a97c838da3b130dcd6468f4848992b21a82f2a63ec34377137d9", size = 1250147, upload-time = "2026-08-17T08:02:44.912Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.19.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/43/35e4d8aa320bffe8287fe8f65f578fa2d2db0a64212f0e710dce58267854/s3transfer-0.19.2.tar.gz", hash = "sha256:ba0309fd86be3c27dbf78cdd813c13c5e1df16e5874b99d2535ebbdfb9892993", size = 165592, upload-time = "2026-07-22T19:30:44.432Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl", hash = "sha256:d8168eccca828cbb2cd573675333f3bddd254313a9c42494b84c76b539e8ba25", size = 90216, upload-time = "2026-07-22T19:30:43.251Z" },
+]
+
+[[package]]
+name = "scripts"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "boto3" },
+    { name = "duckdb" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "boto3", specifier = ">=1.43.75" },
+    { name = "duckdb", specifier = ">=1.5.5" },
+]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=9.1.1" }]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]


### PR DESCRIPTION
## What

Implements #737.

- `scripts/pyproject.toml` gains real dependencies: `duckdb` (for the upcoming `validate` command's Parquet queries), `boto3` (replaces `mc` for bucket create/destroy), `pytest` as a dev dependency.
- `mc` → `boto3` for bucket create/destroy: credentials become Python function arguments instead of a subprocess command-line string, so there's no equivalent of `sh()`'s command-echoing accidentally printing the secret to guard against in the first place — not just fixed once (as in #736), structurally impossible now. Needs path-style bucket addressing for Hetzner's endpoint (`addressing_style="path"`).
- New `scripts/test-branch-on-hetzner/tests/test_cloud_test.py`: turns the logic hand-verified in every PR against this tool so far into 20 permanent, committed tests — label sanitization, S3 credential/client construction, bucket create/destroy (mocked `boto3`, including the `--yes` prompt-skip and empty-before-delete ordering), `containerized_run_command`'s flag/env-file/regional-extract/run-id construction, `cmd_start`'s containerized validation, `cmd_deploy`'s branch-vs-image branching. No real network/Hetzner/S3 calls.
- New CI workflow `test-scripts.yml`: path-filtered to `scripts/**`, `merge_group:` trigger, hard-fail job — same pattern `shellcheck.yml` already established (not added to the branch-protection required-checks list, same path-filter-vs-required-check reasoning documented there).
- `README.md`'s Prerequisites section updated: `uv sync` instead of "no pip install needed", plus a pointer to running the new tests.

`hcloud`/`ssh`/`scp`/`podman` stay shelled out to directly, not wrapped in a library — deliberately unchanged, per #737's reasoning.

## Testing

- `uv run pytest` from `scripts/`: 20 passed, 0.07s.
- `uvx ruff check` on the new files: clean (after one auto-fixed import-order issue on the brand-new test file — didn't touch `cloud_test.py`'s own pre-existing style, matching the lesson from #725's history).
- `actionlint` on the new workflow: clean. Verified `astral-sh/setup-uv`'s pinned SHA and both `working-directory`/`enable-cache` input names against the action's real `action.yml` at that tag, rather than guessing.
- `py_compile` on all changed/new Python files: clean.
- Confirmed `uv run pytest` (no path argument, exactly as the CI workflow invokes it) auto-discovers the new tests correctly.

Caught one real bug while writing the tests: one test initially forgot to mock `ssh_cmd`/`scp_to` and made a real SSH connection attempt to a fake IP, hanging for ~75s until timeout — fixed before landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)