### PR TITLE
feat: add advisory checks to `validate`

### DIFF
--- a/scripts/test-branch-on-hetzner/README.md
+++ b/scripts/test-branch-on-hetzner/README.md
@@ -206,15 +206,34 @@ broken, not just that today's data looks different from yesterday's:
   without it, since there's no universal floor that makes sense across
   every run.
 
+`validate` also prints a set of **advisory** checks -- content-shaped
+signals that are expected to drift as real data and matching logic
+evolve, so they're never grounds for a fixed pass/fail, only reported
+for a human to eyeball:
+
+- Conflation match rate -- skipped (not silently passed) if
+  `--regional-extract` is given, since AllThePlaces is worldwide and a
+  regional OSM extract will show ~0% match outside its region by
+  design, not by defect.
+- `rss_file_bytes` vs `rss_anon_bytes`/`rss_shmem_bytes` on the
+  `conflate` step -- the mmap/page-cache design's own signal (#711);
+  large `rss_shmem_bytes` is flagged as a likely tmpfs-workdir
+  misconfiguration worth a look.
+- Any 85%-of-cgroup-limit `WARN` the pipeline already self-logs.
+- Disk headroom, from the downloaded `disk.log`.
+- Wall-clock timings per step, from `pipeline.log`'s own
+  `elapsed_seconds` fields.
+- OSM geometry count (matched features only) from `conflate.write`'s
+  tally.
+
 `--bucket-name`/`--bucket-region` point `validate` at the same test
 bucket `start --containerized --bucket-name ...` uploaded to;
 `--pipeline-log` (and, if not alongside it, `--dmesg-log`) point at a
-local directory `logs` already downloaded to. Standalone-runnable
+local directory `logs` already downloaded to; `--regional-extract`
+should match whatever `start` was given, if anything. Standalone-runnable
 against any past run this way, even after its VM has been `destroy`ed.
-Exits non-zero if any hard check fails. **Content-shaped** signals
-(match rate, memory distribution -- expected to drift as real data and
-matching logic evolve) aren't part of this yet; see issue #722's plan
-for the deferred advisory-check tier.
+Exits non-zero if any hard check fails -- advisory checks never affect
+the exit code.
 
 ## Making sense of the logs
 

--- a/scripts/test-branch-on-hetzner/README.md
+++ b/scripts/test-branch-on-hetzner/README.md
@@ -215,9 +215,10 @@ for a human to eyeball:
   `--regional-extract` is given, since AllThePlaces is worldwide and a
   regional OSM extract will show ~0% match outside its region by
   design, not by defect.
-- `rss_file_bytes` vs `rss_anon_bytes`/`rss_shmem_bytes` on the
-  `conflate` step -- the mmap/page-cache design's own signal (#711);
-  large `rss_shmem_bytes` is flagged as a likely tmpfs-workdir
+- `rss_file_bytes` vs `rss_anon_bytes`/`rss_shmem_bytes` at peak, from
+  the periodic `conflate.match: progress` snapshots logged during
+  matching -- the mmap/page-cache design's own signal (#711); large
+  `rss_shmem_bytes` is flagged as a likely tmpfs-workdir
   misconfiguration worth a look.
 - Any 85%-of-cgroup-limit `WARN` the pipeline already self-logs.
 - Disk headroom, from the downloaded `disk.log`.

--- a/scripts/test-branch-on-hetzner/cloud_test.py
+++ b/scripts/test-branch-on-hetzner/cloud_test.py
@@ -511,12 +511,13 @@ def cmd_bucket_destroy(args):
 
 
 def cmd_validate(args):
-    """Runs `validate.py`'s hard checks against a completed run's
-    `conflated.parquet` (read straight from the S3 test bucket) and a
-    locally downloaded `pipeline.log`/`dmesg.log` (see `logs`).
-    Standalone -- doesn't touch the VM at all, so it works just as well
-    against a run whose server has already been `destroy`ed."""
-    dmesg_path = Path(args.dmesg_log) if args.dmesg_log else Path(args.pipeline_log).with_name("dmesg.log")
+    """Runs `validate.py`'s hard + advisory checks against a completed
+    run's `conflated.parquet` (read straight from the S3 test bucket)
+    and a locally downloaded `pipeline.log`/`dmesg.log`/`disk.log` (see
+    `logs`). Standalone -- doesn't touch the VM at all, so it works just
+    as well against a run whose server has already been `destroy`ed."""
+    pipeline_log = Path(args.pipeline_log)
+    dmesg_path = Path(args.dmesg_log) if args.dmesg_log else pipeline_log.with_name("dmesg.log")
     if not dmesg_path.exists():
         print(
             f"Warning: {dmesg_path} not found -- run `logs` first if you haven't; "
@@ -524,13 +525,15 @@ def cmd_validate(args):
             file=sys.stderr,
         )
     dmesg_text = dmesg_path.read_text() if dmesg_path.exists() else ""
-    records = validate.read_pipeline_log(args.pipeline_log)
+    disk_log_path = pipeline_log.with_name("disk.log")
+    disk_log_text = disk_log_path.read_text() if disk_log_path.exists() else ""
+    records = validate.read_pipeline_log(pipeline_log)
 
     access_key, secret_key = s3_credentials()
     con = validate.connect(args.bucket_region, access_key, secret_key)
     url = validate.parquet_url(args.bucket_name)
 
-    results = validate.run_hard_checks(
+    hard_results = validate.run_hard_checks(
         con,
         url,
         records,
@@ -539,12 +542,20 @@ def cmd_validate(args):
         args.expect_pipeline_version,
         args.min_atp_features,
     )
+    advisory_results = validate.run_advisory_checks(
+        con, url, records, disk_log_text, args.regional_extract
+    )
 
     print("\nHard checks:")
     failed = False
-    for r in results:
+    for r in hard_results:
         status = "SKIP" if r.passed is None else ("PASS" if r.passed else "FAIL")
         failed = failed or r.passed is False
+        print(f"  [{status}] {r.name}: {r.message}")
+
+    print("\nAdvisory (informational, never fails validate):")
+    for r in advisory_results:
+        status = "SKIP" if r.passed is None else "INFO"
         print(f"  [{status}] {r.name}: {r.message}")
 
     if failed:
@@ -711,6 +722,12 @@ def main():
     )
     p_validate.add_argument(
         "--dmesg-log", help="local path to a downloaded dmesg.log (default: alongside --pipeline-log)"
+    )
+    p_validate.add_argument(
+        "--regional-extract",
+        help="the --regional-extract the run was started with, if any -- skips the advisory "
+        "match-rate check (a regional OSM extract won't match ATP's worldwide data outside "
+        "its region, by design)",
     )
     p_validate.add_argument(
         "--mem-limit",

--- a/scripts/test-branch-on-hetzner/tests/test_validate.py
+++ b/scripts/test-branch-on-hetzner/tests/test_validate.py
@@ -405,6 +405,26 @@ def test_check_memory_distribution_no_note_when_shmem_below_file():
     assert "tmpfs" not in result.message
 
 
+def _match_progress(**fields):
+    return {"message": "conflate.match: progress", "fields": fields}
+
+
+def test_check_memory_distribution_prefers_peak_progress_record_over_conflate_end():
+    records = [
+        _match_progress(rss_bytes=100, rss_file_bytes=50, rss_anon_bytes=50, rss_shmem_bytes=0),
+        _match_progress(rss_bytes=900, rss_file_bytes=800, rss_anon_bytes=100, rss_shmem_bytes=0),
+        _conflate_end(rss_file_bytes=1, rss_anon_bytes=1, rss_shmem_bytes=1),
+    ]
+    result = v.check_memory_distribution(records)
+    assert "rss_file_bytes=800" in result.message
+
+
+def test_check_memory_distribution_falls_back_to_conflate_end_without_progress_records():
+    records = [_conflate_end(rss_file_bytes=800, rss_anon_bytes=200, rss_shmem_bytes=0)]
+    result = v.check_memory_distribution(records)
+    assert "rss_file_bytes=800" in result.message
+
+
 def test_check_cgroup_warnings_lists_hits():
     records = [
         {"level": "WARN", "fields": {"step": "conflate", "phase": "end", "cgroup_usage_fraction": 0.9}},

--- a/scripts/test-branch-on-hetzner/tests/test_validate.py
+++ b/scripts/test-branch-on-hetzner/tests/test_validate.py
@@ -365,3 +365,91 @@ def test_run_hard_checks_returns_all_checks_in_order(tmp_path, monkeypatch):
         "ATP geometry floor",
     ]
     assert all(r.passed for r in results)
+
+
+# ── advisory checks ─────────────────────────────────────────────────
+#
+# Leaner than the hard-check tests above: one test per piece of actual
+# logic (rate/ratio math, last-sample parsing, summing), not one per
+# trivial branch -- these checks never fail validate, so a wrong
+# CheckResult.passed value isn't the risk here; a wrong *number* is.
+
+
+def test_check_match_rate_skips_for_regional_extract(tmp_path):
+    con, url = make_parquet(tmp_path, VALID_ROW_SQL)
+    result = v.check_match_rate(con, url, regional_extract="europe/switzerland")
+    assert result.passed is None
+    assert "skipped" in result.message
+
+
+def test_check_match_rate_computes_ratio(tmp_path):
+    # One matched row (VALID_ROW_SQL) plus one ATP-only (unmatched) row,
+    # built by nulling out osm/osm_geometry on a second copy of it.
+    sql = f"{VALID_ROW_SQL} UNION ALL SELECT atp, atp_geometry, NULL, NULL FROM ({VALID_ROW_SQL})"
+    con, url = make_parquet(tmp_path, sql)
+    result = v.check_match_rate(con, url, regional_extract=None)
+    assert result.passed is True
+    assert "1/2 rows matched (50.0%)" in result.message
+
+
+def test_check_memory_distribution_reports_ratio_and_flags_shmem():
+    records = [_conflate_end(rss_file_bytes=800, rss_anon_bytes=200, rss_shmem_bytes=900)]
+    result = v.check_memory_distribution(records)
+    assert "ratio=4.00" in result.message
+    assert "tmpfs" in result.message
+
+
+def test_check_memory_distribution_no_note_when_shmem_below_file():
+    records = [_conflate_end(rss_file_bytes=800, rss_anon_bytes=200, rss_shmem_bytes=10)]
+    result = v.check_memory_distribution(records)
+    assert "tmpfs" not in result.message
+
+
+def test_check_cgroup_warnings_lists_hits():
+    records = [
+        {"level": "WARN", "fields": {"step": "conflate", "phase": "end", "cgroup_usage_fraction": 0.9}},
+        {"level": "INFO", "fields": {"step": "conflate", "phase": "end"}},
+    ]
+    result = v.check_cgroup_warnings(records)
+    assert "1 logged" in result.message
+    assert "conflate/end=90%" in result.message
+
+
+def test_check_cgroup_warnings_reports_none_when_absent():
+    result = v.check_cgroup_warnings([{"level": "INFO", "fields": {}}])
+    assert result.message == "none logged"
+
+
+def test_check_disk_headroom_parses_last_sample():
+    text = "2026-01-01 00:00:00 100 900\n2026-01-01 00:00:05 200 800\n"
+    result = v.check_disk_headroom(text)
+    assert "used=200 avail=800 (20.0% full)" in result.message
+
+
+def test_check_timings_sums_elapsed():
+    records = [
+        {"fields": {"step": "import_atp", "phase": "end", "elapsed_seconds": 10.0}},
+        {"fields": {"step": "conflate", "phase": "end", "elapsed_seconds": 20.5}},
+        {"fields": {"step": "conflate", "phase": "start", "elapsed_seconds": None}},
+    ]
+    result = v.check_timings(records)
+    assert "total=30.5s" in result.message
+
+
+def test_check_osm_geometry_count_sums_tally():
+    records = [{"message": "conflate.write: osm_geometry geometry types", "fields": {"point": 5, "polygon": 3}}]
+    result = v.check_osm_geometry_count(records)
+    assert "8 matched OSM geometries" in result.message
+
+
+def test_run_advisory_checks_returns_all_in_order(tmp_path):
+    con, url = make_parquet(tmp_path, VALID_ROW_SQL)
+    results = v.run_advisory_checks(con, url, records=[], disk_log_text="", regional_extract=None)
+    assert [r.name for r in results] == [
+        "match rate",
+        "memory distribution",
+        "cgroup 85% warnings",
+        "disk headroom",
+        "timings",
+        "OSM geometry count",
+    ]

--- a/scripts/test-branch-on-hetzner/validate.py
+++ b/scripts/test-branch-on-hetzner/validate.py
@@ -5,13 +5,19 @@ against the invariants `docs/outputs/CONFLATED_PARQUET.md` and
 `src/pipeline/logging.rs`/`src/pipeline/mod.rs` document. Implements the
 "Validation checks (`validate`)" section of issue #722's plan.
 
-Two tiers, per that plan -- this module is the **hard** tier only:
-checks that can't legitimately vary run-to-run (a schema break is a
-schema break, regardless of what today's real-world data looks like), so
-`cmd_validate` in `cloud_test.py` exits non-zero if any of them fail. The
-**advisory** tier (match rate, memory distribution -- content-shaped
-signals expected to drift as real data and matching logic evolve) is a
-separate, later addition; see the plan's "Advisory checks" section.
+Two tiers, per that plan:
+
+- **Hard** checks (`run_hard_checks`) can't legitimately vary run-to-run
+  (a schema break is a schema break, regardless of what today's
+  real-world data looks like) -- `cmd_validate` in `cloud_test.py` exits
+  non-zero if any of them fail.
+- **Advisory** checks (`run_advisory_checks`) are content-shaped signals
+  (match rate, memory distribution) expected to drift as real data and
+  matching logic evolve -- reported prominently, never fail the run.
+  `CheckResult.passed` is always `True` for these except when a check is
+  genuinely inapplicable (`None`, e.g. match rate on a
+  `--regional-extract` run) -- there's no "fail" outcome to report by
+  design.
 
 Kept a separate module rather than folded into `cloud_test.py` itself --
 that file is already sizeable, and this logic (DuckDB queries, JSONL log
@@ -329,6 +335,104 @@ def check_atp_geometry_floor(records, min_features):
     if total < min_features:
         return CheckResult("ATP geometry floor", False, f"only {total} ATP geometries imported, expected >= {min_features}")
     return CheckResult("ATP geometry floor", True, f"{total} ATP geometries imported")
+
+
+def check_match_rate(con, url, regional_extract):
+    if regional_extract:
+        # AllThePlaces is always worldwide -- a regional OSM extract
+        # shows ~0% match outside its region by design, not by defect.
+        return CheckResult("match rate", None, "skipped (regional extract)")
+    total, matched = con.execute(
+        "SELECT count(*), count(*) FILTER (WHERE atp IS NOT NULL AND osm IS NOT NULL) "
+        "FROM read_parquet(?)",
+        [url],
+    ).fetchone()
+    rate = matched / total if total else 0.0
+    return CheckResult("match rate", True, f"{matched}/{total} rows matched ({rate:.1%})")
+
+
+def check_memory_distribution(records):
+    # The mmap/page-cache design's own signal (#711): the "conflate" step
+    # is the only one with fine-grained enough logging to read this from
+    # -- there's no separate "conflate.match" log_snapshot record, just a
+    # progress-bar label (src/pipeline/conflate/mod.rs), so the step's
+    # own end-of-step snapshot is the closest available granularity.
+    end = find_step_record(records, "conflate", "end")
+    fields = end.get("fields", {}) if end else {}
+    file_bytes = fields.get("rss_file_bytes")
+    anon_bytes = fields.get("rss_anon_bytes")
+    shmem_bytes = fields.get("rss_shmem_bytes")
+    if file_bytes is None or anon_bytes is None:
+        return CheckResult("memory distribution", True, "rss_file_bytes/rss_anon_bytes unavailable")
+    ratio = file_bytes / anon_bytes if anon_bytes else float("inf")
+    note = ""
+    if shmem_bytes and shmem_bytes > file_bytes:
+        note = " -- rss_shmem_bytes exceeds rss_file_bytes, worth a look for a tmpfs workdir misconfiguration"
+    return CheckResult(
+        "memory distribution",
+        True,
+        f"rss_file_bytes={file_bytes} rss_anon_bytes={anon_bytes} rss_shmem_bytes={shmem_bytes} "
+        f"(file/anon ratio={ratio:.2f}){note}",
+    )
+
+
+def check_cgroup_warnings(records):
+    # The 85%-of-limit WARN log_snapshot self-logs (CGROUP_WARN_THRESHOLD
+    # in src/pipeline/mod.rs) -- an early signal ahead of an actual
+    # OOM-kill, worth surfacing even on a run that never hit one.
+    hits = [r for r in records if r.get("level") == "WARN" and "cgroup_usage_fraction" in r.get("fields", {})]
+    if not hits:
+        return CheckResult("cgroup 85% warnings", True, "none logged")
+    lines = [
+        f"{r['fields'].get('step')}/{r['fields'].get('phase')}={r['fields']['cgroup_usage_fraction']:.0%}"
+        for r in hits
+    ]
+    return CheckResult("cgroup 85% warnings", True, f"{len(hits)} logged: {', '.join(lines)}")
+
+
+def check_disk_headroom(disk_log_text):
+    # disk.log lines: "YYYY-MM-DD HH:MM:SS <used_bytes> <avail_bytes>"
+    # (remote/monitor.sh's df -B1 --output=used,avail sampling loop).
+    lines = [line for line in disk_log_text.splitlines() if line.strip()]
+    if not lines:
+        return CheckResult("disk headroom", True, "no disk.log samples available")
+    used, avail = (int(x) for x in lines[-1].split()[-2:])
+    total = used + avail
+    fraction = used / total if total else 0.0
+    return CheckResult("disk headroom", True, f"used={used} avail={avail} ({fraction:.1%} full)")
+
+
+def check_timings(records):
+    ends = [r for r in records if r.get("fields", {}).get("phase") == "end" and r["fields"].get("elapsed_seconds") is not None]
+    if not ends:
+        return CheckResult("timings", True, "no step timings available")
+    total = sum(r["fields"]["elapsed_seconds"] for r in ends)
+    per_step = ", ".join(f"{r['fields']['step']}={r['fields']['elapsed_seconds']:.1f}s" for r in ends)
+    return CheckResult("timings", True, f"total={total:.1f}s ({per_step})")
+
+
+def check_osm_geometry_count(records):
+    record = next((r for r in records if r.get("message") == "conflate.write: osm_geometry geometry types"), None)
+    if record is None:
+        return CheckResult("OSM geometry count", True, "no conflate.write osm_geometry tally in pipeline.log")
+    fields = record.get("fields", {})
+    types = ("point", "line_string", "polygon", "multi_point", "multi_line_string", "multi_polygon", "geometry_collection")
+    total = sum(fields.get(t, 0) for t in types)
+    return CheckResult("OSM geometry count", True, f"{total} matched OSM geometries")
+
+
+def run_advisory_checks(con, url, records, disk_log_text, regional_extract):
+    """Runs every advisory check and returns the list of `CheckResult`s,
+    in the order printed. Never fails `validate` by itself -- see the
+    module docstring for why."""
+    return [
+        check_match_rate(con, url, regional_extract),
+        check_memory_distribution(records),
+        check_cgroup_warnings(records),
+        check_disk_headroom(disk_log_text),
+        check_timings(records),
+        check_osm_geometry_count(records),
+    ]
 
 
 def run_hard_checks(con, url, records, dmesg_text, mem_limit, expect_pipeline_version, min_atp_features):

--- a/scripts/test-branch-on-hetzner/validate.py
+++ b/scripts/test-branch-on-hetzner/validate.py
@@ -352,13 +352,24 @@ def check_match_rate(con, url, regional_extract):
 
 
 def check_memory_distribution(records):
-    # The mmap/page-cache design's own signal (#711): the "conflate" step
-    # is the only one with fine-grained enough logging to read this from
-    # -- there's no separate "conflate.match" log_snapshot record, just a
-    # progress-bar label (src/pipeline/conflate/mod.rs), so the step's
-    # own end-of-step snapshot is the closest available granularity.
-    end = find_step_record(records, "conflate", "end")
-    fields = end.get("fields", {}) if end else {}
+    # The mmap/page-cache design's own signal (#711): maybe_log_progress
+    # (src/pipeline/conflate/mod.rs) logs a "conflate.match: progress"
+    # snapshot every 30s *during* matching -- exactly the granularity the
+    # plan asks for, not just the "conflate" step's overall start/end
+    # pair (which would dilute the signal with the write phase too).
+    # Picks the highest-rss_bytes sample rather than the last one, since
+    # page-cache eviction under a tight --mem-limit can make a later
+    # sample read *lower* than an earlier peak. Falls back to the
+    # "conflate" step's own end-of-step snapshot for a run that finishes
+    # matching before the first 30s tick (e.g. a small
+    # --regional-extract smoke test never logs a progress record at
+    # all) -- diluted by the write phase, but better than nothing.
+    progress_records = [r for r in records if r.get("message") == "conflate.match: progress"]
+    if progress_records:
+        record = max(progress_records, key=lambda r: r.get("fields", {}).get("rss_bytes") or 0)
+    else:
+        record = find_step_record(records, "conflate", "end")
+    fields = record.get("fields", {}) if record else {}
     file_bytes = fields.get("rss_file_bytes")
     anon_bytes = fields.get("rss_anon_bytes")
     shmem_bytes = fields.get("rss_shmem_bytes")


### PR DESCRIPTION
## What

Completes issue #722's two-tier `validate` design -- #743 shipped the hard-check tier, this adds the **advisory** tier: content-shaped signals expected to drift as real data and matching logic evolve, so they're reported for a human to eyeball rather than gated on a fixed threshold. Never fail `validate` or affect its exit code.

- conflation match rate -- skipped (not silently passed) for `--regional-extract` runs, since AllThePlaces is worldwide and a regional OSM extract won't match outside its region by design
- `rss_file_bytes` vs `rss_anon_bytes`/`rss_shmem_bytes` at peak, from the periodic `"conflate.match: progress"` snapshots `maybe_log_progress` logs every 30s during matching (`src/pipeline/conflate/mod.rs`) -- the #711 mmap/page-cache signal; flags likely tmpfs-workdir misconfiguration if `rss_shmem_bytes` dominates
- any 85%-of-cgroup-limit `WARN` the pipeline already self-logs
- disk headroom, from `disk.log` (`logs` now also downloads this, alongside `dmesg.log` from #743)
- per-step wall-clock timings, from `pipeline.log`'s own `elapsed_seconds` fields
- matched OSM geometry count, from `conflate.write`'s tally

**Correction, added after review**: an earlier version of this PR read the memory-distribution signal from the `conflate` step's own end-of-step snapshot, on the mistaken belief that `conflate.match` had no log record of its own -- @brawer asked about this directly, and checking the source properly showed that's wrong: there *is* a `"conflate.match: progress"` record, logged every 30s during matching with exactly the fields this check wants, and it's a better signal than the step-end snapshot (which is diluted by the write phase too). Fixed to use the peak-`rss_bytes` sample among those, falling back to the `conflate`-step-end snapshot only for a run that finishes matching before the first 30s tick (e.g. a small `--regional-extract` smoke test).

## Testing

Leaner than #743's hard-check suite -- per your feedback that one was heavy for a hand-run tool. One test per piece of actual logic (rate/ratio math, last-sample `disk.log` parsing, elapsed-time summing, peak-sample selection), not one per trivial branch, since these checks can't fail `validate` by design so a wrong `passed` value isn't the risk -- a wrong *number* is.

Also manually smoke-tested `cmd_validate`'s full output (hard + advisory sections, including a real `"conflate.match: progress"` fixture record) end-to-end against a local fixture. `uvx ruff check` shows no new findings beyond the same 5 pre-existing ones already on `main`.

This closes out #722's `validate` subcommand -- the last piece of that plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)