### PR TITLE
fix: teardown_cost_note crashed cmd_destroy before deleting anything

### DIFF
--- a/scripts/test-branch-on-hetzner/cloud_test.py
+++ b/scripts/test-branch-on-hetzner/cloud_test.py
@@ -513,21 +513,27 @@ def teardown_cost_note(name):
     """A best-effort '~€X.YZ' summary line for `destroy`, gathered
     *before* deleting anything (the `describe` calls need the resources
     to still exist) -- or `None` if any part of this didn't work out.
-    Deleting the resources always proceeds either way; see
-    `fetch_pricing()`'s docstring for why."""
+    Deleting the resources always proceeds either way -- the whole body
+    is one try/except on purpose, not just the two `describe` calls:
+    the first version of this function only wrapped those, and a wrong
+    field-name assumption while parsing their *result* (`datacenter` ->
+    `location`, caught live against a real account) raised straight out
+    of `cmd_destroy` and skipped deletion entirely. That must never
+    happen again regardless of what turns out to be wrong next time --
+    see `fetch_pricing()`'s docstring for the same rule applied there."""
     try:
         server = hcloud_json(["server", "describe", name])
         volume = hcloud_json(["volume", "describe", f"{name}-data"])
-    except subprocess.CalledProcessError:
+        pricing = fetch_pricing()
+        if pricing is None:
+            return None
+        created = datetime.fromisoformat(server["created"])
+        hours = (datetime.now(UTC) - created).total_seconds() / 3600
+        server_type = server["server_type"]["name"]
+        location = server["location"]["name"]
+        cost = compute_run_cost(pricing, server_type, location, volume["size"], hours)
+    except (subprocess.CalledProcessError, KeyError, TypeError, ValueError):
         return None
-    pricing = fetch_pricing()
-    if pricing is None:
-        return None
-    created = datetime.fromisoformat(server["created"])
-    hours = (datetime.now(UTC) - created).total_seconds() / 3600
-    server_type = server["server_type"]["name"]
-    location = server["datacenter"]["location"]["name"]
-    cost = compute_run_cost(pricing, server_type, location, volume["size"], hours)
     if cost is None:
         return None
     return (

--- a/scripts/test-branch-on-hetzner/tests/test_cloud_test.py
+++ b/scripts/test-branch-on-hetzner/tests/test_cloud_test.py
@@ -320,14 +320,26 @@ def test_compute_run_cost_returns_none_on_unexpected_shape(pricing, server_type,
     assert ct.compute_run_cost(pricing, server_type, location, volume_gb=100, hours=10) is None
 
 
+def _fake_server_describe(**overrides):
+    # Field shapes taken from hcloud-go's schema/server.go, not guessed
+    # -- see the 2026-08-21 incident this fixture exists to prevent a
+    # repeat of: `location` sits directly on the server object, *not*
+    # nested under a `datacenter` key (that assumption shipped once,
+    # untested against a real account, and crashed `cmd_destroy` before
+    # it deleted anything).
+    fields = {
+        "created": "2026-01-01T00:00:00+00:00",
+        "server_type": {"name": "cpx32"},
+        "location": {"name": "hel1"},
+    }
+    fields.update(overrides)
+    return fields
+
+
 def test_teardown_cost_note_reports_estimate(monkeypatch):
     def fake_hcloud_json(args):
         if args[0] == "server":
-            return {
-                "created": "2026-01-01T00:00:00+00:00",
-                "server_type": {"name": "cpx32"},
-                "datacenter": {"location": {"name": "hel1"}},
-            }
+            return _fake_server_describe()
         return {"size": 100}
 
     monkeypatch.setattr(ct, "hcloud_json", fake_hcloud_json)
@@ -339,8 +351,25 @@ def test_teardown_cost_note_reports_estimate(monkeypatch):
 
 
 def test_teardown_cost_note_is_none_when_pricing_unavailable(monkeypatch):
-    monkeypatch.setattr(ct, "hcloud_json", lambda args: {"created": "2026-01-01T00:00:00+00:00", "server_type": {"name": "cpx32"}, "datacenter": {"location": {"name": "hel1"}}, "size": 1})
+    monkeypatch.setattr(ct, "hcloud_json", lambda args: _fake_server_describe(size=1))
     monkeypatch.setattr(ct, "fetch_pricing", lambda: None)
+    assert ct.teardown_cost_note("t") is None
+
+
+def test_teardown_cost_note_is_none_on_unexpected_response_shape(monkeypatch):
+    """The actual 2026-08-21 incident, reproduced: `hcloud_json`/
+    `fetch_pricing` both return *something*, but not the shape the
+    parsing code expects (any KeyError/TypeError while reading it) --
+    must degrade to None, not raise out of `cmd_destroy` before it
+    deletes anything."""
+
+    def fake_hcloud_json(args):
+        if args[0] == "server":
+            return _fake_server_describe(location={"unexpected_key": "hel1"})
+        return {"size": 100}
+
+    monkeypatch.setattr(ct, "hcloud_json", fake_hcloud_json)
+    monkeypatch.setattr(ct, "fetch_pricing", lambda: PRICING_FIXTURE)
     assert ct.teardown_cost_note("t") is None
 
 


### PR DESCRIPTION
## What

Caught live during the first real smoke test today (2026-08-21). #747's cost-estimate feature had a real bug that meant `cloud_test.py destroy --name smoke-ch --yes` **crashed before deleting anything**:

```
KeyError: 'datacenter'
  File ".../cloud_test.py", line 529, in teardown_cost_note
    location = server["datacenter"]["location"]["name"]
```

Confirmed against `hcloud-go`'s actual `schema/server.go`: `location` sits directly on the server object, not nested under a `datacenter` key. That part alone would have been a quick one-line fix -- but the real problem is structural: only the two `describe` calls were wrapped in `try/except`, not the field access that followed, so this `KeyError` propagated straight out of `cmd_destroy` before it ran a single deletion command. That's exactly the failure mode `teardown_cost_note`'s own docstring said it was designed to avoid ("a pricing hiccup must never block destroy's actual teardown"). Had to tear down the VM by hand via plain `hcloud` commands while diagnosing this.

## Fix

The whole body of `teardown_cost_note` is now one `try/except (subprocess.CalledProcessError, KeyError, TypeError, ValueError)` -- covering both the `describe` calls *and* everything read from their result -- so a similarly wrong assumption about some other field can never again block deletion, regardless of what turns out to be wrong next time.

Also: fixes the field name itself, adds a regression test that reproduces the actual incident (a response shape missing the expected key -- verifies `teardown_cost_note` returns `None` rather than raising), and corrects the two existing tests' fixtures -- which had encoded the exact same wrong `datacenter`-nesting assumption the code made, so they couldn't have caught this before it shipped.

## Testing

`uv run pytest` (78/78) and `uvx ruff check` clean (same 2 pre-existing findings as `main`). Also manually verified `teardown_cost_note` against the real, confirmed API response shape (`hcloud-go`'s schema, not guessed) -- produces a sensible estimate without crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)