### PR TITLE
docs: mention regional-extract smoke testing and validate in TESTING.md

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -79,5 +79,9 @@ real hardware before a change lands, not automated gates:
   — full pipeline on real cloud hardware, either built from your
   feature branch or pulled as an already-built image (e.g. a released
   container), optionally run containerized under a real cgroup
-  memory/CPU limit. Costs real money and needs Hetzner credentials —
-  see its README before reaching for it.
+  memory/CPU limit, against a Geofabrik regional extract instead of
+  the full planet for a faster smoke test. Its `validate` subcommand
+  then checks the result (schema, provenance, cgroup behavior, and
+  more) against `docs/outputs/CONFLATED_PARQUET.md`'s own contract.
+  Costs real money and needs Hetzner credentials — see its README
+  before reaching for it.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -79,8 +79,9 @@ real hardware before a change lands, not automated gates:
   — full pipeline on real cloud hardware, either built from your
   feature branch or pulled as an already-built image (e.g. a released
   container), optionally run containerized under a real cgroup
-  memory/CPU limit, against a Geofabrik regional extract instead of
-  the full planet for a faster smoke test. Its `validate` subcommand
+  memory/CPU limit, against a
+  [Geofabrik](https://download.geofabrik.de/) regional extract instead
+  of the full planet for a faster smoke test. Its `validate` subcommand
   then checks the result (schema, provenance, cgroup behavior, and
   more) against `docs/outputs/CONFLATED_PARQUET.md`'s own contract.
   Costs real money and needs Hetzner credentials — see its README


### PR DESCRIPTION
## What

Extends the existing `scripts/test-branch-on-hetzner/` bullet in `docs/TESTING.md`'s "For Large System Changes" section with a brief mention of two capabilities added across #722/#743/#744: smoke-testing against a Geofabrik regional extract instead of the full planet, and the `validate` subcommand that checks the result.

Kept deliberately brief -- just enough for someone scanning `TESTING.md` to know this exists and roughly what it covers, not a duplicate of `scripts/test-branch-on-hetzner/README.md`'s own detail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)