### PR TITLE
chore(deps): track scripts/'s Python dependencies with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,17 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+  - package-ecosystem: "uv"
+    directory: "/scripts"
+    schedule:
+      interval: "monthly"
+    groups:
+      uv:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:


### PR DESCRIPTION
## What

Adds a `package-ecosystem: "uv"` entry to `.github/dependabot.yml`, tracking `scripts/pyproject.toml`/`scripts/uv.lock`.

## Why

`scripts/pyproject.toml` gained real dependencies in #738 (`duckdb`, `boto3`, `pytest`) — previously `dependencies = []` made this a non-issue, now there's an actual update surface (including `boto3`'s own security-relevant advisories) with no automated tracking at all.

## Design notes

- `package-ecosystem: "uv"`, not the older `"pip"` — native Dependabot support since March 2025, understands `pyproject.toml` and `uv.lock` together rather than just a loose requirements file.
- `directory: "/scripts"`, since that's where `pyproject.toml`/`uv.lock` actually live, not the repo root.
- Grouped into one PR per update cycle and given the same `commit-message` treatment as the existing `cargo` entry (`chore` prefix, so it's a valid Conventional Commits title but never triggers the auto-label job's breaking/enhancement/bug labels).
- Monthly cadence, matching `cargo`'s — `boto3` in particular releases very frequently, and this is lower-stakes tooling rather than the core pipeline, so a tighter interval would just be PR noise.

## Sequencing note

This is independent of #738 and doesn't need it merged first — but Dependabot won't actually have anything to update until `scripts/pyproject.toml` on `main` has the real dependencies #738 adds (currently still `dependencies = []` on `main`). Fine to land in either order.

## Testing

Validated the YAML with a one-off `uv run --with pyyaml python3 -c "yaml.safe_load(...)"` (not added as a project dependency) — parses correctly, structure matches the existing `cargo`/`docker`/`github-actions` entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)