### PR TITLE
fix: log unbuildable relation geometry at WARN, not ERROR

### DIFF
--- a/src/pipeline/osm/assemble.rs
+++ b/src/pipeline/osm/assemble.rs
@@ -472,7 +472,7 @@ fn assemble_leaf_relations<'a>(
                             /* super_relations */ None,
                         )?
                         else {
-                            log::error!("could not build geometry for relation/{}", relation.id);
+                            log::warn!("could not build geometry for relation/{}", relation.id);
                             continue;
                         };
 
@@ -633,7 +633,7 @@ fn assemble_super_relations(
                 };
 
                 let Some(rel_geometry) = rel_geometry else {
-                    log::error!("could not build geometry for relation/{}", rel_id);
+                    log::warn!("could not build geometry for relation/{}", rel_id);
                     continue;
                 };
 


### PR DESCRIPTION
## Why

Both relation-geometry call sites (`assemble_leaf_relations`, `assemble_super_relations`) logged `"could not build geometry for relation/..."` at `ERROR`, while the structurally identical way case (`assemble_ways`, same pattern: one feature dropped, processing continues) logs at `WARN`. Traced the history: the way case's `log::warn!` was added in #587 explicitly "mirroring the existing relation case" -- but the relation case's `log::error!` predates that commit and was never itself deliberated on. The inconsistency is what was original; there's no actual severity difference between the two failure modes.

Also inconsistent with how this codebase uses `ERROR` everywhere else: `pipeline::mod`'s own `run_step` reserves `log::error!` specifically for a step actually failing (`"{name} failed: {e:#}"`), not a single skipped feature within an otherwise-successful step -- exactly the `WARN` case, same category as the way failures right next to it.

**Latent tooling risk this avoids**: `scripts/test-on-hetzner/validate.py`'s `check_run_completed` currently only scans records *after* `conflate`'s own `phase="start"` (so these ERRORs, logged earlier during `import_osm`, don't trip it today) -- but that's incidental scoping, not a deliberate carve-out. A real full-planet run logs 100+ of these routinely; any future broadening of that check, or other tooling treating "any ERROR in `pipeline.log`" as a red flag, would misfire on completely normal runs.

## Testing

`cargo test` (252 passed)/`clippy`/`fmt` clean. No test hardcodes the old `ERROR` level for either call site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)