### PR TITLE
docs: document reliance on Mozilla's CA trust store, not the OS's

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -8,6 +8,8 @@ We prefer that you use the [GitHub mechanism for privately reporting a vulnerabi
 
 For how we secure the release process itself — build provenance, SBOMs, signed attestations — see [`SUPPLY_CHAIN_SECURITY.md`](https://github.com/alltheplaces/osm-diffs/blob/main/docs/SUPPLY_CHAIN_SECURITY.md).
 
+Our container has no OS at all — so there's no OS trust store to verify outbound TLS connections against, either. See `SUPPLY_CHAIN_SECURITY.md`'s ["Certificate trust"](https://github.com/alltheplaces/osm-diffs/blob/main/docs/SUPPLY_CHAIN_SECURITY.md#certificate-trust) section for what we do instead.
+
 We also run [SAST](https://en.wikipedia.org/wiki/Static_application_security_testing) via [GitHub CodeQL](https://codeql.github.com/) on every change, enforced by branch protection on `main` — see [`TESTING.md`](https://github.com/alltheplaces/osm-diffs/blob/main/docs/TESTING.md) for details.
 
 We also publish an [OSSF Scorecard](https://scorecard.dev/viewer/?uri=github.com/alltheplaces/osm-diffs) analysis on every push to `main` (badge in the [README](https://github.com/alltheplaces/osm-diffs#readme)). Its "Vulnerabilities" check reports known, already-public advisories in our dependencies (RUSTSEC/OSV) — the same ones [Dependabot](https://github.com/alltheplaces/osm-diffs/network/updates) already opens PRs for. A nonzero score there isn't a new finding and doesn't need private disclosure; check [open pull requests](https://github.com/alltheplaces/osm-diffs/pulls) for the fix already in progress.

--- a/docs/SUPPLY_CHAIN_SECURITY.md
+++ b/docs/SUPPLY_CHAIN_SECURITY.md
@@ -59,6 +59,22 @@ Mechanically, a multi-architecture image is just an
 image per platform. Pulling by tag automatically fetches the right one
 for your machine.
 
+## Certificate trust
+
+Because we ship `FROM scratch` (see “Minimal containers” above),
+there’s no `/etc/ssl` in the final image either — no OS-provided CA
+trust store to fall back on for verifying a TLS server’s certificate.
+Rather than adding one, `osm-diffs` embeds Mozilla’s own CA root
+bundle directly into the binary at compile time, via the
+[`webpki-roots`](https://github.com/rustls/webpki-roots) crate (see
+`main.rs`’s `build_client()`) — the same trust store
+[Firefox ships and verifies against](https://wiki.mozilla.org/CA),
+independent of whatever the underlying OS or container happens to
+trust. Certificate verification this way doesn’t depend on anything
+present in the container at all, and behaves identically across every
+platform it runs on. This is also declared as an explicit, queryable
+fact in the CBOM — see below.
+
 ## Bill of Materials (BOM)
 
 A Bill of Materials is a structured, machine-readable record of what

--- a/scripts/sbom/pipeline.jq
+++ b/scripts/sbom/pipeline.jq
@@ -117,13 +117,25 @@ else . end |
 .metadata.component.licenses = [{expression: "MIT"}] |
 .components |= [ .[] | add_supplier ] |
 
-# Declare that we only use TLS 1.3, with the AWS BoringSSL fork.
+# Declare that we only use TLS 1.3, with the AWS BoringSSL fork, and
+# that certificate verification trusts Mozilla's own CA root bundle --
+# vendored at compile time via the webpki-roots crate (already listed
+# as an ordinary library component below, since cargo-cyclonedx walks
+# Cargo.lock) -- rather than any OS/container-provided trust store.
+# Not modeled as a CycloneDX "certificate" cryptographic-asset: that
+# type's cryptoProperties (subjectName, issuerName, notValidBefore/
+# After, ...) describe a single certificate, not a curated bundle of
+# ~140 unrelated root CAs -- these properties record the same fact a
+# security auditor would otherwise have to infer from webpki-roots's
+# free-text description, as a directly queryable field instead, same
+# as the crypto:tls:* properties already do for the TLS version.
 .metadata.component.properties += [
-  {name: "cdx:cbom:version",      value: "1.0"},
   {name: "crypto:tls:library",    value: "rustls"},
   {name: "crypto:tls:backend",    value: "aws-lc-rs"},
   {name: "crypto:tls:minVersion", value: "1.3"},
-  {name: "crypto:tls:maxVersion", value: "1.3"}
+  {name: "crypto:tls:maxVersion", value: "1.3"},
+  {name: "crypto:catrust:source", value: "Mozilla CA Certificate Program (via webpki-roots)"},
+  {name: "crypto:catrust:osTrustStoreUsed", value: "false"}
 ] |
 .formulation = [{
     "bom-ref": "build-formulation",

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,8 +56,6 @@ fn build_client() -> reqwest::Client {
     let mut root_store = RootCertStore::empty();
     root_store.extend(TLS_SERVER_ROOTS.iter().cloned());
 
-    // Install the crypto provider as process-wide default,
-    // which makes librqbit use it as well for BitTorrent.
     let provider = rustls::crypto::aws_lc_rs::default_provider();
 
     let config = ClientConfig::builder_with_provider(provider.into())


### PR DESCRIPTION
## Why

#755 removed the last code path (librqbit's internal, unconfigured HTTP client) that ever depended on an OS-provided certificate store -- the only reqwest client left in the codebase already bundles Mozilla's own CA root bundle at compile time via `webpki-roots` (`main.rs`'s `build_client()`), same as it always has. That was never written down anywhere, though, and #754 (bundling `ca-certificates.crt` into the scratch image instead) showed it's easy to reach for "give the container an OS trust store" without realizing there's a deliberate, existing alternative already in place -- closer to what browsers like Firefox do.

## What

- Adds a dedicated "Certificate trust" section to `docs/SUPPLY_CHAIN_SECURITY.md` explaining this -- placed right after the Containers/Minimal containers/Multi-architecture containers sequence (rather than wedged inside "Minimal containers" itself, which would've interrupted that build-topic flow) and right before Bill of Materials/SBOM and CBOM, so it flows straight into where the new CBOM properties (below) live -- plus a short pointer line from `docs/SECURITY.md`, matching that file's existing pattern of one-line routes to more detailed docs, rather than duplicating the explanation there.
- Declares it as an explicit, queryable fact in the CBOM (`scripts/sbom/pipeline.jq`), extending the existing `crypto:tls:*` custom-property convention with `crypto:catrust:source` and `crypto:catrust:osTrustStoreUsed` on the `osm-diffs` component. `webpki-roots` itself already shows up as an ordinary SBOM library component (`cargo-cyclonedx` walks `Cargo.lock`), but that's one dependency among ~390 others -- this makes "what CA trust store does this software use" directly answerable instead of inferred from a dependency's free-text description. Not modeled as a CycloneDX `"certificate"` cryptographic-asset: that type's `cryptoProperties` (`subjectName`, `issuerName`, `notValidBefore`/`After`, ...) describe a single certificate, not a curated bundle of ~140 unrelated root CAs.
- Drops the pre-existing `cdx:cbom:version` property while in here. Checked CycloneDX's actual [property taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy): the `cdx:` namespace is reserved for officially registered CycloneDX properties only, and `cbom` isn't among the registered `cdx` sub-namespaces (`ai-ml`, `composer`, `device`, `esbuild`, `gomod`, `lifecycle`, `maven`, `npm`, `pipenv`, `poetry`, `python`, `rustc`, plus the standalone `cdx:reproducible`). Worse, there's nothing for a "CBOM version" to actually mean: grepped the real [CycloneDX 1.6 JSON schema](https://github.com/CycloneDX/specification) and `"cbom"` appears zero times in it. CBOM isn't a distinct document type with its own version -- it's just a CycloneDX document containing `cryptographic-asset` components (which this file already has, e.g. `crypto/protocol/tls-1.3`). That property was a fossil from before [IBM Research's original, standalone CBOM spec](https://github.com/IBM/CBOM) (which did have its own version number) got absorbed into CycloneDX 1.6 as native `cryptographic-asset` support.
- Drops a stale comment in `build_client()` referencing `librqbit`, which #755 already removed.

Closes #754 (superseded -- its fix only mattered for the code path #755 deleted).

## Testing

`cargo test`/`clippy`/`fmt` clean. Regenerated a dev SBOM locally and validated it with `cyclonedx-cli validate --fail-on-errors` (same check `test-container.yml` runs in CI) -- passes, with the new properties landing on the `osm-diffs` component as expected and `cdx:cbom:version` gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)