### PR TITLE
feat: log import_osm's internal sub-steps individually

### DIFF
--- a/docs/LOGGING.md
+++ b/docs/LOGGING.md
@@ -21,7 +21,13 @@ See [`src/logging.rs`](../src/logging.rs) for the implementation, and
 [`src/pipeline/mod.rs`](../src/pipeline/mod.rs)’s `log_snapshot` for an
 example of a structured record (step name, phase, elapsed time, RSS/
 cgroup memory snapshot — logged at the start and end of every pipeline
-step).
+step). A step can log its own internal sub-steps the same way, under a
+dotted name (e.g. `import_osm.fetch`, `import_osm.assemble`) — not a
+second logging mechanism, the exact same `run_step` helper, just called
+again from inside a step for finer timing resolution than that step’s
+own start/end pair alone would give. `import_osm` does this for its
+fetch/open/prune/assemble/index-build phases; see
+[`src/pipeline/osm/mod.rs`](../src/pipeline/osm/mod.rs).
 
 ## Where weekly-run logs end up
 

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -141,7 +141,7 @@ fn run_pipeline_steps(
     Ok(())
 }
 
-/// Runs one top-level pipeline step, logging a [`memstats`]
+/// Runs one pipeline step, logging a [`memstats`]
 /// snapshot and the step's wall-clock run time -- to help diagnose
 /// out-of-memory kills and resource misconfigurations, since each step
 /// here (import, build tables, conflate, ...) tends to be where a
@@ -149,6 +149,20 @@ fn run_pipeline_steps(
 /// the step succeeds or fails, so a step that errors out (e.g. due to
 /// an actual OOM) still gets its "end" snapshot, with an elapsed time,
 /// on the way out.
+///
+/// Not just for the top-level steps `run_pipeline_steps` itself calls
+/// this with (`import_atp`, `conflate`, ...): `pipeline::osm::import_osm`
+/// also calls this directly (via plain Rust module-tree visibility --
+/// this function isn't `pub`, but `osm` is a descendant module of
+/// `pipeline`, so it can see it) for its own internal sub-steps
+/// (`import_osm.fetch`, `.open`, `.prune`, `.assemble`, `.index`),
+/// dotted-named to stay visually distinct from top-level steps in
+/// `pipeline.log` while sharing the exact same logging shape -- one
+/// mechanism, not two, and no separate parsing convention needed for
+/// sub-step timings. Added after a real case (#711) where only having
+/// `import_osm`'s own start/end pair wasn't enough resolution to tell
+/// which of its internal phases actually needed the memory a tight
+/// `--mem-limit` run ran short on.
 ///
 /// A step that returns `Err` also gets its error logged here, at ERROR
 /// level, with the full `anyhow` context chain -- this is the single

--- a/src/pipeline/osm/mod.rs
+++ b/src/pipeline/osm/mod.rs
@@ -75,10 +75,32 @@ pub fn import_osm<'a>(
         return OsmFeatures::open(&osm_index_path, &strings_path);
     }
 
-    let (pbf, fetch_metadata) = fetch::fetch_planet(http_client, progress, workdir)?;
+    // Each sub-step below gets the same step/phase/elapsed_seconds/
+    // memstats logging shape as this crate's top-level pipeline steps
+    // (see `super::run_step`, which this reuses directly rather than a
+    // second, parallel logging mechanism) -- just under a dotted name
+    // ("import_osm.fetch", not "fetch") so a log consumer can tell a
+    // sub-step from a top-level one at a glance, and so `import_osm`'s
+    // own already-existing top-level start/end pair (logged by
+    // whichever `run_step` call wraps this whole function, see
+    // `pipeline::run_pipeline_steps`) keeps meaning "the whole step",
+    // not "the whole step minus its sub-steps". Before this, only two
+    // points inside `import_osm` were distinguishable at all --
+    // "opened OpenStreetMap planet file" (after fetch+hash+blob-scan)
+    // and the outer step's own end -- which lumps prune/assemble/
+    // index-build into one undifferentiated number; not enough
+    // resolution to tell which of those actually needs the memory a
+    // tight `--mem-limit` run runs short on (see #711's investigation,
+    // e.g. alltheplaces/osm-diffs#711's comments for a real case where
+    // that distinction mattered).
+    let (pbf, fetch_metadata) = super::run_step("import_osm.fetch", || {
+        fetch::fetch_planet(http_client, progress, workdir)
+    })?;
     let pbf_error = || format!("could not open file `{:?}`", pbf);
     let mut file = File::open(&pbf).with_context(pbf_error)?;
-    let mut reader = BlobReader::open(&mut file).with_context(pbf_error)?;
+    let mut reader = super::run_step("import_osm.open", || {
+        BlobReader::open(&mut file).with_context(pbf_error)
+    })?;
     let header = reader.header();
     let replication_timestamp = header
         .replication_timestamp
@@ -92,9 +114,15 @@ pub fn import_osm<'a>(
         "opened OpenStreetMap planet file"
     );
 
-    let prunings = Prunings::create(&mut reader, progress, workdir)?;
-    let assembly = assemble::assemble(&mut reader, &prunings, progress, workdir)?;
-    let index = index::build_index(&assembly, progress, workdir, &osm_index_path)?;
+    let prunings = super::run_step("import_osm.prune", || {
+        Prunings::create(&mut reader, progress, workdir)
+    })?;
+    let assembly = super::run_step("import_osm.assemble", || {
+        assemble::assemble(&mut reader, &prunings, progress, workdir)
+    })?;
+    let index = super::run_step("import_osm.index", || {
+        index::build_index(&assembly, progress, workdir, &osm_index_path)
+    })?;
     Ok(OsmFeatures {
         index,
         strings: assembly.strings,


### PR DESCRIPTION
## Why

The #711 mem-limit sweep just ran into exactly the gap this fixes: `import_osm` only had two points of resolution in `pipeline.log` -- its own top-level start/end pair, and the ad hoc `"opened OpenStreetMap planet file"` message partway through -- so a wall-clock difference between two runs (e.g. a 4g vs 6g `--mem-limit` sweep point) could only be attributed to "somewhere in prune/assemble/index-build", not to which of those three actually needed the memory. That's exactly the question a `--mem-limit` sizing decision needs answered.

## What

Reuses `run_step` (already used for top-level steps in `run_pipeline_steps`) directly for `import_osm`'s own five internal phases -- fetch, open (`BlobReader::open`'s blob-index scan + partition), prune, assemble, index-build -- under dotted names (`import_osm.fetch`, `.open`, `.prune`, `.assemble`, `.index`) so they're visually distinct from top-level steps while sharing the exact same `step`/`phase`/`elapsed_seconds`/memstats logging shape. `run_step` isn't `pub`, but `osm` is a descendant module of `pipeline`, so it's already visible there via plain Rust module-tree visibility -- no visibility change needed.

`docs/LOGGING.md` gets a short addition explaining the dotted-name convention.

Deliberately **not** applied to the currently-running `--mem-limit` sweep (`v0.8.2`, already released) -- this is for the next major pipeline change, per the user's own framing, not a re-run of the current one.

## Testing

`cargo test` (252 passed)/`clippy`/`fmt` clean. Manually ran the pipeline against the `zugerland.osm.pbf` fixture and confirmed all five `import_osm.*` records appear in `pipeline.log`, correctly ordered, same schema as top-level steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)