### PR TITLE
docs: mention scripts/ tests in TESTING.md and CONTRIBUTING.md

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -30,6 +30,8 @@ This checks the new dependency graph against
 — disallowed licenses, banned/duplicated crates, untrusted sources, and
 known RUSTSEC/OSV advisories.
 
+If you changed a Python script, run `uv run pytest` from `scripts/`.
+
 After you've sent a Pull Request, our Continuous Integration (CI) runs a
 series of checks on it — the commands above are a subset of what CI runs
 ([`test.yml`](https://github.com/alltheplaces/osm-diffs/blob/main/.github/workflows/test.yml),

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -13,6 +13,8 @@ two copies going stale independently.
 - **Integration tests**: [`tests/`](../tests) — a full pipeline run
   against a real OSM extract (a Swiss shopping mall) plus minimal
   AllThePlaces data. Fast enough to run on every `cargo test`.
+- **Script tests**: [`scripts/test-branch-on-hetzner/tests/`](../scripts/test-branch-on-hetzner/tests) —
+  run `uv run pytest` from `scripts/`.
 
 ## CI
 
@@ -22,7 +24,13 @@ tests, and a minimum coverage threshold) and
 [`codeql.yml`](../.github/workflows/codeql.yml) (static analysis).
 PRs that touch `Containerfile` or `scripts/sbom/` also run
 [`test-container.yml`](../.github/workflows/test-container.yml). PRs and
-pushes that touch `Cargo.toml`, `Cargo.lock`, or `deny.toml` run
+pushes touching `scripts/**/*.sh` run
+[`shellcheck.yml`](../.github/workflows/shellcheck.yml); those touching
+`scripts/**` run
+[`test-scripts.yml`](../.github/workflows/test-scripts.yml) (`pytest`
+for the scripts that have real test coverage — currently just
+`scripts/test-branch-on-hetzner/`). PRs and pushes that touch
+`Cargo.toml`, `Cargo.lock`, or `deny.toml` run
 [`cargo-deny.yml`](../.github/workflows/cargo-deny.yml) — dependency
 licenses, banned/duplicated crates, sources, and known RUSTSEC/OSV
 advisories, via [`cargo-deny`](https://github.com/EmbarkStudios/cargo-deny)


### PR DESCRIPTION
## What

Brief pointers to `scripts/test-branch-on-hetzner/tests/` (added in #738) and how to run them (`uv run pytest` from `scripts/`), plus a mention of the two new CI workflows (`shellcheck.yml`, `test-scripts.yml`) in `TESTING.md`'s existing CI rundown.

## Note

`uv` doesn't have a `test` subcommand (checked: `uv test` → "unrecognized subcommand") — used `uv run pytest` throughout, matching what's already documented in `scripts/test-branch-on-hetzner/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)