### PR TITLE
fix: check_geometry_validity failed against real output

### DIFF
--- a/scripts/test-branch-on-hetzner/tests/test_validate.py
+++ b/scripts/test-branch-on-hetzner/tests/test_validate.py
@@ -28,7 +28,7 @@ SELECT
         'tags': MAP(['shop'], ['bakery']),
         'fetched': {'timestamp': TIMESTAMP '2026-01-01 00:00:00', 'spider': 'example_spider'}
     } AS atp,
-    ST_AsWKB(ST_Point(8.5, 47.4))::BLOB AS atp_geometry,
+    ST_Point(8.5, 47.4) AS atp_geometry,
     {
         'type': 'node',
         'id': 12345::UBIGINT,
@@ -37,14 +37,20 @@ SELECT
         'way_members': NULL::UBIGINT[],
         'relation_members': NULL::STRUCT("type" VARCHAR, id UBIGINT, "role" VARCHAR)[]
     } AS osm,
-    ST_AsWKB(ST_Point(8.5, 47.4))::BLOB AS osm_geometry
+    ST_Point(8.5, 47.4) AS osm_geometry
 """
+# Native GEOMETRY, not WKB bytes cast to BLOB: docs/outputs/CONFLATED_PARQUET.md
+# documents atp_geometry/osm_geometry as WKB, but DuckDB's spatial extension
+# auto-decodes the real column (which carries the native Parquet GEOGRAPHY
+# logical type) straight to GEOMETRY on read -- matching that here, not the
+# documented on-disk representation, is what makes these fixtures behave the
+# same way validate.py's checks see the real file behave.
 
 
 def make_parquet(tmp_path, select_sql, name="conflated.parquet", kv_metadata=None):
     """Writes `select_sql`'s result to a real local Parquet file (loading
-    the `spatial` extension first, since the fixture rows use ST_Point/
-    ST_AsWKB) and returns its path as a `str`, usable directly with
+    the `spatial` extension first, since the fixture rows use ST_Point)
+    and returns its path as a `str`, usable directly with
     `read_parquet()`."""
     con = duckdb.connect()
     con.execute("INSTALL spatial")
@@ -122,9 +128,7 @@ def test_check_nonempty(tmp_path, select_suffix, expected):
     [
         (VALID_ROW_SQL, True),
         (
-            VALID_ROW_SQL.replace(
-                "ST_AsWKB(ST_Point(8.5, 47.4))::BLOB AS atp_geometry,", "NULL::BLOB AS atp_geometry,"
-            ),
+            VALID_ROW_SQL.replace("ST_Point(8.5, 47.4) AS atp_geometry,", "NULL::GEOMETRY AS atp_geometry,"),
             False,
         ),
     ],
@@ -138,15 +142,13 @@ def test_check_null_consistency(tmp_path, sql, expected):
 @pytest.mark.parametrize(
     "geometry_sql,expected",
     [
-        ("ST_AsWKB(ST_Point(8.5, 47.4))::BLOB", True),
+        ("ST_Point(8.5, 47.4)", True),
         # A self-intersecting ("bowtie") polygon -- the textbook invalid geometry.
-        ("ST_AsWKB(ST_GeomFromText('POLYGON((0 0, 2 2, 2 0, 0 2, 0 0))'))::BLOB", False),
+        ("ST_GeomFromText('POLYGON((0 0, 2 2, 2 0, 0 2, 0 0))')", False),
     ],
 )
 def test_check_geometry_validity(tmp_path, geometry_sql, expected):
-    sql = VALID_ROW_SQL.replace(
-        "ST_AsWKB(ST_Point(8.5, 47.4))::BLOB AS osm_geometry", f"{geometry_sql} AS osm_geometry"
-    )
+    sql = VALID_ROW_SQL.replace("ST_Point(8.5, 47.4) AS osm_geometry", f"{geometry_sql} AS osm_geometry")
     con, url = make_parquet(tmp_path, sql)
     assert v.check_geometry_validity(con, url).passed is expected
 

--- a/scripts/test-branch-on-hetzner/validate.py
+++ b/scripts/test-branch-on-hetzner/validate.py
@@ -199,9 +199,17 @@ def check_null_consistency(con, url, struct_col, geom_col):
 
 
 def check_geometry_validity(con, url):
+    # osm_geometry is documented (docs/outputs/CONFLATED_PARQUET.md) as
+    # plain WKB bytes, but DuckDB's spatial extension auto-decodes it to
+    # a native GEOMETRY value on read -- the column carries the native
+    # Parquet GEOGRAPHY logical type annotation (see
+    # pipeline::conflate::writer's own doc comment for why), which
+    # `read_parquet` recognizes once `spatial` is loaded. No
+    # ST_GeomFromWKB() needed (or accepted -- it only takes BLOB, and
+    # this is already GEOMETRY).
     n = con.execute(
         "SELECT count(*) FROM read_parquet(?) "
-        "WHERE osm_geometry IS NOT NULL AND NOT ST_IsValid(ST_GeomFromWKB(osm_geometry))",
+        "WHERE osm_geometry IS NOT NULL AND NOT ST_IsValid(osm_geometry)",
         [url],
     ).fetchone()[0]
     return CheckResult("osm_geometry validity", n == 0, f"{n} invalid geometries")


### PR DESCRIPTION
## What

Caught live during the first fully successful smoke-test run of #722's whole chain: `ST_GeomFromWKB(osm_geometry)` crashed with

```
_duckdb.BinderException: Binder Error: No function matches the given name and argument types 'st_geomfromwkb(GEOMETRY)'.
```

`docs/outputs/CONFLATED_PARQUET.md` documents `osm_geometry` as plain WKB bytes, but the real column carries the native Parquet GEOGRAPHY logical type -- DuckDB's spatial extension auto-decodes that straight to a native `GEOMETRY` value on read, once loaded. `ST_GeomFromWKB` expects `BLOB` input, so calling it on an already-`GEOMETRY` value was never going to work. Fix: call `ST_IsValid` directly, no conversion needed.

## Why this shipped undetected through #743/#744

The test fixtures constructed `atp_geometry`/`osm_geometry` via `ST_AsWKB(...)::BLOB` -- a column type real osm-diffs output never actually has. Updated fixtures to use native `GEOMETRY` (`ST_Point(...)` directly), matching reality, which is exactly what would have caught this before it shipped.

## Testing

`uv run pytest` (78/78) and `uvx ruff check` clean. Verified against the real completed run this was found on: `validate` now passes cleanly end-to-end -- 1,731,159 rows, every hard check green. First fully successful run of the whole #722 chain (built from `main`, containerized, `--regional-extract europe/switzerland`, real cgroup limits, real S3 upload).

🤖 Generated with [Claude Code](https://claude.com/claude-code)