### PR TITLE
chore(release): bump version to 0.8.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1959,7 +1959,7 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "osm-diffs"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "osm-diffs"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2024"
 license = "MIT"
 


### PR DESCRIPTION
Version bump ahead of releasing v0.8.2. Opened by scripts/cut-release.sh.