### PR TITLE
docs: mention crypto:catrust:* properties in scripts/sbom/README.md

### DIFF
--- a/docs/TECHNICAL_DESIGN.md
+++ b/docs/TECHNICAL_DESIGN.md
@@ -195,20 +195,25 @@ never lost.
 
 ### Pipeline steps
 
-Timings below (where known) are wall-clock numbers from one real
-full-planet run on production-representative hardware — a
-deliberately memory-constrained Hetzner cpx22 (2 vCPU / 4 GB RAM) with
-its working directory on an attached volume that peaked at ~174 GB
-used (settling to ~148 GB once `import_osm` finished), not a dev
-machine; see
+Timings below (where known) come from two real full-planet runs on
+production-representative hardware, not a dev machine: a deliberately
+memory-constrained, bare (uncontainerized) Hetzner cpx22 (2 vCPU / 4 GB
+RAM) with its working directory on an attached volume that peaked at
+~174 GB used (settling to ~148 GB once `import_osm` finished) — see
 [#665](https://github.com/alltheplaces/osm-diffs/issues/665) for the
-full writeup. Nothing aggregates or dashboards these on an ongoing
-basis, but every run's `pipeline.log` — with per-step timings for
-that specific run — is uploaded to S3 alongside its output (see
-`upload_logs` above), so up-to-date numbers are always one log fetch
-away. Treat the ones below as one data point rather than a guarantee
-— worth refreshing occasionally as the planet grows and the code
-changes.
+full writeup — and a later, containerized Hetzner cpx42 (8 vCPU / 16 GB
+RAM, `podman run --memory=12g --cpus=6`), run in the course of
+validating [#722](https://github.com/alltheplaces/osm-diffs/issues/722)
+(and feeding into [#711](https://github.com/alltheplaces/osm-diffs/issues/711)'s
+memory-limit sweep). The two aren't directly comparable — different
+CPU/memory/container configuration — so both are cited below where
+they cover the same step, rather than one silently overwriting the
+other. Nothing aggregates or dashboards these on an ongoing basis, but
+every run's `pipeline.log` — with per-step timings for that specific
+run — is uploaded to S3 alongside its output (see `upload_logs` above),
+so up-to-date numbers are always one log fetch away. Treat the ones
+below as data points rather than a guarantee — worth refreshing
+occasionally as the planet grows and the code changes.
 
 - **`import_atp`** ([`src/pipeline/atp/`](../src/pipeline/atp/)) —
   downloads AllThePlaces’ latest published run (`fetch.rs`) and parses
@@ -225,21 +230,28 @@ changes.
   tracks elsewhere, [#682](https://github.com/alltheplaces/osm-diffs/issues/682));
   not consumed by anything yet. Not separately timed.
 - **`import_osm`** ([`src/pipeline/osm/`](../src/pipeline/osm/)) —
-  downloads the OpenStreetMap planet dump via BitTorrent (`fetch.rs`);
-  does a first pass over it that decides, by tag, which nodes/ways/
-  relations are even worth fully assembling, and which node
-  coordinates and relation members they’ll need (`prune.rs`); builds
-  real OGC geometry (point/line/polygon) for everything kept,
-  resolving ways and relations down through their member nodes as
-  OpenStreetMap’s data model requires (`assemble.rs`; see
-  “Background” above); and writes the result into a memory-mapped
+  downloads the OpenStreetMap planet dump over plain HTTPS (`fetch.rs`;
+  a redirect straight to a well-provisioned cloud object store, not
+  BitTorrent — see [#755](https://github.com/alltheplaces/osm-diffs/pull/755)
+  for why that switch happened); does a first pass over it that
+  decides, by tag, which nodes/ways/relations are even worth fully
+  assembling, and which node coordinates and relation members they’ll
+  need (`prune.rs`); builds real OGC geometry (point/line/polygon) for
+  everything kept, resolving ways and relations down through their
+  member nodes as OpenStreetMap’s data model requires (`assemble.rs`;
+  see “Background” above); and writes the result into a memory-mapped
   spatial index (`OsmFeatureIndex`), queryable by S2 cell range
   without decoding every candidate (`index.rs`,
   [`src/tables/feature_index.rs`](../src/tables/feature_index.rs)).
-  **~4h48m** for the whole step (dominated by the BitTorrent download,
-  which varies with swarm health well beyond this project’s control;
-  `OsmFeatureIndex::create` itself, the compute-heavy part, is only
-  ~26 minutes of that).
+  **~4h48m** for the whole step on the #665 bare-VM run, back when the
+  planet download itself went over BitTorrent and dominated that
+  figure. On the newer, HTTPS-based cpx42 run, the download itself
+  took **~28 minutes** — roughly 10x faster than the old BitTorrent
+  baseline — with the whole step (download + SHA-256 hash + prune/
+  assemble/index-build) completing in **2h24m12s**. The two runs’
+  compute-heavy portions (prune/assemble/index-build) aren’t a clean
+  apples-to-apples comparison, since they ran under different CPU
+  counts and memory limits.
 - **`conflate`**
   ([`src/pipeline/conflate/mod.rs`](../src/pipeline/conflate/mod.rs))
   — a single scan over AllThePlaces (the smaller of the two datasets),
@@ -250,20 +262,28 @@ changes.
   `conflated.parquet`. See
   [`docs/outputs/CONFLATED_PARQUET.md`](outputs/CONFLATED_PARQUET.md)
   for that file’s schema. **~8 minutes** (~5 min matching, ~3 min
-  writing) for 3.8M ATP features against the full planet.
+  writing) for 3.8M ATP features against the full planet, on the #665
+  bare-VM run. **10m37s** (636.95s) on the cpx42 run, writing
+  1,731,159 rows (719,507 matched).
 - **`suggest_edits`** ([`src/pipeline/edits.rs`](../src/pipeline/edits.rs))
   — scans `conflated.parquet` for matched rows and asks an
   [`edit_suggesters`](../src/edit_suggesters/) implementation what
   should change, split into GeoJSON Lines layers by category (shops,
-  infrastructure, trees). Not yet measured at full-planet scale.
+  infrastructure, trees). **~20 seconds** at full-planet scale (cpx42
+  run).
 - **`render_tiles`** ([`src/pipeline/tiles.rs`](../src/pipeline/tiles.rs))
   — runs [tippecanoe](https://github.com/felt/tippecanoe) over those
-  layers to build one PMTiles archive for visual review. Not yet
-  measured at full-planet scale.
-- **`upload_conflated` / `upload_tiles` / `upload_logs`**
+  layers to build one PMTiles archive for visual review. **~2m48s** at
+  full-planet scale (cpx42 run).
+- **`upload_conflated` / `upload_tiles`**
   ([`src/pipeline/upload.rs`](../src/pipeline/upload.rs)) — push the
-  data output, the tiles, and the run’s own log to S3-compatible
-  storage. Not yet measured at full-planet scale.
+  data output and the tiles to S3-compatible storage. **~5.5s** /
+  **~3s** respectively at full-planet scale (cpx42 run). `upload_logs`
+  (same file, pushes the run’s own log) isn’t wrapped by the same
+  per-step timing machinery as the others (see `run_pipeline` in
+  [`src/pipeline/mod.rs`](../src/pipeline/mod.rs)), so it has no
+  comparable number here — it’s a single small JSON file, not
+  expected to be a meaningful cost either way.
 
 ### Why `conflate` doesn’t need its own cache
 
@@ -288,6 +308,25 @@ which shows up as slower wall-clock time, not an out-of-memory kill —
 so it’s not moot even though the memory is “just” cache. A box with
 meaningfully less RAM than the actively-touched working set erodes
 exactly the speed benefit this design exists for.
+
+That reasoning held on the #665 bare VM, but a bare VM has no
+configured cgroup memory limit at all — `cgroup_current_bytes` is
+normally still populated (systemd puts every service unit into its own
+cgroup even outside a container), but `cgroup_max_bytes` reads `None`
+without one; see
+[`src/pipeline/memstats.rs`](../src/pipeline/memstats.rs)'s own doc
+comment. The design’s central bet is specifically about page-cache
+accounting *under* such a limit, which only a real container can
+exercise. The cpx42 run cited above gives a first container data
+point: under a comfortable 12 GB `podman --memory` limit,
+`rss_file_bytes` again dominated during `conflate.match` (11.0 GB of
+11.2 GB total RSS), with no OOM-kill even while `cgroup_current_bytes`
+briefly touched 89–90% of the limit during the later, non-`conflate`
+steps. That’s encouraging, but it’s one comfortable limit, not yet the
+deliberately tight `--mem-limit` sweep
+[#711](https://github.com/alltheplaces/osm-diffs/issues/711) calls for
+to find where the design actually starts to strain — see that issue
+for the current status.
 
 ### Code structure
 

--- a/scripts/sbom/README.md
+++ b/scripts/sbom/README.md
@@ -40,9 +40,13 @@ tools such as `apk`, `sed`, `awk` and `grep`. It then:
    `cargo cyclonedx` currently supports).
 2. Pipes that through [`pipeline.jq`](pipeline.jq), which upgrades it to
    CycloneDX 1.7 and enriches it with build-environment metadata,
-   supplier/license info, the CBOM entry, and the vendored “data”
-   components (`id-tagging-schema`, `osm-testdata-grid`) that
-   `cargo cyclonedx` has no way to see.
+   supplier/license info, the CBOM facts (a `cryptographic-asset`
+   component for TLS 1.3, plus `crypto:tls:*`/`crypto:catrust:*`
+   custom properties on the `osm-diffs` component — see that file’s own
+   comments for why a curated CA root bundle isn’t a good fit for
+   CycloneDX’s `certificate` cryptographic-asset type), and the
+   vendored “data” components (`id-tagging-schema`,
+   `osm-testdata-grid`) that `cargo cyclonedx` has no way to see.
 3. Builds a CycloneDX fragment for the statically linked `tippecanoe`
    binary from scratch, with [`tippecanoe.jq`](tippecanoe.jq).
 4. Combines both fragments into the final, single SBOM for the container,

--- a/scripts/test-branch-on-macos/README.md
+++ b/scripts/test-branch-on-macos/README.md
@@ -31,8 +31,8 @@ monitor log:  /tmp/osm-diffs-workdir/macos_monitor.log
 - `--skip-build` reuses the existing `target/release/osm-diffs` as-is,
   for re-running against the same binary without waiting on a rebuild.
 - `--clean` clears the workdir first but keeps `planet-latest.osm.pbf`/
-  its metadata sidecar, so re-running doesn't re-fetch the planet over
-  BitTorrent.
+  its metadata sidecar, so re-running doesn't re-download the ~94GB
+  planet file.
 - `./test_macos.py build` runs just the `cargo build --release` step on
   its own.
 

--- a/scripts/test-on-hetzner/README.md
+++ b/scripts/test-on-hetzner/README.md
@@ -112,7 +112,7 @@ restart a run with a clean workdir without tearing down the VM
 | `up` | Create the server + volume, deploy, start the pipeline. |
 | `create` | Server + a formatted, attached, automounted data volume. Also collects `sysinfo` and runs `fio` once, automatically. Prints the exact `destroy` command needed to remove what it just created. |
 | `deploy` | `--branch NAME`: clone/update the given branch on an existing server and build it via the project's `Containerfile`, natively (see below for why that matters). `--image REF`: pull an already-built image instead (e.g. `ghcr.io/alltheplaces/osm-diffs:v1.2.3`) -- either way, binaries get extracted the same way, so bare-mode `start` works unchanged regardless of which path was used. |
-| `start` | Launch `osm-diffs run` and the vmstat/disk monitor, both detached via `systemd-run`. `--clean` clears the workdir first but keeps `planet-latest.osm.pbf`/its metadata sidecar, so re-running doesn't re-fetch the planet over BitTorrent. `--containerized --mem-limit SIZE --cpu-limit N` runs `podman run` against the image `deploy` produced instead of the bare extracted binary, for real cgroup accounting -- see below. |
+| `start` | Launch `osm-diffs run` and the vmstat/disk monitor, both detached via `systemd-run`. `--clean` clears the workdir first but keeps `planet-latest.osm.pbf`/its metadata sidecar, so re-running doesn't re-download the ~94GB planet file. `--containerized --mem-limit SIZE --cpu-limit N` runs `podman run` against the image `deploy` produced instead of the bare extracted binary, for real cgroup accounting -- see below. |
 | `status` | `systemctl status` for the run, plus `df` and the last few `pipeline.log` lines. |
 | `fio` | Random-read benchmark of the attached volume (the same command used by hand throughout the PR 665 experiment -- see `#667`). Re-runnable anytime, e.g. to check whether a result was a one-off blip. |
 | `sysinfo` | OS/kernel version, CPU model, memory, swap, disk layout, cgroup limits -- environment facts that turned out to matter for interpreting results but aren't anything this tool controls. |
@@ -138,22 +138,31 @@ $ ./cloud_test.py up --name reg1 --ssh-key my-key \
 - `--containerized --mem-limit SIZE --cpu-limit N` runs the pipeline via
   `podman run --memory=<SIZE> --cpus=<N>` instead of the bare extracted
   binary. This is the whole point for anything measuring memory/CPU
-  behavior: a bare-VM run never populates `pipeline.log`'s own
-  `cgroup_*` fields (there's no cgroup to report on), so it can't
-  validate a memory-pressure design under real container limits, only a
-  containerized run can. `--mem-limit`/`--cpu-limit` are required
-  together with `--containerized`.
+  behavior: a bare-VM run's `cgroup_current_bytes` is normally still
+  populated (systemd puts every service unit into its own cgroup even
+  outside a container), but `cgroup_max_bytes` reads `None` -- there's
+  no configured limit to report -- so it can't validate a
+  memory-pressure design against an actual limit, only a containerized
+  run (with a real `podman --memory`) can. See
+  [`src/pipeline/memstats.rs`](../../src/pipeline/memstats.rs)'s own
+  doc comment for the full nuance. `--mem-limit`/`--cpu-limit` are
+  required together with `--containerized`.
 - `--regional-extract REGION` (a Geofabrik path fragment, e.g.
   `europe/switzerland`) downloads that extract straight to
   `planet-latest.osm.pbf` before starting the container, skipping the
-  ~5h BitTorrent download entirely -- cheap, fast iteration for
-  comparing many `--mem-limit`/`--cpu-limit`/`--type` combinations. Only
-  worth it for a region meaningfully bigger than CI's own tiny
-  `zugerland.osm.pbf` fixture (40 KB) -- a micro-extract creates no real
-  memory pressure to observe. Omit it to exercise the real, unmodified
-  BitTorrent path against the full planet, e.g. for a final check once a
-  promising configuration is narrowed down, or to get genuine
-  full-scale cost/duration numbers.
+  planet download entirely -- useful for a quick functional smoke test
+  of the tool/pipeline itself. Since the planet now downloads over
+  plain HTTPS instead of BitTorrent (~28 minutes for the full ~94GB
+  file, not the ~4h48m the old BitTorrent path took), skipping the
+  download buys much less than it used to, and a small extract creates
+  no real memory pressure to observe in the first place -- so prefer
+  omitting `--regional-extract` for anything actually measuring
+  `--mem-limit` behavior; only worth it for a region meaningfully
+  bigger than CI's own tiny `zugerland.osm.pbf` fixture (40 KB)
+  regardless. Omit it to exercise the real download path against the
+  full planet, which is now the recommended default even for
+  comparing several `--mem-limit`/`--cpu-limit`/`--type`
+  combinations, e.g. for #711.
 - `--bucket-name NAME --bucket-region LOC` uploads output to an
   ephemeral S3-compatible test bucket, reading credentials from
   `HETZNER_TEST_S3_ACCESS_KEY_ID`/`HETZNER_TEST_S3_ACCESS_KEY_SECRET` in
@@ -194,10 +203,13 @@ broken, not just that today's data looks different from yesterday's:
   `--expect-pipeline-version` is given -- its `pipeline_version` matches.
 - The `conflate` step reached its `phase="end"` log record with no
   `ERROR` records logged after `phase="start"`.
-- `pipeline.log`'s `cgroup_current_bytes`/`cgroup_max_bytes` are
-  populated on that record (proof the run was actually containerized
-  under a real cgroup, impossible for a bare-VM run) -- and, if
-  `--mem-limit` is given, that `cgroup_max_bytes` matches it.
+- `pipeline.log`'s `cgroup_current_bytes`/`cgroup_max_bytes` are both
+  populated on that record. `cgroup_max_bytes` specifically is the
+  proof: it only reads non-`None` when a real memory limit was
+  configured (i.e. `podman --memory`), unlike `cgroup_current_bytes`,
+  which is normally populated even on a bare VM -- and, if
+  `--mem-limit` is given, `check_cgroup_signal` also checks that
+  `cgroup_max_bytes` matches it.
 - No OOM-kill signature in the downloaded `dmesg.log` (an OOM-killed
   step's own log record is simply missing, not an error entry -- this
   is the check that actually catches that case).


### PR DESCRIPTION
Small follow-up found while double-checking doc currency (stacked on #758, since #758 is already in the merge queue and can't take another commit right now).

`scripts/sbom/README.md` still said "the CBOM entry" (singular) -- stale since #757 added the `crypto:catrust:*` custom properties alongside the pre-existing TLS 1.3 `cryptographic-asset` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)