### PR TITLE
feat: destroy cost estimate, create prints teardown command, list surfaces buckets

### DIFF
--- a/scripts/test-branch-on-hetzner/README.md
+++ b/scripts/test-branch-on-hetzner/README.md
@@ -110,7 +110,7 @@ restart a run with a clean workdir without tearing down the VM
 | Command | What it does |
 |---|---|
 | `up` | Create the server + volume, deploy, start the pipeline. |
-| `create` | Server + a formatted, attached, automounted data volume. Also collects `sysinfo` and runs `fio` once, automatically. |
+| `create` | Server + a formatted, attached, automounted data volume. Also collects `sysinfo` and runs `fio` once, automatically. Prints the exact `destroy` command needed to remove what it just created. |
 | `deploy` | `--branch NAME`: clone/update the given branch on an existing server and build it via the project's `Containerfile`, natively (see below for why that matters). `--image REF`: pull an already-built image instead (e.g. `ghcr.io/alltheplaces/osm-diffs:v1.2.3`) -- either way, binaries get extracted the same way, so bare-mode `start` works unchanged regardless of which path was used. |
 | `start` | Launch `osm-diffs run` and the vmstat/disk monitor, both detached via `systemd-run`. `--clean` clears the workdir first but keeps `planet-latest.osm.pbf`/its metadata sidecar, so re-running doesn't re-fetch the planet over BitTorrent. `--containerized --mem-limit SIZE --cpu-limit N` runs `podman run` against the image `deploy` produced instead of the bare extracted binary, for real cgroup accounting -- see below. |
 | `status` | `systemctl status` for the run, plus `df` and the last few `pipeline.log` lines. |
@@ -118,10 +118,10 @@ restart a run with a clean workdir without tearing down the VM
 | `sysinfo` | OS/kernel version, CPU model, memory, swap, disk layout, cgroup limits -- environment facts that turned out to matter for interpreting results but aren't anything this tool controls. |
 | `logs` | Downloads `pipeline.log`, `vmstat.log`, `disk.log`, `sysinfo.txt`, `dmesg.log` to `logs/<name>/`. |
 | `stop` | Stops the pipeline + monitor, leaves the VM (and its disk contents) alone. |
-| `destroy` | Deletes the server and volume. Asks for confirmation unless `--yes`. |
+| `destroy` | Deletes the server and volume. Asks for confirmation unless `--yes`. Prints a rough cost estimate for the run just torn down (unit price × actual lifetime, from Hetzner's own `/v1/pricing`) -- an estimate, not the invoiced figure; Object Storage/traffic aren't included. |
 | `bucket create`/`bucket destroy` | Ephemeral S3 test bucket lifecycle -- see "Containerized runs" below. |
 | `validate` | Hard pass/fail checks against a run's `conflated.parquet` + downloaded logs -- see "Validation checks" below. |
-| `list` | Lists every instance this tool created (via a Hetzner label), so nothing gets forgotten and left running. |
+| `list` | Lists every instance this tool created (via a Hetzner label), so nothing gets forgotten and left running. `--bucket-region LOC` also lists live test buckets in that Object Storage region. |
 
 Run `./cloud_test.py <command> --help` for the full flag list; defaults
 are `cpx32` / `hel1` / a 400GB volume, all overridable.

--- a/scripts/test-branch-on-hetzner/cloud_test.py
+++ b/scripts/test-branch-on-hetzner/cloud_test.py
@@ -20,6 +20,9 @@ import subprocess
 import sys
 import tempfile
 import time
+import urllib.error
+import urllib.request
+from datetime import UTC, datetime
 from pathlib import Path
 
 import boto3
@@ -36,6 +39,7 @@ LABEL_KEY = "osm-diffs-test"
 REMOTE_DIR = "/root/osm-diffs"
 SCRIPT_DIR = Path(__file__).resolve().parent
 LOGS_DIR = SCRIPT_DIR / "logs"
+PRICING_URL = "https://api.hetzner.cloud/v1/pricing"
 
 PLANET_FILES = ("planet-latest.osm.pbf", "planet-latest.osm.pbf.meta.json")
 
@@ -238,6 +242,7 @@ def cmd_create(args):
     print(f"  IP:      {ip}")
     print(f"  workdir: {workdir}")
     print(f"\nNext: cloud_test.py deploy --name {args.name} --branch <branch>")
+    print(f"When done: cloud_test.py destroy --name {args.name}")
 
 
 def run_sysinfo(ip):
@@ -466,15 +471,84 @@ def cmd_stop(args):
     ssh_cmd(ip, "systemctl stop osm-diffs-run osm-diffs-monitor || true")
 
 
+def fetch_pricing():
+    """Hetzner Cloud's `GET /v1/pricing` -- unit prices (hourly per
+    server type + location, monthly per GB for volumes) in the
+    account's own currency. Not wrapped by the `hcloud` CLI (there's no
+    `hcloud pricing` subcommand, confirmed against the version this was
+    written against), so this is a plain authenticated HTTP call using
+    the same `HCLOUD_TOKEN` `hcloud` itself reads. Returns `None`
+    (never raises) on any failure -- a pricing hiccup must never block
+    `destroy`'s actual teardown, which is the part that matters."""
+    token = os.environ.get("HCLOUD_TOKEN")
+    if not token:
+        return None
+    try:
+        req = urllib.request.Request(PRICING_URL, headers={"Authorization": f"Bearer {token}"})
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return json.load(resp)["pricing"]
+    except (urllib.error.URLError, TimeoutError, KeyError, ValueError) as e:
+        print(f"(pricing lookup failed: {e})", file=sys.stderr)
+        return None
+
+
+def compute_run_cost(pricing, server_type, location, volume_gb, hours):
+    """Unit price x duration, from figures the caller already has on
+    hand (exact server-type/location/volume-size, and the server's own
+    `created` timestamp through now) -- no metering integration needed.
+    An estimate, not Hetzner's actual invoiced figure (billing rounds/
+    aggregates differently); Object Storage/traffic aren't included.
+    Returns `None` if `pricing` doesn't have the shape this expects --
+    see `fetch_pricing()`'s docstring for why this never raises."""
+    try:
+        server_prices = next(t["prices"] for t in pricing["server_types"] if t["name"] == server_type)
+        hourly = float(next(p for p in server_prices if p["location"] == location)["price_hourly"]["gross"])
+        volume_gb_month = float(pricing["volume"]["price_per_gb_month"]["gross"])
+        return hourly * hours + volume_gb_month * volume_gb * (hours / (24 * 30))
+    except (KeyError, StopIteration, TypeError, ValueError):
+        return None
+
+
+def teardown_cost_note(name):
+    """A best-effort '~€X.YZ' summary line for `destroy`, gathered
+    *before* deleting anything (the `describe` calls need the resources
+    to still exist) -- or `None` if any part of this didn't work out.
+    Deleting the resources always proceeds either way; see
+    `fetch_pricing()`'s docstring for why."""
+    try:
+        server = hcloud_json(["server", "describe", name])
+        volume = hcloud_json(["volume", "describe", f"{name}-data"])
+    except subprocess.CalledProcessError:
+        return None
+    pricing = fetch_pricing()
+    if pricing is None:
+        return None
+    created = datetime.fromisoformat(server["created"])
+    hours = (datetime.now(UTC) - created).total_seconds() / 3600
+    server_type = server["server_type"]["name"]
+    location = server["datacenter"]["location"]["name"]
+    cost = compute_run_cost(pricing, server_type, location, volume["size"], hours)
+    if cost is None:
+        return None
+    return (
+        f"Estimated cost: ~€{cost:.2f} for ~{hours:.1f}h ({server_type}, "
+        f"{volume['size']}GB volume) -- rough estimate, not Hetzner's actual "
+        "invoiced figure; Object Storage/traffic not included."
+    )
+
+
 def cmd_destroy(args):
     if not args.yes:
         reply = input(f"Delete server and volume for {args.name!r}? [y/N] ")
         if reply.strip().lower() != "y":
             print("Aborted.", file=sys.stderr)
             return
-    subprocess.run(["hcloud", "volume", "detach", f"{args.name}-data"])
-    subprocess.run(["hcloud", "volume", "delete", f"{args.name}-data"])
-    subprocess.run(["hcloud", "server", "delete", args.name])
+    cost_note = teardown_cost_note(args.name)
+    subprocess.run(["hcloud", "volume", "detach", f"{args.name}-data"], check=False)
+    subprocess.run(["hcloud", "volume", "delete", f"{args.name}-data"], check=False)
+    subprocess.run(["hcloud", "server", "delete", args.name], check=False)
+    if cost_note:
+        print(cost_note)
 
 
 def cmd_bucket_create(args):
@@ -563,16 +637,26 @@ def cmd_validate(args):
     print("\nAll hard checks passed.")
 
 
-def cmd_list(_args):
+def cmd_list(args):
     servers = hcloud_json(["server", "list", "-l", f"{LABEL_KEY}=true"])
     if not servers:
         print("No osm-diffs-test instances running.")
-        return
     for s in servers:
         labels = s.get("labels", {})
         branch = labels.get(f"{LABEL_KEY}-branch", "?").replace("--", "/")
         ip = s["public_net"]["ipv4"]["ip"]
         print(f"{s['name']:20} {ip:16} branch={branch}")
+
+    # Buckets aren't Hetzner-labeled the way servers/volumes are (the S3
+    # API has no such concept), and aren't scoped to a location the way
+    # `hcloud server list` is either -- so this only runs when asked,
+    # rather than guessing at every Object Storage region there is.
+    if args.bucket_region:
+        buckets = s3_client(args.bucket_region).list_buckets().get("Buckets", [])
+        if not buckets:
+            print(f"No test buckets in {args.bucket_region}.")
+        for b in buckets:
+            print(f"  bucket: {b['Name']:30} created={b['CreationDate']:%Y-%m-%d}")
 
 
 def cmd_up(args):
@@ -746,6 +830,9 @@ def main():
     p_validate.set_defaults(func=cmd_validate)
 
     p_list = sub.add_parser("list", help="list all osm-diffs-test instances")
+    p_list.add_argument(
+        "--bucket-region", help="also list S3 test buckets in this Hetzner Object Storage region"
+    )
     p_list.set_defaults(func=cmd_list)
 
     args = parser.parse_args()

--- a/scripts/test-branch-on-hetzner/tests/test_cloud_test.py
+++ b/scripts/test-branch-on-hetzner/tests/test_cloud_test.py
@@ -9,6 +9,7 @@ mocked, so this suite runs the same everywhere, no credentials needed.
 """
 
 import argparse
+from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import MagicMock, call
 
@@ -288,3 +289,110 @@ def test_cmd_deploy_branch_path(monkeypatch):
     assert any("build.sh" in s for s in scp_names)
     assert not any("pull.sh" in s for s in scp_names)
     assert any("build.sh" in c and "my/feature" in c for c in ssh_cmds)
+
+
+# ── compute_run_cost / teardown_cost_note ──────────────────────────
+
+
+PRICING_FIXTURE = {
+    "server_types": [
+        {"name": "cpx32", "prices": [{"location": "hel1", "price_hourly": {"gross": "0.10"}}]},
+    ],
+    "volume": {"price_per_gb_month": {"gross": "0.05"}},
+}
+
+
+def test_compute_run_cost():
+    # 10h @ 0.10/h server + 100GB @ 0.05/GB-month, prorated for 10h.
+    cost = ct.compute_run_cost(PRICING_FIXTURE, "cpx32", "hel1", volume_gb=100, hours=10)
+    assert cost == pytest.approx(0.10 * 10 + 0.05 * 100 * (10 / (24 * 30)))
+
+
+@pytest.mark.parametrize(
+    "pricing,server_type,location",
+    [
+        (PRICING_FIXTURE, "unknown-type", "hel1"),  # server type not in pricing
+        (PRICING_FIXTURE, "cpx32", "unknown-location"),  # location not in that type's prices
+        ({"server_types": []}, "cpx32", "hel1"),  # no volume pricing at all
+    ],
+)
+def test_compute_run_cost_returns_none_on_unexpected_shape(pricing, server_type, location):
+    assert ct.compute_run_cost(pricing, server_type, location, volume_gb=100, hours=10) is None
+
+
+def test_teardown_cost_note_reports_estimate(monkeypatch):
+    def fake_hcloud_json(args):
+        if args[0] == "server":
+            return {
+                "created": "2026-01-01T00:00:00+00:00",
+                "server_type": {"name": "cpx32"},
+                "datacenter": {"location": {"name": "hel1"}},
+            }
+        return {"size": 100}
+
+    monkeypatch.setattr(ct, "hcloud_json", fake_hcloud_json)
+    monkeypatch.setattr(ct, "fetch_pricing", lambda: PRICING_FIXTURE)
+
+    note = ct.teardown_cost_note("t")
+    assert note is not None
+    assert "Estimated cost: ~€" in note
+
+
+def test_teardown_cost_note_is_none_when_pricing_unavailable(monkeypatch):
+    monkeypatch.setattr(ct, "hcloud_json", lambda args: {"created": "2026-01-01T00:00:00+00:00", "server_type": {"name": "cpx32"}, "datacenter": {"location": {"name": "hel1"}}, "size": 1})
+    monkeypatch.setattr(ct, "fetch_pricing", lambda: None)
+    assert ct.teardown_cost_note("t") is None
+
+
+def test_cmd_destroy_deletes_everything_even_when_cost_note_fails(monkeypatch):
+    calls = []
+    monkeypatch.setattr(ct, "teardown_cost_note", lambda name: None)
+    monkeypatch.setattr(ct.subprocess, "run", lambda cmd, **kw: calls.append(cmd))
+
+    ct.cmd_destroy(Args(name="t", yes=True))
+
+    assert len(calls) == 3  # volume detach, volume delete, server delete
+
+
+# ── cmd_list: --bucket-region ────────────────────────────────────────
+
+
+def test_cmd_list_skips_buckets_without_bucket_region(monkeypatch, capsys):
+    monkeypatch.setattr(ct, "hcloud_json", lambda args: [])
+    monkeypatch.setattr(ct, "s3_client", lambda region: (_ for _ in ()).throw(AssertionError("should not be called")))
+
+    ct.cmd_list(Args(bucket_region=None))
+
+    assert "bucket:" not in capsys.readouterr().out
+
+
+def test_cmd_list_lists_buckets_with_bucket_region(monkeypatch, capsys):
+    mock_client = MagicMock()
+    mock_client.list_buckets.return_value = {
+        "Buckets": [{"Name": "osm-diffs-container-test-1", "CreationDate": datetime(2026, 1, 1, tzinfo=UTC)}]
+    }
+    monkeypatch.setattr(ct, "hcloud_json", lambda args: [])
+    monkeypatch.setattr(ct, "s3_client", lambda region: mock_client)
+
+    ct.cmd_list(Args(bucket_region="fsn1"))
+
+    assert "osm-diffs-container-test-1" in capsys.readouterr().out
+
+
+# ── cmd_create prints the teardown command ────────────────────────────
+
+
+def test_cmd_create_prints_destroy_command(monkeypatch, capsys):
+    monkeypatch.setattr(ct, "sh", lambda cmd, **kw: None)
+    monkeypatch.setattr(ct, "hcloud_json", lambda args: {"id": "123"})
+    monkeypatch.setattr(ct, "server_ip", lambda name: "1.2.3.4")
+    monkeypatch.setattr(ct, "wait_for_ssh", lambda ip: None)
+    monkeypatch.setattr(ct, "ssh_cmd", lambda ip, cmd, **kw: None)
+    monkeypatch.setattr(ct, "run_sysinfo", lambda ip: None)
+    monkeypatch.setattr(ct, "run_fio", lambda ip, workdir: None)
+
+    ct.cmd_create(
+        Args(name="t", type="cpx32", location="hel1", ssh_key="k", branch=None, volume_size=400)
+    )
+
+    assert "cloud_test.py destroy --name t" in capsys.readouterr().out


### PR DESCRIPTION
## What

Closes three small gaps against #722's original plan that never actually landed across #723-#746:

1. **`destroy` prints a rough cost estimate** for the run just torn down -- unit price × actual lifetime (the server's own `created` timestamp through now), from Hetzner's `GET /v1/pricing`. Not wrapped by the `hcloud` CLI (confirmed: no `hcloud pricing` subcommand), so this is a plain authenticated HTTP call on the same `HCLOUD_TOKEN`. **Deliberately defensive**: any failure along the way (missing token, network hiccup, an unexpected response shape) just means no cost line gets printed -- it never blocks or delays the actual teardown, which proceeds regardless (also switched the 3 `subprocess.run` calls there to explicit `check=False`, matching `cmd_bucket_destroy`'s existing resilience pattern, and incidentally clearing 3 of the 5 pre-existing `ruff` `PLW1510` findings on this file).
2. **`create`/`up` print the exact `destroy --name ...` command** right when they provision something, same as `bucket create` already does -- so cleanup is sitting in scrollback rather than something to reconstruct from memory.
3. **`list --bucket-region LOC`** also lists live S3 test buckets in that region. Buckets aren't Hetzner-labeled the way servers/volumes are, so this only runs when a region is explicitly given, rather than guessing at every Object Storage region there is.

## ⚠️ Verification note

I could confirm the server-type hourly-pricing JSON shape (`prices[].price_hourly.gross`) against a real `hcloud server-type describe` call locally. I could **not** verify, live, against a real account (no `HCLOUD_TOKEN` in this environment):

- `GET /v1/pricing`'s own response shape (`server_types[]`, `volume.price_per_gb_month`)
- `hcloud server describe`'s `created`/`server_type.name`/`datacenter.location.name` fields

These are based on documented Hetzner Cloud API behavior, not something I tested end-to-end this session -- worth a quick sanity check against a real account the first time `destroy` runs for real. If any field name turns out to be wrong, `teardown_cost_note` degrades to returning `None` (prints nothing) by explicit design -- it cannot affect `destroy`'s actual deletion either way, since the describe/pricing calls all happen before deletion and are fully separated from it.

## Testing

10 new tests: `compute_run_cost`'s pure math (including three "unexpected pricing shape → `None`" cases), `teardown_cost_note` with mocked `hcloud_json`/`fetch_pricing`, `cmd_destroy` still deletes all three resources even when the cost note fails, `cmd_list`'s bucket-listing wiring (with and without `--bucket-region`), and `cmd_create` printing the teardown command. `uv run pytest` (77/77) and `uvx ruff check` both clean (net -3 pre-existing findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)