### PR TITLE
feat: add `validate` subcommand to cloud_test.py

### DIFF
--- a/scripts/test-branch-on-hetzner/README.md
+++ b/scripts/test-branch-on-hetzner/README.md
@@ -116,9 +116,11 @@ restart a run with a clean workdir without tearing down the VM
 | `status` | `systemctl status` for the run, plus `df` and the last few `pipeline.log` lines. |
 | `fio` | Random-read benchmark of the attached volume (the same command used by hand throughout the PR 665 experiment -- see `#667`). Re-runnable anytime, e.g. to check whether a result was a one-off blip. |
 | `sysinfo` | OS/kernel version, CPU model, memory, swap, disk layout, cgroup limits -- environment facts that turned out to matter for interpreting results but aren't anything this tool controls. |
-| `logs` | Downloads `pipeline.log`, `vmstat.log`, `disk.log`, `sysinfo.txt` to `logs/<name>/`. |
+| `logs` | Downloads `pipeline.log`, `vmstat.log`, `disk.log`, `sysinfo.txt`, `dmesg.log` to `logs/<name>/`. |
 | `stop` | Stops the pipeline + monitor, leaves the VM (and its disk contents) alone. |
 | `destroy` | Deletes the server and volume. Asks for confirmation unless `--yes`. |
+| `bucket create`/`bucket destroy` | Ephemeral S3 test bucket lifecycle -- see "Containerized runs" below. |
+| `validate` | Hard pass/fail checks against a run's `conflated.parquet` + downloaded logs -- see "Validation checks" below. |
 | `list` | Lists every instance this tool created (via a Hetzner label), so nothing gets forgotten and left running. |
 
 Run `./cloud_test.py <command> --help` for the full flag list; defaults
@@ -166,6 +168,53 @@ Recommended: keep all of this pointed at a Hetzner project (and S3
 credentials) dedicated to testing, separate from anything
 production-related -- testing shouldn't touch production, since
 something always goes wrong during testing.
+
+## Validation checks
+
+```console
+$ ./cloud_test.py validate \
+    --bucket-name osm-diffs-container-test-1 --bucket-region fsn1 \
+    --pipeline-log logs/reg1/pipeline.log \
+    --mem-limit 4g --expect-pipeline-version 0.8.0 --min-atp-features 100000
+```
+
+`validate` runs a fixed set of **hard** checks -- invariants that can't
+legitimately vary run-to-run, so a failure means something's actually
+broken, not just that today's data looks different from yesterday's:
+
+- Output is non-empty, and its schema matches
+  [`docs/outputs/CONFLATED_PARQUET.md`](../../docs/outputs/CONFLATED_PARQUET.md)
+  (struct field names, not full types -- e.g. this is what would have
+  caught `changeset` if #731 had only updated one of the writer/doc).
+- `atp`/`atp_geometry` and `osm`/`osm_geometry` are null exactly
+  together, and every `osm_geometry` is a valid geometry.
+- The embedded provenance BOM is present, passes
+  [`cyclonedx-cli validate`](https://github.com/CycloneDX/cyclonedx-cli)
+  (the same tool `test-container.yml` already uses), and -- if
+  `--expect-pipeline-version` is given -- its `pipeline_version` matches.
+- The `conflate` step reached its `phase="end"` log record with no
+  `ERROR` records logged after `phase="start"`.
+- `pipeline.log`'s `cgroup_current_bytes`/`cgroup_max_bytes` are
+  populated on that record (proof the run was actually containerized
+  under a real cgroup, impossible for a bare-VM run) -- and, if
+  `--mem-limit` is given, that `cgroup_max_bytes` matches it.
+- No OOM-kill signature in the downloaded `dmesg.log` (an OOM-killed
+  step's own log record is simply missing, not an error entry -- this
+  is the check that actually catches that case).
+- AllThePlaces' geometry count (`import_atp`'s tally) is at least
+  `--min-atp-features`, if given -- skipped (not silently passed)
+  without it, since there's no universal floor that makes sense across
+  every run.
+
+`--bucket-name`/`--bucket-region` point `validate` at the same test
+bucket `start --containerized --bucket-name ...` uploaded to;
+`--pipeline-log` (and, if not alongside it, `--dmesg-log`) point at a
+local directory `logs` already downloaded to. Standalone-runnable
+against any past run this way, even after its VM has been `destroy`ed.
+Exits non-zero if any hard check fails. **Content-shaped** signals
+(match rate, memory distribution -- expected to drift as real data and
+matching logic evolve) aren't part of this yet; see issue #722's plan
+for the deferred advisory-check tier.
 
 ## Making sense of the logs
 

--- a/scripts/test-branch-on-hetzner/cloud_test.py
+++ b/scripts/test-branch-on-hetzner/cloud_test.py
@@ -23,6 +23,7 @@ import time
 from pathlib import Path
 
 import boto3
+import validate
 from botocore.client import Config as BotoConfig
 from botocore.exceptions import ClientError
 
@@ -447,6 +448,16 @@ def cmd_logs(args):
     scp_from(ip, f"{REMOTE_DIR}/vmstat.log", dest / "vmstat.log")
     scp_from(ip, f"{REMOTE_DIR}/disk.log", dest / "disk.log")
     scp_from(ip, f"{REMOTE_DIR}/sysinfo.txt", dest / "sysinfo.txt")
+    # `validate`'s no-OOM check needs this from a local copy, since an
+    # OOM-killed step's own pipeline.log record is simply missing, not
+    # an error entry -- dmesg first, journalctl -k as a fallback (some
+    # images/kernels restrict unprivileged `dmesg` access), either way
+    # never failing the whole `logs` run if both come up empty.
+    ssh_cmd(
+        ip,
+        f"(dmesg 2>&1 || journalctl -k --no-pager 2>&1 || true) > {REMOTE_DIR}/dmesg.log",
+    )
+    scp_from(ip, f"{REMOTE_DIR}/dmesg.log", dest / "dmesg.log")
     print(f"\nLogs saved to {dest}")
 
 
@@ -497,6 +508,48 @@ def cmd_bucket_destroy(args):
         client.delete_bucket(Bucket=args.name)
     except ClientError as e:
         print(f"Warning: {e}", file=sys.stderr)
+
+
+def cmd_validate(args):
+    """Runs `validate.py`'s hard checks against a completed run's
+    `conflated.parquet` (read straight from the S3 test bucket) and a
+    locally downloaded `pipeline.log`/`dmesg.log` (see `logs`).
+    Standalone -- doesn't touch the VM at all, so it works just as well
+    against a run whose server has already been `destroy`ed."""
+    dmesg_path = Path(args.dmesg_log) if args.dmesg_log else Path(args.pipeline_log).with_name("dmesg.log")
+    if not dmesg_path.exists():
+        print(
+            f"Warning: {dmesg_path} not found -- run `logs` first if you haven't; "
+            "the no-OOM check will have nothing to flag either way.",
+            file=sys.stderr,
+        )
+    dmesg_text = dmesg_path.read_text() if dmesg_path.exists() else ""
+    records = validate.read_pipeline_log(args.pipeline_log)
+
+    access_key, secret_key = s3_credentials()
+    con = validate.connect(args.bucket_region, access_key, secret_key)
+    url = validate.parquet_url(args.bucket_name)
+
+    results = validate.run_hard_checks(
+        con,
+        url,
+        records,
+        dmesg_text,
+        args.mem_limit,
+        args.expect_pipeline_version,
+        args.min_atp_features,
+    )
+
+    print("\nHard checks:")
+    failed = False
+    for r in results:
+        status = "SKIP" if r.passed is None else ("PASS" if r.passed else "FAIL")
+        failed = failed or r.passed is False
+        print(f"  [{status}] {r.name}: {r.message}")
+
+    if failed:
+        sys.exit("\nvalidate: one or more hard checks failed")
+    print("\nAll hard checks passed.")
 
 
 def cmd_list(_args):
@@ -645,6 +698,35 @@ def main():
     )
     p_bucket_destroy.add_argument("--yes", action="store_true", help="skip the confirmation prompt")
     p_bucket_destroy.set_defaults(func=cmd_bucket_destroy)
+
+    p_validate = sub.add_parser(
+        "validate", help="hard checks against a run's conflated.parquet + pipeline.log"
+    )
+    p_validate.add_argument("--bucket-name", required=True, help="S3 test bucket the run uploaded to")
+    p_validate.add_argument(
+        "--bucket-region", required=True, help="Hetzner Object Storage region, e.g. fsn1"
+    )
+    p_validate.add_argument(
+        "--pipeline-log", required=True, help="local path to a downloaded pipeline.log (see `logs`)"
+    )
+    p_validate.add_argument(
+        "--dmesg-log", help="local path to a downloaded dmesg.log (default: alongside --pipeline-log)"
+    )
+    p_validate.add_argument(
+        "--mem-limit",
+        help="the --mem-limit the run was started with, e.g. 4g -- checked against "
+        "cgroup_max_bytes if given",
+    )
+    p_validate.add_argument(
+        "--expect-pipeline-version",
+        help="fail unless the embedded provenance BOM's pipeline_version matches, e.g. 0.8.0",
+    )
+    p_validate.add_argument(
+        "--min-atp-features",
+        type=int,
+        help="fail unless import_atp's geometry tally totals at least this many features",
+    )
+    p_validate.set_defaults(func=cmd_validate)
 
     p_list = sub.add_parser("list", help="list all osm-diffs-test instances")
     p_list.set_defaults(func=cmd_list)

--- a/scripts/test-branch-on-hetzner/tests/test_validate.py
+++ b/scripts/test-branch-on-hetzner/tests/test_validate.py
@@ -1,0 +1,367 @@
+# SPDX-FileCopyrightText: 2026 Sascha Brawer <sascha@brawer.ch>
+# SPDX-License-Identifier: MIT
+
+"""Tests for validate.py's hard checks. Runs real DuckDB queries against
+small Parquet fixtures built on the fly (rather than mocking the query
+engine itself, which would just be re-asserting the SQL string instead
+of actually exercising it) -- no S3/network/podman calls: fixtures are
+plain local files, and the one check that does shell out
+(check_provenance_bom's cyclonedx-cli call) has `subprocess.run` mocked.
+"""
+
+import json
+
+import duckdb
+import pytest
+import validate as v
+
+# A single valid row matching docs/outputs/CONFLATED_PARQUET.md's
+# schema -- a matched ATP/OSM pair. Used as the default fixture content;
+# individual tests override only what they need to.
+VALID_ROW_SQL = """
+SELECT
+    {
+        'tags': MAP(['shop'], ['bakery']),
+        'fetched': {'timestamp': TIMESTAMP '2026-01-01 00:00:00', 'spider': 'example_spider'}
+    } AS atp,
+    ST_AsWKB(ST_Point(8.5, 47.4))::BLOB AS atp_geometry,
+    {
+        'type': 'node',
+        'id': 12345::UBIGINT,
+        'tags': MAP(['shop'], ['bakery']),
+        'modified': {'timestamp': TIMESTAMP '2026-01-01 00:00:00', 'version': 3::UINTEGER},
+        'way_members': NULL::UBIGINT[],
+        'relation_members': NULL::STRUCT("type" VARCHAR, id UBIGINT, "role" VARCHAR)[]
+    } AS osm,
+    ST_AsWKB(ST_Point(8.5, 47.4))::BLOB AS osm_geometry
+"""
+
+
+def make_parquet(tmp_path, select_sql, name="conflated.parquet", kv_metadata=None):
+    """Writes `select_sql`'s result to a real local Parquet file (loading
+    the `spatial` extension first, since the fixture rows use ST_Point/
+    ST_AsWKB) and returns its path as a `str`, usable directly with
+    `read_parquet()`."""
+    con = duckdb.connect()
+    con.execute("INSTALL spatial")
+    con.execute("LOAD spatial")
+    path = tmp_path / name
+    kv = ""
+    if kv_metadata:
+        pairs = ", ".join(f"'{key}': '{value}'" for key, value in kv_metadata.items())
+        kv = f", KV_METADATA {{{pairs}}}"
+    con.execute(f"COPY ({select_sql}) TO '{path}' (FORMAT PARQUET{kv})")
+    return con, str(path)
+
+
+# ── parse_byte_size ──────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("4g", 4 * 1024**3),
+        ("512m", 512 * 1024**2),
+        ("2k", 2 * 1024),
+        ("100b", 100),
+        ("2147483648", 2147483648),
+        ("4G", 4 * 1024**3),
+    ],
+)
+def test_parse_byte_size(text, expected):
+    assert v.parse_byte_size(text) == expected
+
+
+# ── read_pipeline_log / find_step_record ────────────────────────────
+
+
+def test_read_pipeline_log_parses_jsonl(tmp_path):
+    log = tmp_path / "pipeline.log"
+    log.write_text('{"level": "INFO", "message": "a"}\n{"level": "ERROR", "message": "b"}\n')
+    records = v.read_pipeline_log(log)
+    assert [r["message"] for r in records] == ["a", "b"]
+
+
+def test_read_pipeline_log_skips_blank_lines(tmp_path):
+    log = tmp_path / "pipeline.log"
+    log.write_text('{"message": "a"}\n\n{"message": "b"}\n')
+    assert len(v.read_pipeline_log(log)) == 2
+
+
+def test_find_step_record_matches_step_and_phase():
+    records = [
+        {"fields": {"step": "conflate", "phase": "start"}},
+        {"fields": {"step": "conflate", "phase": "end"}, "marker": "found"},
+    ]
+    assert v.find_step_record(records, "conflate", "end") == records[1]
+
+
+def test_find_step_record_returns_none_when_missing():
+    assert v.find_step_record([{"fields": {"step": "conflate", "phase": "start"}}], "conflate", "end") is None
+
+
+# ── check_nonempty ───────────────────────────────────────────────────
+
+
+def test_check_nonempty_passes_with_rows(tmp_path):
+    con, url = make_parquet(tmp_path, VALID_ROW_SQL)
+    result = v.check_nonempty(con, url)
+    assert result.passed is True
+
+
+def test_check_nonempty_fails_when_empty(tmp_path):
+    con, url = make_parquet(tmp_path, VALID_ROW_SQL + " WHERE false")
+    result = v.check_nonempty(con, url)
+    assert result.passed is False
+
+
+# ── check_schema ─────────────────────────────────────────────────────
+
+
+def test_check_schema_passes_for_documented_schema(tmp_path):
+    con, url = make_parquet(tmp_path, VALID_ROW_SQL)
+    result = v.check_schema(con, url)
+    assert result.passed is True
+
+
+def test_check_schema_fails_if_changeset_reappears(tmp_path):
+    """The regression this check exists for: #731 removed `changeset`
+    from osm.modified -- if it ever came back, this must fail."""
+    sql = VALID_ROW_SQL.replace(
+        "'modified': {'timestamp': TIMESTAMP '2026-01-01 00:00:00', 'version': 3::UINTEGER},",
+        "'modified': {'timestamp': TIMESTAMP '2026-01-01 00:00:00', 'version': 3::UINTEGER, "
+        "'changeset': 99::UBIGINT},",
+    )
+    con, url = make_parquet(tmp_path, sql)
+    result = v.check_schema(con, url)
+    assert result.passed is False
+    assert "changeset" in result.message
+
+
+def test_check_schema_fails_on_missing_top_level_column(tmp_path):
+    sql = "SELECT NULL::STRUCT(tags MAP(VARCHAR, VARCHAR)) AS atp"
+    con, url = make_parquet(tmp_path, sql)
+    result = v.check_schema(con, url)
+    assert result.passed is False
+
+
+# ── check_null_consistency ───────────────────────────────────────────
+
+
+def test_check_null_consistency_passes_when_consistent(tmp_path):
+    con, url = make_parquet(tmp_path, VALID_ROW_SQL)
+    result = v.check_null_consistency(con, url, "atp", "atp_geometry")
+    assert result.passed is True
+
+
+def test_check_null_consistency_fails_when_mismatched(tmp_path):
+    sql = VALID_ROW_SQL.replace("ST_AsWKB(ST_Point(8.5, 47.4))::BLOB AS atp_geometry,", "NULL::BLOB AS atp_geometry,")
+    con, url = make_parquet(tmp_path, sql)
+    result = v.check_null_consistency(con, url, "atp", "atp_geometry")
+    assert result.passed is False
+
+
+# ── check_geometry_validity ──────────────────────────────────────────
+
+
+def test_check_geometry_validity_passes_for_valid_geometry(tmp_path):
+    con, url = make_parquet(tmp_path, VALID_ROW_SQL)
+    result = v.check_geometry_validity(con, url)
+    assert result.passed is True
+
+
+def test_check_geometry_validity_fails_for_invalid_polygon(tmp_path):
+    # A self-intersecting ("bowtie") polygon -- the textbook invalid
+    # geometry.
+    sql = VALID_ROW_SQL.replace(
+        "ST_AsWKB(ST_Point(8.5, 47.4))::BLOB AS osm_geometry",
+        "ST_AsWKB(ST_GeomFromText("
+        "'POLYGON((0 0, 2 2, 2 0, 0 2, 0 0))')) ::BLOB AS osm_geometry",
+    )
+    con, url = make_parquet(tmp_path, sql)
+    result = v.check_geometry_validity(con, url)
+    assert result.passed is False
+
+
+# ── check_provenance_bom ─────────────────────────────────────────────
+
+
+def _bom(pipeline_version="0.8.0", spec_version="1.7"):
+    return json.dumps(
+        {
+            "specVersion": spec_version,
+            "metadata": {"tools": {"components": [{"version": pipeline_version}]}},
+        }
+    )
+
+
+def test_check_provenance_bom_passes(tmp_path, monkeypatch):
+    monkeypatch.setattr(v.subprocess, "run", lambda *a, **k: type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})())
+    con, url = make_parquet(tmp_path, VALID_ROW_SQL, kv_metadata={"org.cyclonedx.bom": _bom()})
+    result = v.check_provenance_bom(con, url, expect_pipeline_version=None)
+    assert result.passed is True
+
+
+def test_check_provenance_bom_fails_when_key_missing(tmp_path):
+    con, url = make_parquet(tmp_path, VALID_ROW_SQL)
+    result = v.check_provenance_bom(con, url, expect_pipeline_version=None)
+    assert result.passed is False
+    assert "org.cyclonedx.bom" in result.message
+
+
+def test_check_provenance_bom_fails_when_cyclonedx_cli_rejects_it(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        v.subprocess,
+        "run",
+        lambda *a, **k: type("R", (), {"returncode": 1, "stdout": "invalid", "stderr": ""})(),
+    )
+    con, url = make_parquet(tmp_path, VALID_ROW_SQL, kv_metadata={"org.cyclonedx.bom": _bom()})
+    result = v.check_provenance_bom(con, url, expect_pipeline_version=None)
+    assert result.passed is False
+
+
+def test_check_provenance_bom_fails_on_pipeline_version_mismatch(tmp_path, monkeypatch):
+    monkeypatch.setattr(v.subprocess, "run", lambda *a, **k: type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})())
+    con, url = make_parquet(tmp_path, VALID_ROW_SQL, kv_metadata={"org.cyclonedx.bom": _bom(pipeline_version="0.7.0")})
+    result = v.check_provenance_bom(con, url, expect_pipeline_version="0.8.0")
+    assert result.passed is False
+    assert "0.7.0" in result.message
+
+
+# ── check_run_completed ──────────────────────────────────────────────
+
+
+def test_check_run_completed_passes_when_conflate_ends_cleanly():
+    records = [
+        {"level": "INFO", "message": "conflate: start", "fields": {"step": "conflate", "phase": "start"}},
+        {"level": "INFO", "message": "conflate: end", "fields": {"step": "conflate", "phase": "end"}},
+    ]
+    assert v.check_run_completed(records).passed is True
+
+
+def test_check_run_completed_fails_when_conflate_end_missing():
+    records = [{"level": "INFO", "message": "conflate: start", "fields": {"step": "conflate", "phase": "start"}}]
+    assert v.check_run_completed(records).passed is False
+
+
+def test_check_run_completed_fails_on_error_after_start():
+    records = [
+        {"level": "INFO", "message": "conflate: start", "fields": {"step": "conflate", "phase": "start"}},
+        {"level": "ERROR", "message": "conflate failed: boom", "fields": {"step": "conflate"}},
+        {"level": "INFO", "message": "conflate: end", "fields": {"step": "conflate", "phase": "end"}},
+    ]
+    result = v.check_run_completed(records)
+    assert result.passed is False
+    assert "boom" in result.message
+
+
+# ── check_cgroup_signal ───────────────────────────────────────────────
+
+
+def _conflate_end(**fields):
+    return {
+        "level": "INFO",
+        "message": "conflate: end",
+        "fields": {"step": "conflate", "phase": "end", **fields},
+    }
+
+
+def test_check_cgroup_signal_passes_when_fields_present_and_matching():
+    records = [_conflate_end(cgroup_current_bytes=1000, cgroup_max_bytes=4 * 1024**3)]
+    result = v.check_cgroup_signal(records, mem_limit="4g")
+    assert result.passed is True
+
+
+def test_check_cgroup_signal_fails_when_fields_null():
+    records = [_conflate_end()]
+    result = v.check_cgroup_signal(records, mem_limit="4g")
+    assert result.passed is False
+
+
+def test_check_cgroup_signal_fails_when_mem_limit_mismatched():
+    records = [_conflate_end(cgroup_current_bytes=1000, cgroup_max_bytes=2 * 1024**3)]
+    result = v.check_cgroup_signal(records, mem_limit="4g")
+    assert result.passed is False
+
+
+def test_check_cgroup_signal_skips_mem_limit_comparison_when_not_given():
+    records = [_conflate_end(cgroup_current_bytes=1000, cgroup_max_bytes=2 * 1024**3)]
+    result = v.check_cgroup_signal(records, mem_limit=None)
+    assert result.passed is True
+
+
+def test_check_cgroup_signal_fails_when_conflate_end_missing():
+    assert v.check_cgroup_signal([], mem_limit="4g").passed is False
+
+
+# ── check_no_oom ──────────────────────────────────────────────────────
+
+
+def test_check_no_oom_passes_on_clean_log():
+    assert v.check_no_oom("kernel: some unrelated line\n").passed is True
+
+
+def test_check_no_oom_fails_on_oom_kill_signature():
+    result = v.check_no_oom("kernel: Out of memory: Killed process 123 (osm-diffs)\n")
+    assert result.passed is False
+
+
+# ── check_atp_geometry_floor ───────────────────────────────────────────
+
+
+def _atp_tally_record(**counts):
+    fields = {"point": 0, "line_string": 0, "polygon": 0, "multi_point": 0, "multi_line_string": 0, "multi_polygon": 0, "geometry_collection": 0}
+    fields.update(counts)
+    return {"message": "import_atp: alltheplaces.parquet geometry types", "fields": fields}
+
+
+def test_check_atp_geometry_floor_passes_above_floor():
+    records = [_atp_tally_record(point=1000)]
+    result = v.check_atp_geometry_floor(records, min_features=500)
+    assert result.passed is True
+
+
+def test_check_atp_geometry_floor_fails_below_floor():
+    records = [_atp_tally_record(point=10)]
+    result = v.check_atp_geometry_floor(records, min_features=500)
+    assert result.passed is False
+
+
+def test_check_atp_geometry_floor_skips_when_no_floor_given():
+    records = [_atp_tally_record(point=10)]
+    result = v.check_atp_geometry_floor(records, min_features=None)
+    assert result.passed is None
+
+
+def test_check_atp_geometry_floor_fails_when_record_missing():
+    result = v.check_atp_geometry_floor([], min_features=500)
+    assert result.passed is False
+
+
+# ── run_hard_checks (integration) ─────────────────────────────────────
+
+
+def test_run_hard_checks_returns_all_checks_in_order(tmp_path, monkeypatch):
+    monkeypatch.setattr(v.subprocess, "run", lambda *a, **k: type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})())
+    con, url = make_parquet(tmp_path, VALID_ROW_SQL, kv_metadata={"org.cyclonedx.bom": _bom()})
+    records = [
+        {"level": "INFO", "message": "conflate: start", "fields": {"step": "conflate", "phase": "start"}},
+        _conflate_end(cgroup_current_bytes=1000, cgroup_max_bytes=4 * 1024**3),
+        _atp_tally_record(point=1000),
+    ]
+    results = v.run_hard_checks(
+        con, url, records, dmesg_text="", mem_limit="4g", expect_pipeline_version=None, min_atp_features=500
+    )
+    assert [r.name for r in results] == [
+        "non-empty output",
+        "schema",
+        "atp/atp_geometry null-consistency",
+        "osm/osm_geometry null-consistency",
+        "osm_geometry validity",
+        "provenance BOM",
+        "run completed",
+        "cgroup signal",
+        "no OOM",
+        "ATP geometry floor",
+    ]
+    assert all(r.passed for r in results)

--- a/scripts/test-branch-on-hetzner/validate.py
+++ b/scripts/test-branch-on-hetzner/validate.py
@@ -1,0 +1,350 @@
+"""Hard validation checks for a completed `cloud_test.py start
+--containerized` run: `conflated.parquet` (read straight off the S3 test
+bucket via DuckDB) and the downloaded `pipeline.log`/`dmesg.log`, checked
+against the invariants `docs/outputs/CONFLATED_PARQUET.md` and
+`src/pipeline/logging.rs`/`src/pipeline/mod.rs` document. Implements the
+"Validation checks (`validate`)" section of issue #722's plan.
+
+Two tiers, per that plan -- this module is the **hard** tier only:
+checks that can't legitimately vary run-to-run (a schema break is a
+schema break, regardless of what today's real-world data looks like), so
+`cmd_validate` in `cloud_test.py` exits non-zero if any of them fail. The
+**advisory** tier (match rate, memory distribution -- content-shaped
+signals expected to drift as real data and matching logic evolve) is a
+separate, later addition; see the plan's "Advisory checks" section.
+
+Kept a separate module rather than folded into `cloud_test.py` itself --
+that file is already sizeable, and this logic (DuckDB queries, JSONL log
+parsing) is independently testable against small local fixtures without
+needing any of `cloud_test.py`'s VM/SSH machinery.
+"""
+
+import json
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+import duckdb
+
+PARQUET_KEY = "conflated.parquet"
+
+# The struct field *names* docs/outputs/CONFLATED_PARQUET.md documents
+# for each nested column -- kept in sync by hand with that doc, the same
+# as any other two hand-maintained descriptions of one contract (e.g.
+# CONTRIBUTING.md's `!`-marker paragraph and RELEASING.md's own). Checked
+# as a set of names, not full types: robust to DuckDB rendering a
+# logically-unchanged type slightly differently (e.g. TIMESTAMP vs
+# TIMESTAMP WITH TIME ZONE) while still catching an added, removed, or
+# renamed field -- e.g. this is exactly what would have caught
+# `changeset` if #731 had removed it from the writer and forgotten the
+# doc, or vice versa.
+EXPECTED_TOP_LEVEL = {"atp", "atp_geometry", "osm", "osm_geometry"}
+EXPECTED_ATP_FIELDS = {"tags", "fetched"}
+EXPECTED_ATP_FETCHED_FIELDS = {"timestamp", "spider"}
+EXPECTED_OSM_FIELDS = {"type", "id", "tags", "modified", "way_members", "relation_members"}
+EXPECTED_OSM_MODIFIED_FIELDS = {"timestamp", "version"}
+EXPECTED_RELATION_MEMBER_FIELDS = {"type", "id", "role"}
+
+# The CycloneDX spec version docs/outputs/CONFLATED_PARQUET.md and
+# src/pipeline/provenance.rs both currently target.
+CYCLONEDX_SPEC_VERSION = "1.7"
+
+BYTE_UNITS = {"b": 1, "k": 1024, "m": 1024**2, "g": 1024**3}
+
+
+@dataclass
+class CheckResult:
+    """One check's outcome. `passed=None` means skipped (e.g. the
+    cgroup-limit check when `--mem-limit` wasn't passed to `validate`) --
+    printed and counted separately from an actual pass or fail."""
+
+    name: str
+    passed: bool | None
+    message: str
+
+
+def parse_byte_size(text):
+    """Parses a podman `--memory=` value (e.g. "4g", "512m",
+    "2147483648") into a plain integer number of bytes -- the same
+    binary-suffix convention podman/docker's `--memory` flag uses
+    (`b`/`k`/`m`/`g`, 1024-based), matching what `cgroup_max_bytes`
+    actually reads back after `podman run --memory=4g` (empirically
+    confirmed during the #711 cloud smoke test: 4g -> 4294967296)."""
+    text = text.strip().lower()
+    if text and text[-1] in BYTE_UNITS:
+        return int(text[:-1]) * BYTE_UNITS[text[-1]]
+    return int(text)
+
+
+def parquet_url(bucket_name):
+    return f"s3://{bucket_name}/{PARQUET_KEY}"
+
+
+def connect(bucket_region, access_key, secret_key):
+    """A DuckDB connection with `httpfs` configured against Hetzner
+    Object Storage, and `spatial` loaded for `ST_IsValid`. Extensions are
+    downloaded from DuckDB's official extension repository on first use
+    -- this machine already needs network access for everything else
+    `cloud_test.py` does."""
+    con = duckdb.connect()
+    con.execute("INSTALL httpfs")
+    con.execute("LOAD httpfs")
+    con.execute("INSTALL spatial")
+    con.execute("LOAD spatial")
+    con.execute("SET s3_endpoint = ?", [f"{bucket_region}.your-objectstorage.com"])
+    con.execute("SET s3_region = ?", [bucket_region])
+    con.execute("SET s3_url_style = 'path'")
+    con.execute("SET s3_access_key_id = ?", [access_key])
+    con.execute("SET s3_secret_access_key = ?", [secret_key])
+    return con
+
+
+def read_pipeline_log(path):
+    """Parses `pipeline.log` (JSON lines -- see `src/pipeline/logging.rs`)
+    into a list of records, each `{"timestamp", "level", "target",
+    "message", "fields": {...}}` ("fields" omitted on records with no
+    structured key-values attached)."""
+    records = []
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                records.append(json.loads(line))
+    return records
+
+
+def find_step_record(records, step, phase):
+    """The record for `step`'s `phase` ("start" or "end"), as logged by
+    `run_step`/`log_snapshot` (`src/pipeline/mod.rs`). `None` if missing
+    -- e.g. because the step never finished."""
+    for r in records:
+        fields = r.get("fields", {})
+        if fields.get("step") == step and fields.get("phase") == phase:
+            return r
+    return None
+
+
+def struct_field_names(duckdb_type):
+    return {name for name, _ in duckdb_type.children}
+
+
+def list_element_type(duckdb_type):
+    # See validate.py's tests for why this shape: a LIST's only child is
+    # named "child" and holds the element type, empirically confirmed
+    # against this project's own DuckDB version.
+    return duckdb_type.children[0][1]
+
+
+def check_nonempty(con, url):
+    count = con.execute("SELECT count(*) FROM read_parquet(?)", [url]).fetchone()[0]
+    return CheckResult("non-empty output", count > 0, f"{count} rows")
+
+
+def check_schema(con, url):
+    rel = con.sql("SELECT * FROM read_parquet($1)", params=[url])
+    columns = set(rel.columns)
+    if columns != EXPECTED_TOP_LEVEL:
+        return CheckResult(
+            "schema", False, f"top-level columns {sorted(columns)} != {sorted(EXPECTED_TOP_LEVEL)}"
+        )
+    types = dict(zip(rel.columns, rel.types))
+
+    atp_fields = struct_field_names(types["atp"])
+    if atp_fields != EXPECTED_ATP_FIELDS:
+        return CheckResult("schema", False, f"atp fields {sorted(atp_fields)} != {sorted(EXPECTED_ATP_FIELDS)}")
+    atp_children = dict(types["atp"].children)
+    fetched_fields = struct_field_names(atp_children["fetched"])
+    if fetched_fields != EXPECTED_ATP_FETCHED_FIELDS:
+        return CheckResult(
+            "schema",
+            False,
+            f"atp.fetched fields {sorted(fetched_fields)} != {sorted(EXPECTED_ATP_FETCHED_FIELDS)}",
+        )
+
+    osm_fields = struct_field_names(types["osm"])
+    if osm_fields != EXPECTED_OSM_FIELDS:
+        return CheckResult("schema", False, f"osm fields {sorted(osm_fields)} != {sorted(EXPECTED_OSM_FIELDS)}")
+    osm_children = dict(types["osm"].children)
+    modified_fields = struct_field_names(osm_children["modified"])
+    if modified_fields != EXPECTED_OSM_MODIFIED_FIELDS:
+        return CheckResult(
+            "schema",
+            False,
+            f"osm.modified fields {sorted(modified_fields)} != {sorted(EXPECTED_OSM_MODIFIED_FIELDS)}",
+        )
+    relation_member_fields = struct_field_names(list_element_type(osm_children["relation_members"]))
+    if relation_member_fields != EXPECTED_RELATION_MEMBER_FIELDS:
+        return CheckResult(
+            "schema",
+            False,
+            f"osm.relation_members fields {sorted(relation_member_fields)} "
+            f"!= {sorted(EXPECTED_RELATION_MEMBER_FIELDS)}",
+        )
+    return CheckResult("schema", True, "matches docs/outputs/CONFLATED_PARQUET.md")
+
+
+def check_null_consistency(con, url, struct_col, geom_col):
+    n = con.execute(
+        f"SELECT count(*) FROM read_parquet(?) WHERE ({struct_col} IS NULL) != ({geom_col} IS NULL)",
+        [url],
+    ).fetchone()[0]
+    return CheckResult(f"{struct_col}/{geom_col} null-consistency", n == 0, f"{n} mismatched rows")
+
+
+def check_geometry_validity(con, url):
+    n = con.execute(
+        "SELECT count(*) FROM read_parquet(?) "
+        "WHERE osm_geometry IS NOT NULL AND NOT ST_IsValid(ST_GeomFromWKB(osm_geometry))",
+        [url],
+    ).fetchone()[0]
+    return CheckResult("osm_geometry validity", n == 0, f"{n} invalid geometries")
+
+
+def check_provenance_bom(con, url, expect_pipeline_version):
+    row = con.execute(
+        "SELECT decode(value) FROM parquet_kv_metadata(?) WHERE key::VARCHAR = 'org.cyclonedx.bom'",
+        [url],
+    ).fetchone()
+    if row is None:
+        return CheckResult("provenance BOM", False, "no org.cyclonedx.bom key in Parquet metadata")
+    bom_json = row[0]
+
+    with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+        f.write(bom_json)
+        bom_path = f.name
+    try:
+        # Same tool this repo already validates its container SBOM with
+        # -- see .github/workflows/test-container.yml.
+        result = subprocess.run(
+            [
+                "podman",
+                "run",
+                "--rm",
+                "--volume",
+                f"{Path(bom_path).parent}:/artifacts:ro",
+                "cyclonedx/cyclonedx-cli",
+                "validate",
+                "--input-file",
+                f"/artifacts/{Path(bom_path).name}",
+                "--fail-on-errors",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    finally:
+        Path(bom_path).unlink()
+    if result.returncode != 0:
+        return CheckResult("provenance BOM", False, f"cyclonedx-cli: {result.stdout}{result.stderr}")
+
+    bom = json.loads(bom_json)
+    spec_version = bom.get("specVersion")
+    if spec_version != CYCLONEDX_SPEC_VERSION:
+        return CheckResult(
+            "provenance BOM", False, f"specVersion {spec_version!r} != {CYCLONEDX_SPEC_VERSION!r}"
+        )
+    if expect_pipeline_version:
+        actual = bom.get("metadata", {}).get("tools", {}).get("components", [{}])[0].get("version")
+        if actual != expect_pipeline_version:
+            return CheckResult(
+                "provenance BOM",
+                False,
+                f"pipeline_version {actual!r} != expected {expect_pipeline_version!r}",
+            )
+    return CheckResult("provenance BOM", True, "valid CycloneDX, spec version matches")
+
+
+def check_run_completed(records):
+    end = find_step_record(records, "conflate", "end")
+    if end is None:
+        return CheckResult("run completed", False, "no conflate/end record in pipeline.log")
+    start = find_step_record(records, "conflate", "start")
+    start_index = records.index(start) if start else 0
+    errors = [
+        r for r in records[start_index:] if r.get("level") == "ERROR"
+    ]
+    if errors:
+        messages = "; ".join(r["message"] for r in errors)
+        return CheckResult("run completed", False, f"{len(errors)} ERROR record(s): {messages}")
+    return CheckResult("run completed", True, "conflate/end reached with no ERROR records")
+
+
+def check_cgroup_signal(records, mem_limit):
+    end = find_step_record(records, "conflate", "end")
+    if end is None:
+        return CheckResult("cgroup signal", False, "no conflate/end record in pipeline.log")
+    fields = end.get("fields", {})
+    current = fields.get("cgroup_current_bytes")
+    maximum = fields.get("cgroup_max_bytes")
+    if current is None or maximum is None:
+        return CheckResult(
+            "cgroup signal",
+            False,
+            "cgroup_current_bytes/cgroup_max_bytes are null -- this run wasn't containerized "
+            "under a real cgroup memory limit",
+        )
+    if mem_limit is not None:
+        expected = parse_byte_size(mem_limit)
+        if maximum != expected:
+            return CheckResult(
+                "cgroup signal", False, f"cgroup_max_bytes={maximum} != --mem-limit {mem_limit} ({expected} bytes)"
+            )
+    return CheckResult("cgroup signal", True, f"cgroup_current_bytes={current} cgroup_max_bytes={maximum}")
+
+
+# Kernel log phrasing this checks for, across dmesg's and journalctl's
+# slightly different wordings for the same event -- both mention
+# "out of memory" and "kill" on the offending line either way.
+OOM_SIGNATURES = ("out of memory", "oom-kill", "oom_kill", "killed process")
+
+
+def check_no_oom(dmesg_text):
+    hits = [
+        line
+        for line in dmesg_text.splitlines()
+        if any(sig in line.lower() for sig in OOM_SIGNATURES)
+    ]
+    if hits:
+        return CheckResult("no OOM", False, f"{len(hits)} OOM-looking kernel log line(s): {hits[0]}")
+    return CheckResult("no OOM", True, "no OOM-kill signature in dmesg/journalctl -k")
+
+
+def check_atp_geometry_floor(records, min_features):
+    record = next(
+        (
+            r
+            for r in records
+            if r.get("message") == "import_atp: alltheplaces.parquet geometry types"
+        ),
+        None,
+    )
+    if record is None:
+        return CheckResult("ATP geometry floor", False, "no import_atp geometry-tally record in pipeline.log")
+    fields = record.get("fields", {})
+    types = ("point", "line_string", "polygon", "multi_point", "multi_line_string", "multi_polygon", "geometry_collection")
+    total = sum(fields.get(t, 0) for t in types)
+    if min_features is None:
+        return CheckResult("ATP geometry floor", None, f"{total} ATP geometries imported (no --min-atp-features given)")
+    if total < min_features:
+        return CheckResult("ATP geometry floor", False, f"only {total} ATP geometries imported, expected >= {min_features}")
+    return CheckResult("ATP geometry floor", True, f"{total} ATP geometries imported")
+
+
+def run_hard_checks(con, url, records, dmesg_text, mem_limit, expect_pipeline_version, min_atp_features):
+    """Runs every hard check and returns the list of `CheckResult`s, in
+    the order printed. Doesn't short-circuit on the first failure --
+    `cmd_validate` wants the full picture in one pass, not a
+    fix-one-rerun-find-the-next loop."""
+    return [
+        check_nonempty(con, url),
+        check_schema(con, url),
+        check_null_consistency(con, url, "atp", "atp_geometry"),
+        check_null_consistency(con, url, "osm", "osm_geometry"),
+        check_geometry_validity(con, url),
+        check_provenance_bom(con, url, expect_pipeline_version),
+        check_run_completed(records),
+        check_cgroup_signal(records, mem_limit),
+        check_no_oom(dmesg_text),
+        check_atp_geometry_floor(records, min_atp_features),
+    ]


### PR DESCRIPTION
## What

Adds the `validate` subcommand from issue #722's plan -- the last major piece of that plan. Runs hard pass/fail checks against a completed `start --containerized` run's `conflated.parquet` (read straight off the S3 test bucket via DuckDB) and its downloaded `pipeline.log`/`dmesg.log`:

- non-empty output, schema matches `docs/outputs/CONFLATED_PARQUET.md` (checked as struct field *names*, not full types -- robust to DuckDB rendering an unchanged type slightly differently, while still catching an added/removed/renamed field -- e.g. this is exactly what would have caught `changeset` if #731 had only updated one of the writer/doc)
- `atp`/`atp_geometry` and `osm`/`osm_geometry` null-consistency
- `osm_geometry` validity (`ST_IsValid`)
- provenance BOM present, valid per `cyclonedx-cli` (same tool `test-container.yml` already uses), and its `pipeline_version` matches `--expect-pipeline-version` if given
- `conflate` step reached `phase=end` with no `ERROR` records logged after `phase=start`
- `cgroup_current_bytes`/`cgroup_max_bytes` populated on that record (proof the run was actually containerized under a real cgroup -- impossible for a bare-VM run), matching `--mem-limit` if given -- the core #711 signal
- no OOM-kill signature in `dmesg.log` (an OOM-killed step's own log record is simply missing, not an error entry -- `logs` is extended to also pull `dmesg`/`journalctl -k` output for this, since it can't be recovered after the VM is gone otherwise)
- `import_atp`'s geometry tally is at or above `--min-atp-features`, if given (skipped, not silently passed, without it)

Advisory checks (match rate, memory distribution -- content-shaped signals expected to legitimately drift as real data and matching logic evolve) are deliberately left for a follow-up PR, per the plan's two-tier design.

## Why a separate `validate.py` module

`cloud_test.py` is already sizeable, and this logic (DuckDB queries, JSONL log parsing) is naturally independent of any of `cloud_test.py`'s VM/SSH machinery -- splitting it out keeps it testable against small local fixtures with zero network/Hetzner/podman mocking needed for most checks.

## Testing

38 new pytest tests in `tests/test_validate.py`, run via `uv run pytest` from `scripts/`. These build real Parquet fixtures on the fly (via DuckDB's own `COPY TO ... KV_METADATA` support) and run real DuckDB queries against them, rather than mocking the query engine -- only the one check that shells out (`check_provenance_bom`'s `cyclonedx-cli` call) mocks `subprocess.run`.

Also manually smoke-tested the full `cmd_validate` wiring end-to-end against a local fixture (pointing DuckDB at a local file instead of S3): confirmed the pass path prints all-PASS and returns normally, and confirmed the failure path -- including a real (unmocked) `podman run cyclonedx/cyclonedx-cli validate` call against a deliberately-invalid BOM -- correctly fails that check and `sys.exit`s non-zero.

`uvx ruff check` on the changed/new files shows no new findings beyond the 5 pre-existing `PLW1510` ones already on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)