### PR TITLE
docs: add PRODUCTION.md, from the #711 --mem-limit sweep results

### DIFF
--- a/docs/PRODUCTION.md
+++ b/docs/PRODUCTION.md
@@ -17,7 +17,8 @@ re-establish it from scratch.
 many CPUs” is still an open question, not a documented recommendation.
 
 **Memory**: a `--mem-limit` sweep of the released `v0.8.2` container
-against the full planet, same CPU count throughout, gave:
+against the full OpenStreetMap planet, same CPU count throughout,
+gave:
 
 | `--mem-limit` | `import_osm` | `conflate` | Total |
 |---|---|---|---|

--- a/docs/PRODUCTION.md
+++ b/docs/PRODUCTION.md
@@ -100,6 +100,18 @@ Five environment variables, read once at startup (see
   `logs/<run-id>.log`), never the ephemeral per-run test buckets
   `scripts/test-on-hetzner` creates for its own testing.
 
+`S3_ACCESS_KEY_ID`/`S3_ACCESS_KEY_SECRET` are real credentials — handle
+them as secrets, not plain configuration. Keep them out of a command
+line (visible to anyone who can `ps` the host, and easy to leak into
+shell history or CI logs) and out of any manifest committed to a repo.
+The `podman run --env-file` invocation above already does the
+minimum right thing for a manual/systemd invocation — the file's
+contents never appear as process arguments. Whatever eventually
+schedules this in production should do the equivalent for its own
+environment: a Kubernetes `Secret` referenced via `secretKeyRef` (not
+a literal value in the `Job`/`CronJob` manifest), or the analogous
+mechanism for whatever scheduler ends up being used.
+
 ## Scheduling
 
 Nothing here runs on a schedule yet. The design intent

--- a/docs/PRODUCTION.md
+++ b/docs/PRODUCTION.md
@@ -3,11 +3,11 @@
 `osm-diffs` doesn’t run anywhere permanent yet — see
 [`TECHNICAL_DESIGN.md`](TECHNICAL_DESIGN.md)’s “Status” section. This
 document isn’t a description of an existing deployment; it’s the
-operational knowledge gathered from real testing on Hetzner Cloud
+operational knowledge gathered from testing on Hetzner Cloud
 ([`scripts/test-on-hetzner`](../scripts/test-on-hetzner/README.md),
 [#711](https://github.com/alltheplaces/osm-diffs/issues/711),
 [#722](https://github.com/alltheplaces/osm-diffs/issues/722)), written
-down now so whoever sets up the real thing doesn’t have to
+down now so whoever sets up the actual deployment doesn’t have to
 re-establish it from scratch.
 
 ## Hardware sizing
@@ -39,7 +39,7 @@ for why those two steps behave so differently under memory pressure.
 **Don’t provision at the measured floor.** 6GB is where the sweep
 happened to land this time; it isn’t a target with margin built in, and
 the planet only grows over time — a floor measured today gets tighter,
-never looser. **8GB is the recommended minimum** for real use: the
+never looser. **8GB is the recommended minimum** in production: the
 first config in the sweep with no measurable difference from a
 generous limit.
 
@@ -74,7 +74,7 @@ podman run --rm --read-only \
   [`SUPPLY_CHAIN_SECURITY.md`](SUPPLY_CHAIN_SECURITY.md#minimal-containers).
   Everything the pipeline writes goes to `/workdir`, the one mounted
   volume.
-- `--memory`/`--cpus`: the real cgroup limits this document’s sizing
+- `--memory`/`--cpus`: the actual cgroup limits this document’s sizing
   guidance is about — without them, `pipeline.log`’s own `cgroup_*`
   memstats fields read `None` (see
   [`LOGGING.md`](LOGGING.md)), and nothing here has been validated
@@ -95,12 +95,12 @@ Five environment variables, read once at startup (see
   uploads (e.g. for a local/dry-run invocation) rather than passing
   empty values.
 - `S3_BUCKET`, `S3_REGION`, `S3_ACCESS_KEY_ID`, `S3_ACCESS_KEY_SECRET`
-  — required once `S3_ENDPOINT` is set; a real S3-compatible bucket for
-  the actual output (`conflated.parquet`, `edits.pmtiles`,
+  — required once `S3_ENDPOINT` is set; a genuine S3-compatible bucket
+  for the actual output (`conflated.parquet`, `edits.pmtiles`,
   `logs/<run-id>.log`), never the ephemeral per-run test buckets
   `scripts/test-on-hetzner` creates for its own testing.
 
-`S3_ACCESS_KEY_ID`/`S3_ACCESS_KEY_SECRET` are real credentials — handle
+`S3_ACCESS_KEY_ID`/`S3_ACCESS_KEY_SECRET` are live credentials — handle
 them as secrets, not plain configuration. Keep them out of a command
 line (visible to anyone who can `ps` the host, and easy to leak into
 shell history or CI logs) and out of any manifest committed to a repo.
@@ -159,10 +159,10 @@ recommended 8GB config takes ~2h43m, so:
   between runs).
 - **~€1.30/month** at a weekly cadence — compute only. Not included:
   S3-compatible storage for the actual output, egress/traffic, or any
-  larger instance chosen for real margin beyond this document’s bare
-  sizing numbers.
+  larger instance chosen for genuine margin beyond this document’s
+  bare sizing numbers.
 
 This is Hetzner-specific pricing, from the same provider
-`scripts/test-on-hetzner` tests against — a real production deployment
-might land on different infrastructure entirely; treat the euro
-figures as an order-of-magnitude anchor, not a quote.
+`scripts/test-on-hetzner` tests against — an actual production
+deployment might land on different infrastructure entirely; treat the
+euro figures as an order-of-magnitude anchor, not a quote.

--- a/docs/PRODUCTION.md
+++ b/docs/PRODUCTION.md
@@ -1,0 +1,155 @@
+# Running `osm-diffs` in production
+
+`osm-diffs` doesn’t run anywhere permanent yet — see
+[`TECHNICAL_DESIGN.md`](TECHNICAL_DESIGN.md)’s “Status” section. This
+document isn’t a description of an existing deployment; it’s the
+operational knowledge gathered from real testing on Hetzner Cloud
+([`scripts/test-on-hetzner`](../scripts/test-on-hetzner/README.md),
+[#711](https://github.com/alltheplaces/osm-diffs/issues/711),
+[#722](https://github.com/alltheplaces/osm-diffs/issues/722)), written
+down now so whoever sets up the real thing doesn’t have to
+re-establish it from scratch.
+
+## Hardware sizing
+
+**CPU**: every number below comes from a fixed `--cpus=6` (a Hetzner
+`cpx42`) — CPU count itself hasn’t been swept independently, so “how
+many CPUs” is still an open question, not a documented recommendation.
+
+**Memory**: a `--mem-limit` sweep of the released `v0.8.2` container
+against the full planet, same CPU count throughout, gave:
+
+| `--mem-limit` | `import_osm` | `conflate` | Total |
+|---|---|---|---|
+| 12g | 2h24m12s | 10m37s | 2h43m2s |
+| 8g | 2h24m24s | 10m18s | 2h43m20s |
+| 6g | 2h27m53s | 10m17s | 2h46m28s |
+| 4g | 4h02m46s | 10m36s | 4h21m36s |
+
+**6GB is the measured floor** on this CPU count: 8g and 6g are
+indistinguishable from a comfortable 12g baseline; 4g still completes
+correctly (identical row counts, all `validate` hard checks pass — the
+memory pressure costs wall-clock time, not correctness) but takes
+~1h40m longer, entirely inside `import_osm`’s node-coordinate
+resolution step, not `conflate` — see
+[`TECHNICAL_DESIGN.md`](TECHNICAL_DESIGN.md#why-conflate-doesnt-need-its-own-cache)
+for why those two steps behave so differently under memory pressure.
+
+**Don’t provision at the measured floor.** 6GB is where the sweep
+happened to land this time; it isn’t a target with margin built in, and
+the planet only grows over time — a floor measured today gets tighter,
+never looser. **8GB is the recommended minimum** for real use: the
+first config in the sweep with no measurable difference from a
+generous limit.
+
+**Disk**: peak usage during a full-planet run was **~172GB**, settling
+to **~143GB** once `import_osm` finishes and its temporary files are
+cleaned up — consistent across two independent runs on different
+hardware (this sweep, and the earlier
+[#665](https://github.com/alltheplaces/osm-diffs/issues/665) shakedown,
+which saw ~174GB peak / ~148GB settled). **220-250GB** gives reasonable
+headroom over that peak without being wildly oversized; the 400GB
+default `scripts/test-on-hetzner/cloud_test.py` uses for testing is
+itself generous margin, not a sizing recommendation.
+
+## Container invocation
+
+The published image (`ghcr.io/alltheplaces/osm-diffs:vX.Y.Z` — pin an
+exact, immutable tag; see
+[`SUPPLY_CHAIN_SECURITY.md`](SUPPLY_CHAIN_SECURITY.md#immutable-releases))
+runs as:
+
+```sh
+podman run --rm --read-only \
+  --memory=8g --cpus=6 \
+  -v /path/to/workdir:/workdir \
+  --env-file s3.env \
+  ghcr.io/alltheplaces/osm-diffs:vX.Y.Z \
+  run --workdir /workdir --run_id "$RUN_ID"
+```
+
+- `--read-only`: the image ships nothing that needs a writable root
+  filesystem — see
+  [`SUPPLY_CHAIN_SECURITY.md`](SUPPLY_CHAIN_SECURITY.md#minimal-containers).
+  Everything the pipeline writes goes to `/workdir`, the one mounted
+  volume.
+- `--memory`/`--cpus`: the real cgroup limits this document’s sizing
+  guidance is about — without them, `pipeline.log`’s own `cgroup_*`
+  memstats fields read `None` (see
+  [`LOGGING.md`](LOGGING.md)), and nothing here has been validated
+  running unconstrained.
+- `--run_id`: becomes `formulation[].workflows[].uid` in the output’s
+  embedded provenance BOM (see
+  [`outputs/CONFLATED_PARQUET.md`](outputs/CONFLATED_PARQUET.md)) —
+  whatever identifier the scheduling system assigns this run (a
+  Kubernetes Job name, a cron invocation ID, …). Optional; empty if
+  omitted.
+
+## Required configuration
+
+Five environment variables, read once at startup (see
+[`src/pipeline/upload.rs`](../src/pipeline/upload.rs)):
+
+- `S3_ENDPOINT` — also the on/off switch: unset it entirely to disable
+  uploads (e.g. for a local/dry-run invocation) rather than passing
+  empty values.
+- `S3_BUCKET`, `S3_REGION`, `S3_ACCESS_KEY_ID`, `S3_ACCESS_KEY_SECRET`
+  — required once `S3_ENDPOINT` is set; a real S3-compatible bucket for
+  the actual output (`conflated.parquet`, `edits.pmtiles`,
+  `logs/<run-id>.log`), never the ephemeral per-run test buckets
+  `scripts/test-on-hetzner` creates for its own testing.
+
+## Scheduling
+
+Nothing here runs on a schedule yet. The design intent
+([`TECHNICAL_DESIGN.md`](TECHNICAL_DESIGN.md#objective)) is a weekly
+cadence, matching how often AllThePlaces itself publishes a fresh dump
+— whatever wires this up (a Kubernetes `CronJob`, a plain cron job
+somewhere, a scheduled GitHub Actions workflow) is future work, not
+something this repository provides today.
+
+## What to watch
+
+Everything below comes straight out of `pipeline.log` (see
+[`LOGGING.md`](LOGGING.md)) — no separate monitoring system needed to
+get started:
+
+- **OOM**: exit code 137, or an OOM-kill signature in `dmesg`/
+  `journalctl -k` — the definitive failure signal. A killed step’s own
+  “end” log record is simply missing, not an error entry, so don’t
+  rely on `pipeline.log` alone to notice this; check the container’s
+  own exit status too.
+- **Approaching the limit**: a `WARN` fires automatically once
+  `cgroup_current_bytes` crosses 85% of `cgroup_max_bytes`, at any
+  step — an early signal ahead of an actual kill.
+- **The page-cache design holding up**: during `conflate.match`
+  specifically, `rss_file_bytes` should dominate `rss_bytes` (reclaimable
+  cache, not heap) — if that ratio drops, something’s changed about the
+  access pattern this design depends on.
+- **Step timings drifting**: `import_osm`’s own sub-steps
+  (`import_osm.fetch`/`.open`/`.prune`/`.assemble`/`.index`, logged
+  individually as of
+  [#761](https://github.com/alltheplaces/osm-diffs/pull/761)) are worth
+  watching over time as the planet grows — a slow drift is expected;
+  a sudden jump on an otherwise-unchanged config is worth investigating
+  the way this document’s own `--mem-limit` sweep did.
+
+## Cost
+
+Real Hetzner Cloud pricing as of 2026-08 (`cpx42`, `fsn1`/`hel1`,
+excluding VAT): **€0.1114/hour**. A weekly full-planet run at the
+recommended 8GB config takes ~2h43m, so:
+
+- **~€0.30 per run** in compute, plus a few cents of volume cost for
+  its few-hour lifetime (volumes bill per GB-month;
+  `€0.0572`/GB-month, negligible unless kept around persistently
+  between runs).
+- **~€1.30/month** at a weekly cadence — compute only. Not included:
+  S3-compatible storage for the actual output, egress/traffic, or any
+  larger instance chosen for real margin beyond this document’s bare
+  sizing numbers.
+
+This is Hetzner-specific pricing, from the same provider
+`scripts/test-on-hetzner` tests against — a real production deployment
+might land on different infrastructure entirely; treat the euro
+figures as an order-of-magnitude anchor, not a quote.

--- a/docs/PRODUCTION.md
+++ b/docs/PRODUCTION.md
@@ -56,9 +56,9 @@ itself generous margin, not a sizing recommendation.
 ## Container invocation
 
 The published image (`ghcr.io/alltheplaces/osm-diffs:vX.Y.Z` — pin an
-exact, immutable tag; see
-[`SUPPLY_CHAIN_SECURITY.md`](SUPPLY_CHAIN_SECURITY.md#immutable-releases))
-runs as:
+exact tag; see
+[the releases page](https://github.com/alltheplaces/osm-diffs/releases)
+for the current version and its notes) runs as:
 
 ```sh
 podman run --rm --read-only \

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,9 @@
 - [`outputs/`](outputs/) — the pipeline's output files: what's in
   them, and how to read them.
 - [`RELEASING.md`](RELEASING.md) — how to cut a release of `osm-diffs`.
+- [`PRODUCTION.md`](PRODUCTION.md) — operational knowledge for running
+  a released container somewhere real: hardware sizing, required
+  configuration, what to monitor.
 - [`SUPPLY_CHAIN_SECURITY.md`](SUPPLY_CHAIN_SECURITY.md) — the concepts
   behind our release process: containers, multi-architecture images,
   SBOM/CBOM, CycloneDX, build provenance and attestations, and

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -210,8 +210,12 @@ for that walkthrough, which is what `verify-release.sh` automates.
 
 - **Production deployment isn’t wired up yet.** This process ends at “a
   correctly built, SBOM’d, attested container sits in `ghcr.io`” — what
-  happens after that, to actually run this in production, doesn’t exist
-  yet and isn’t covered here.
+  happens after that, to actually run this in production (scheduling,
+  where it runs), doesn’t exist yet. What it should take to get there
+  once it does — hardware sizing, required configuration, what to
+  monitor — is written down in
+  [`PRODUCTION.md`](PRODUCTION.md), from real testing rather than
+  guesswork.
 - A few low-priority, deliberately-deferred items are tracked separately
   and don’t block anything: automated freshness checks for vendored
   dependencies

--- a/docs/TECHNICAL_DESIGN.md
+++ b/docs/TECHNICAL_DESIGN.md
@@ -350,6 +350,10 @@ Related documentation:
   step writes, and where weekly-run logs end up archived.
 - [`docs/SUPPLY_CHAIN_SECURITY.md`](SUPPLY_CHAIN_SECURITY.md) — SBOM,
   build provenance, and the release process’s security properties.
+- [`docs/RELEASING.md`](RELEASING.md) — how to cut a release.
+- [`docs/PRODUCTION.md`](PRODUCTION.md) — hardware sizing, required
+  configuration, and what to monitor, for whoever eventually runs this
+  somewhere real.
 - [`docs/outputs/`](outputs/) — the schema of files this pipeline
   produces for public consumption.
 
@@ -362,7 +366,9 @@ uploaded to S3 at the end of a run. What’s still ahead follows from
 that same choice — several pieces are deliberately simple placeholders
 until the full pipeline was proven out:
 
-- It does not yet run on an automatic weekly schedule in production.
+- It does not yet run on an automatic weekly schedule in production —
+  see [`docs/PRODUCTION.md`](PRODUCTION.md) for what’s known so far
+  about what that would take.
 - Nothing yet uploads suggested edits to any of the tools described
   above — that integration (most likely MapRoulette first, given its
   API is the closest fit) is future work, not yet designed in detail.


### PR DESCRIPTION
## Why

Writes down the operational knowledge gathered from real testing (`scripts/test-on-hetzner`, #711, #722) that had nowhere to live: hardware sizing (the 6GB `--mem-limit` floor and 8GB recommendation from the sweep, the ~172GB/~143GB disk peak/settled numbers), the exact `podman` invocation, the five required `S3_*` env vars, and what to watch in `pipeline.log` (OOM, the 85% cgroup `WARN`, `rss_file_bytes` dominance, `import_osm`'s now-per-sub-step timings from #761). Explicit up front that this describes what running it in production *should* take, not an existing deployment -- nothing runs on a schedule anywhere yet.

Deliberately doesn't duplicate `TECHNICAL_DESIGN.md`'s own per-step timing table -- links to it instead. Real Hetzner pricing (as of 2026-08) grounds the cost estimate rather than a guessed number.

## What else

Cross-references added/fixed elsewhere while sweeping the rest of `docs/` for redundancy and structural gaps, per request:

- `docs/README.md`'s index didn't list `PRODUCTION.md` (new) -- added, positioned after `RELEASING.md`.
- `docs/RELEASING.md`'s "Known gaps" bullet said production deployment "isn't covered here" -- now points to `PRODUCTION.md` for what's known about it.
- `docs/TECHNICAL_DESIGN.md`'s "Related documentation" list was missing `RELEASING.md` entirely (pre-existing gap, unrelated to this PR) as well as the new `PRODUCTION.md` -- both added. Its "Status" section's "does not yet run on an automatic weekly schedule" bullet now links to `PRODUCTION.md` too.

No other redundancy found in the rest of `docs/` (`TESTING.md`, `CONTRIBUTING.md`, `LOGGING.md`, `SUPPLY_CHAIN_SECURITY.md`, `SECURITY.md`, `outputs/`) -- checked each against `PRODUCTION.md`'s new content (podman invocation, `S3_*` env vars, cost figures, hardware sizing) and found no overlap worth trimming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)