### PR TITLE
docs: fresh-eyes pass over docs/ and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ edits go where is still being worked out, see
 [#696](https://github.com/alltheplaces/osm-diffs/issues/696).
 
 New here? See [`docs/TECHNICAL_DESIGN.md`](docs/TECHNICAL_DESIGN.md)
-for why this exists and how it's built,
+for why this exists and how it’s built,
 [`docs/CONTRIBUTING.md`](docs/CONTRIBUTING.md) to get started
 contributing, and [`docs/`](docs/) generally for testing, cutting a
 release, and our security practices. Looking for what the pipeline

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thanks for taking a look at `osm-diffs`! 👋 Contributions, questions,
 and bug reports are all welcome — this project is still early, so
-there's no such thing as too small a
+there’s no such thing as too small a
 [Pull Request (PR)](https://docs.github.com/en/pull-requests/get-started/about-pull-requests).
 
 Please be kind to each other and to maintainers; see our
@@ -19,7 +19,7 @@ cargo test
 If your PR touches `Cargo.toml` or `Cargo.lock` (e.g. adding or bumping a
 dependency), also run
 [`cargo deny`](https://github.com/EmbarkStudios/cargo-deny) (`cargo install
-cargo-deny` if you don't have it):
+cargo-deny` if you don’t have it):
 
 ```sh
 cargo deny check
@@ -32,7 +32,7 @@ known RUSTSEC/OSV advisories.
 
 If you changed a Python script, run `uv run pytest` from `scripts/`.
 
-After you've sent a Pull Request, our Continuous Integration (CI) runs a
+After you’ve sent a Pull Request, our Continuous Integration (CI) runs a
 series of checks on it — the commands above are a subset of what CI runs
 ([`test.yml`](https://github.com/alltheplaces/osm-diffs/blob/main/.github/workflows/test.yml),
 [`cargo-deny.yml`](https://github.com/alltheplaces/osm-diffs/blob/main/.github/workflows/cargo-deny.yml)).
@@ -55,29 +55,29 @@ PRs are squash-merged, and the PR title becomes the commit message on
 ([`pr-title-lint.yml`](https://github.com/alltheplaces/osm-diffs/blob/main/.github/workflows/pr-title-lint.yml))
 checks this on every PR and applies an `enhancement`/`bug`/`breaking-change`
 label from it, which feeds
-[`.github/release.yml`](https://github.com/alltheplaces/osm-diffs/blob/main/.github/release.yml)'s
+[`.github/release.yml`](https://github.com/alltheplaces/osm-diffs/blob/main/.github/release.yml)’s
 categorized release notes — so getting the type right saves the
-maintainer a manual labeling step, it's not just a style nit.
+maintainer a manual labeling step, it’s not just a style nit.
 
-**The `!` marker is special here.** Normally it means "breaks the public
-API." `osm-diffs` doesn't have one client code links against — what it
-has is an **output schema** (`conflated.parquet`), and that's what
+**The `!` marker is special here.** Normally it means “breaks the public
+API.” `osm-diffs` doesn’t have one client code links against — what it
+has is an **output schema** (`conflated.parquet`), and that’s what
 matters to everyone downstream. So on this project, `!` means *this PR
 breaks the output schema*, per the rules in
 [`RELEASING.md`](https://github.com/alltheplaces/osm-diffs/blob/main/docs/RELEASING.md#choosing-the-version-number)
 — not that some function signature changed. A `refactor!:` or `chore!:`
 that happens to rename a Parquet column is exactly as `!` as a `feat!:`
-that removes one; a `feat:` CLI flag that doesn't touch the schema isn't
+that removes one; a `feat:` CLI flag that doesn’t touch the schema isn’t
 `!` at all. `cut-release.sh` reads these markers to *suggest* a version
 floor, but the actual version is still your call, per `RELEASING.md`.
 
 ## Where to go next
 
 - [`docs/TESTING.md`](https://github.com/alltheplaces/osm-diffs/blob/main/docs/TESTING.md)
-  — how this project's tests are organized, and how to try a change on
+  — how this project’s tests are organized, and how to try a change on
   real full-planet data before it lands.
 - [`docs/RELEASING.md`](https://github.com/alltheplaces/osm-diffs/blob/main/docs/RELEASING.md)
   — how a release actually ships, for once your change has landed on
   `main`.
 
-That's it — open a PR, and we'll take it from there. 🙂
+That’s it — open a PR, and we’ll take it from there. 🙂

--- a/docs/LOGGING.md
+++ b/docs/LOGGING.md
@@ -17,7 +17,8 @@ Every record has:
   snapshot. Omitted entirely on records that don’t have any, so plain
   log lines stay plain.
 
-See [`src/logging.rs`](../src/logging.rs) for the implementation, and
+See [`src/pipeline/logging.rs`](../src/pipeline/logging.rs) for the
+implementation, and
 [`src/pipeline/mod.rs`](../src/pipeline/mod.rs)’s `log_snapshot` for an
 example of a structured record (step name, phase, elapsed time, RSS/
 cgroup memory snapshot — logged at the start and end of every pipeline

--- a/docs/PRODUCTION.md
+++ b/docs/PRODUCTION.md
@@ -48,7 +48,7 @@ to **~143GB** once `import_osm` finishes and its temporary files are
 cleaned up — consistent across two independent runs on different
 hardware (this sweep, and the earlier
 [#665](https://github.com/alltheplaces/osm-diffs/issues/665) shakedown,
-which saw ~174GB peak / ~148GB settled). **220-250GB** gives reasonable
+which saw ~174GB peak / ~148GB settled). **220–250GB** gives reasonable
 headroom over that peak without being wildly oversized; the 400GB
 default `scripts/test-on-hetzner/cloud_test.py` uses for testing is
 itself generous margin, not a sizing recommendation.
@@ -105,7 +105,7 @@ them as secrets, not plain configuration. Keep them out of a command
 line (visible to anyone who can `ps` the host, and easy to leak into
 shell history or CI logs) and out of any manifest committed to a repo.
 The `podman run --env-file` invocation above already does the
-minimum right thing for a manual/systemd invocation — the file's
+minimum right thing for a manual/systemd invocation — the file’s
 contents never appear as process arguments. Whatever eventually
 schedules this in production should do the equivalent for its own
 environment: a Kubernetes `Secret` referenced via `secretKeyRef` (not

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,14 +1,14 @@
 # Documentation
 
-- [`CONTRIBUTING.md`](CONTRIBUTING.md) — start here if you're new.
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — start here if you’re new.
 - [`TECHNICAL_DESIGN.md`](TECHNICAL_DESIGN.md) — why this pipeline
-  exists, the background it builds on, and how it's put together.
-- [`TESTING.md`](TESTING.md) — how this project's tests are organized,
+  exists, the background it builds on, and how it’s put together.
+- [`TESTING.md`](TESTING.md) — how this project’s tests are organized,
   what CI enforces, and how to try a change on real hardware before it
   lands.
 - [`LOGGING.md`](LOGGING.md) — the JSON log format `osm-diffs run`
   writes, and where weekly-run logs end up archived in S3.
-- [`outputs/`](outputs/) — the pipeline's output files: what's in
+- [`outputs/`](outputs/) — the pipeline’s output files: what’s in
   them, and how to read them.
 - [`RELEASING.md`](RELEASING.md) — how to cut a release of `osm-diffs`.
 - [`PRODUCTION.md`](PRODUCTION.md) — operational knowledge for running

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -85,7 +85,7 @@ Once you run `cut-release.sh vX.Y.Z`:
    pushed directly.
 3. **The script waits** for that PR to clear required checks and the
    merge queue, and actually land on `main`. This normally takes a few
-   minutes (the required test job takes ~4-5 min; the merge queue has a
+   minutes (the required test job takes ~4–5 min; the merge queue has a
    minimum 3 min wait).
 4. **The release is created**: a GitHub Release for `vX.Y.Z` is published
    at the new `main` HEAD, with auto-generated notes (categorized per
@@ -121,8 +121,8 @@ Once you run `cut-release.sh vX.Y.Z`:
    both a build-provenance and an SBOM attestation genuinely exist for
    both architectures (see “Verifying a release” below).
 
-Steps 1-4 usually take under 10 minutes; steps 5-6 (the actual container
-build, plus verification) take roughly another 20-25 minutes.
+Steps 1–4 usually take under 10 minutes; steps 5–6 (the actual container
+build, plus verification) take roughly another 20–25 minutes.
 
 ## Verifying a release
 
@@ -183,7 +183,7 @@ for that walkthrough, which is what `verify-release.sh` automates.
   without a correspondingly published, attested container — that’s a
   known, accepted consequence of immutability, not a bug.
 - **`cut-release.sh` is interrupted, or times out, while waiting on
-  `release.yml`** (~20-25 min; a crashed machine, a dropped connection,
+  `release.yml`** (~20–25 min; a crashed machine, a dropped connection,
   or a truly stuck workflow): the release itself is unaffected — it was
   already created before this wait began. Just run
   `./scripts/verify-release.sh vX.Y.Z` on its own once you’re ready to

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,17 +1,49 @@
 # Security
 
-If you find a significant vulnerability, or evidence of one,
-please report it privately.
+If you find a significant vulnerability, or evidence of one, please
+report it privately.
 
-We prefer that you use the [GitHub mechanism for privately reporting a vulnerability](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability). Under the
-[repository’s security tab](https://github.com/alltheplaces/osm-diffs/security), click "Report a vulnerability" to open the advisory form.
+We prefer the [GitHub mechanism for privately reporting a
+vulnerability](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability):
+under the [repository’s security
+tab](https://github.com/alltheplaces/osm-diffs/security), click
+“Report a vulnerability” to open the advisory form.
 
-For how we secure the release process itself — build provenance, SBOMs, signed attestations — see [`SUPPLY_CHAIN_SECURITY.md`](https://github.com/alltheplaces/osm-diffs/blob/main/docs/SUPPLY_CHAIN_SECURITY.md).
+For how we secure the release process itself — build provenance,
+SBOMs, signed attestations — see
+[`SUPPLY_CHAIN_SECURITY.md`](https://github.com/alltheplaces/osm-diffs/blob/main/docs/SUPPLY_CHAIN_SECURITY.md).
+Our container has no OS at all, so there’s no OS trust store to verify
+outbound TLS connections against either — see that document’s
+[“Certificate
+trust”](https://github.com/alltheplaces/osm-diffs/blob/main/docs/SUPPLY_CHAIN_SECURITY.md#certificate-trust)
+section for what we do instead.
 
-Our container has no OS at all — so there's no OS trust store to verify outbound TLS connections against, either. See `SUPPLY_CHAIN_SECURITY.md`'s ["Certificate trust"](https://github.com/alltheplaces/osm-diffs/blob/main/docs/SUPPLY_CHAIN_SECURITY.md#certificate-trust) section for what we do instead.
+Every change also goes through
+[SAST](https://en.wikipedia.org/wiki/Static_application_security_testing)
+via [GitHub CodeQL](https://codeql.github.com/), enforced by branch
+protection on `main` — see
+[`TESTING.md`](https://github.com/alltheplaces/osm-diffs/blob/main/docs/TESTING.md)
+for details. We publish an [OSSF
+Scorecard](https://scorecard.dev/viewer/?uri=github.com/alltheplaces/osm-diffs)
+analysis on every push to `main` (badge in the
+[README](https://github.com/alltheplaces/osm-diffs#readme)); its
+“Vulnerabilities” check reports known, already-public advisories in
+our dependencies (RUSTSEC/OSV) — the same ones
+[Dependabot](https://github.com/alltheplaces/osm-diffs/network/updates)
+already opens PRs for. A nonzero score there isn’t a new finding and
+doesn’t need private disclosure; check [open pull
+requests](https://github.com/alltheplaces/osm-diffs/pulls) for the fix
+already in progress.
 
-We also run [SAST](https://en.wikipedia.org/wiki/Static_application_security_testing) via [GitHub CodeQL](https://codeql.github.com/) on every change, enforced by branch protection on `main` — see [`TESTING.md`](https://github.com/alltheplaces/osm-diffs/blob/main/docs/TESTING.md) for details.
-
-We also publish an [OSSF Scorecard](https://scorecard.dev/viewer/?uri=github.com/alltheplaces/osm-diffs) analysis on every push to `main` (badge in the [README](https://github.com/alltheplaces/osm-diffs#readme)). Its "Vulnerabilities" check reports known, already-public advisories in our dependencies (RUSTSEC/OSV) — the same ones [Dependabot](https://github.com/alltheplaces/osm-diffs/network/updates) already opens PRs for. A nonzero score there isn't a new finding and doesn't need private disclosure; check [open pull requests](https://github.com/alltheplaces/osm-diffs/pulls) for the fix already in progress.
-
-On top of that, [`cargo-deny.yml`](https://github.com/alltheplaces/osm-diffs/blob/main/.github/workflows/cargo-deny.yml) actively gates PRs and runs weekly, via [`cargo-deny`](https://github.com/EmbarkStudios/cargo-deny) against the rules in [`deny.toml`](https://github.com/alltheplaces/osm-diffs/blob/main/deny.toml). It also checks dependency licenses, banned/duplicated crates, and untrusted sources — not just advisories. Advisories that are already known, already tracked, and not fixable from this repo (e.g. pinned deep in a dependency we don't control) can be allow-listed there with a reason and a link to the upstream fix, rather than leaving CI red on something no PR here can resolve.
+On top of that,
+[`cargo-deny.yml`](https://github.com/alltheplaces/osm-diffs/blob/main/.github/workflows/cargo-deny.yml)
+gates PRs and runs weekly, via
+[`cargo-deny`](https://github.com/EmbarkStudios/cargo-deny) against
+the rules in
+[`deny.toml`](https://github.com/alltheplaces/osm-diffs/blob/main/deny.toml) —
+dependency licenses, banned/duplicated crates, untrusted sources, and
+known advisories alike. An advisory that’s already known, already
+tracked, and not fixable from this repo (e.g. pinned deep in a
+dependency we don’t control) can be allow-listed there with a reason
+and a link to the upstream fix, rather than leaving CI red on
+something no PR here can resolve.

--- a/docs/TECHNICAL_DESIGN.md
+++ b/docs/TECHNICAL_DESIGN.md
@@ -1,10 +1,7 @@
 # Technical design: `osm-diffs`
 
-Status: work in progress. This document describes the pipeline as it
-exists today, not a target architecture — see the repository’s
-[status badge](../README.md) and open issues for what’s still ahead
-(in particular, nothing yet uploads suggested edits anywhere; see
-“Status” at the end).
+Status: Work in Progress — see [“Status”](#status) at the end of this
+document for what’s still ahead.
 
 ## Objective
 
@@ -19,7 +16,7 @@ apply to OpenStreetMap.
 
 ### Why OpenStreetMap needs this
 
-OpenStreetMap's coverage of roads and administrative boundaries is
+OpenStreetMap’s coverage of roads and administrative boundaries is
 comprehensive. Points of interest are a different story: a shop,
 restaurant, or other business only ends up on the map if a volunteer
 happened to notice it and add it by hand — while most retail and
@@ -43,11 +40,10 @@ plans to: scraped data isn’t reliable enough to trust unreviewed, and
 even if it were, bulk edits don’t fit how the OSM
 community works — edits get proposed and reviewed by humans, not
 pushed automatically by a script. What this project can do instead:
-to find the delta between the two datasets systematically, for the
+find the delta between the two datasets systematically, for the
 whole planet, within a week, and turn it into edit proposals for
 volunteers to review — turning “maybe someone notices eventually” into
-a
-standing, repeatable check.
+a standing, repeatable check.
 
 ### What conflation is
 
@@ -90,15 +86,35 @@ down to its constituent nodes — this project has to construct real
 geometry for all three cases, not just look up a point (see
 `tables::feature_index` and `pipeline::osm::assemble` for how).
 
+### Working with data bigger than RAM
+
+A planet-scale OSM index doesn’t fit in memory on the kind of cheap
+machine this pipeline is meant to run on. The pattern used throughout
+[`tables`](../src/tables/) (see “Code structure” below): build the
+table on disk — usually via [external
+sorting](https://en.wikipedia.org/wiki/External_sorting), the
+sort-chunks-then-merge technique for sorting more data than fits in
+RAM — then [memory-map](https://en.wikipedia.org/wiki/Memory-mapped_file)
+the finished file instead of loading it onto the heap. From there,
+virtual memory does the rest: the OS keeps only the pages actually
+being touched resident, backed by its page cache, so a table can be
+far bigger than physical RAM without this project doing any caching of
+its own. That’s not just assumed to work — it’s been verified on real,
+memory-constrained hardware, including inside a container under a real
+cgroup memory limit; see [“Why `conflate` doesn’t need its own
+cache”](#why-conflate-doesnt-need-its-own-cache) below, and
+[#711](https://github.com/alltheplaces/osm-diffs/issues/711) for the
+full sweep.
+
 ### What AllThePlaces does
 
 AllThePlaces runs several thousand site-specific scrapers (“spiders”),
 each written in Python against the [Scrapy](https://scrapy.org/)
 framework — deliberately easy to write and contribute, which is a
 large part of why the project has grown as far as it has. Most spiders
-target one retail chain or brand's own store-locator page, but a
+target one retail chain or brand’s own store-locator page, but a
 growing share instead pull from Open Government Data portals under
-clear open licenses, so the combined dump isn't retail-only. It
+clear open licenses, so the combined dump isn’t retail-only. It
 publishes a combined weekly dump of every spider’s output as open data
 (CC0), which several other projects already consume, including
 OpenStreetMap-adjacent tooling and commercial mapping platforms. As
@@ -185,8 +201,8 @@ memory snapshot, regardless of success or failure — see
 [`docs/LOGGING.md`](LOGGING.md). Steps are meant to be memoized
 against files already in `--workdir`, so re-running the pipeline in
 the same directory skips whatever it already built (this also applies
-below the step level, e.g. within `import_atp`/`import_osm`'s own
-sub-stages) — though that memoization isn't fully reliable yet, see
+below the step level, e.g. within `import_atp`/`import_osm`’s own
+sub-stages) — though that memoization isn’t fully reliable yet, see
 [#704](https://github.com/alltheplaces/osm-diffs/issues/704).
 `pipeline.log` itself is uploaded to S3 at the very end of a run no
 matter how the run went (see
@@ -195,25 +211,22 @@ never lost.
 
 ### Pipeline steps
 
-Timings below (where known) come from two real full-planet runs on
-production-representative hardware, not a dev machine: a deliberately
-memory-constrained, bare (uncontainerized) Hetzner cpx22 (2 vCPU / 4 GB
-RAM) with its working directory on an attached volume that peaked at
-~174 GB used (settling to ~148 GB once `import_osm` finished) — see
-[#665](https://github.com/alltheplaces/osm-diffs/issues/665) for the
-full writeup — and a later, containerized Hetzner cpx42 (8 vCPU / 16 GB
-RAM, `podman run --memory=12g --cpus=6`), run in the course of
-validating [#722](https://github.com/alltheplaces/osm-diffs/issues/722)
-(and feeding into [#711](https://github.com/alltheplaces/osm-diffs/issues/711)'s
-memory-limit sweep). The two aren't directly comparable — different
-CPU/memory/container configuration — so both are cited below where
-they cover the same step, rather than one silently overwriting the
-other. Nothing aggregates or dashboards these on an ongoing basis, but
-every run's `pipeline.log` — with per-step timings for that specific
-run — is uploaded to S3 alongside its output (see `upload_logs` above),
-so up-to-date numbers are always one log fetch away. Treat the ones
-below as data points rather than a guarantee — worth refreshing
-occasionally as the planet grows and the code changes.
+Timings below come from two full-planet runs on production-representative
+hardware, not a dev machine: a deliberately memory-constrained, bare
+(uncontainerized) Hetzner cpx22 (2 vCPU / 4 GB RAM, peaking at ~174 GB
+disk used) — see [#665](https://github.com/alltheplaces/osm-diffs/issues/665)
+for the full writeup — and a later, containerized Hetzner cpx42 (8 vCPU
+/ 16 GB RAM, `podman run --memory=12g --cpus=6`) from the
+[#711](https://github.com/alltheplaces/osm-diffs/issues/711)/[#722](https://github.com/alltheplaces/osm-diffs/issues/722)
+`--mem-limit` sweep — see [`PRODUCTION.md`](PRODUCTION.md) for that
+sweep’s full results and the recommended production configuration. The
+two runs used different hardware and container configuration, so
+aren’t directly comparable to each other; both are cited below where
+they cover the same step. Treat the numbers below as data points
+worth refreshing occasionally, not a guarantee — every run’s own
+`pipeline.log` is uploaded to S3 alongside its output (see
+[`LOGGING.md`](LOGGING.md)), so up-to-date numbers are always one log
+fetch away.
 
 - **`import_atp`** ([`src/pipeline/atp/`](../src/pipeline/atp/)) —
   downloads AllThePlaces’ latest published run (`fetch.rs`) and parses
@@ -263,8 +276,8 @@ occasionally as the planet grows and the code changes.
   [`docs/outputs/CONFLATED_PARQUET.md`](outputs/CONFLATED_PARQUET.md)
   for that file’s schema. **~8 minutes** (~5 min matching, ~3 min
   writing) for 3.8M ATP features against the full OpenStreetMap
-  planet, on the #665 bare-VM run. **10m37s** (636.95s) on the cpx42
-  run, writing 1,731,159 rows (719,507 matched).
+  planet, on the #665 bare-VM run. **10m37s** on the cpx42 run,
+  writing 1,731,159 rows (719,507 matched).
 - **`suggest_edits`** ([`src/pipeline/edits.rs`](../src/pipeline/edits.rs))
   — scans `conflated.parquet` for matched rows and asks an
   [`edit_suggesters`](../src/edit_suggesters/) implementation what
@@ -314,19 +327,19 @@ configured cgroup memory limit at all — `cgroup_current_bytes` is
 normally still populated (systemd puts every service unit into its own
 cgroup even outside a container), but `cgroup_max_bytes` reads `None`
 without one; see
-[`src/pipeline/memstats.rs`](../src/pipeline/memstats.rs)'s own doc
+[`src/pipeline/memstats.rs`](../src/pipeline/memstats.rs)’s own doc
 comment. The design’s central bet is specifically about page-cache
 accounting *under* such a limit, which only a real container can
-exercise. The cpx42 run cited above gives a first container data
-point: under a comfortable 12 GB `podman --memory` limit,
-`rss_file_bytes` again dominated during `conflate.match` (11.0 GB of
-11.2 GB total RSS), with no OOM-kill even while `cgroup_current_bytes`
-briefly touched 89–90% of the limit during the later, non-`conflate`
-steps. That’s encouraging, but it’s one comfortable limit, not yet the
-deliberately tight `--mem-limit` sweep
-[#711](https://github.com/alltheplaces/osm-diffs/issues/711) calls for
-to find where the design actually starts to strain — see that issue
-for the current status.
+exercise. The cpx42 run cited above gave a first container data point:
+under a comfortable 12 GB `podman --memory` limit, `rss_file_bytes`
+again dominated during `conflate.match` (11.0 GB of 11.2 GB total
+RSS), with no OOM-kill even while `cgroup_current_bytes` briefly
+touched 89–90% of the limit during the later, non-`conflate` steps. A
+follow-up `--mem-limit` sweep down to genuinely tight limits
+([#711](https://github.com/alltheplaces/osm-diffs/issues/711))
+confirmed the design holds well below that comfortable baseline too —
+see [`PRODUCTION.md`](PRODUCTION.md) for the full results and the
+recommended production memory limit.
 
 ### Code structure
 

--- a/docs/outputs/README.md
+++ b/docs/outputs/README.md
@@ -1,10 +1,10 @@
 # Output files
 
 This directory documents the files this project produces for public
-consumption — what's in them, and how to read them. (For how the
+consumption — what’s in them, and how to read them. (For how the
 pipeline itself is built and tested, see the parent [`docs/`](../)
 directory instead — those pages are for people working on the
-pipeline's code, not for people using its output.)
+pipeline’s code, not for people using its output.)
 
 - [`CONFLATED_PARQUET.md`](CONFLATED_PARQUET.md) — `conflated.parquet`,
   pairing AllThePlaces features with their matching OpenStreetMap


### PR DESCRIPTION
A fresh-eyes read of every doc in `docs/` plus both `README.md`s, checking that things make sense, are cross-linked correctly, and read well — with a particular focus on `TECHNICAL_DESIGN.md`, which had accumulated some scratchpad-y prose and one now-stale section.

## Real fixes
- `docs/LOGGING.md` linked to a nonexistent `src/logging.rs` — it actually lives at `src/pipeline/logging.rs`.
- `TECHNICAL_DESIGN.md`'s "Why `conflate` doesn't need its own cache" section framed the `--mem-limit` sweep ([#711](https://github.com/alltheplaces/osm-diffs/issues/711)) as still-open future work. It closed today — the section now says the sweep confirmed the design and points to `PRODUCTION.md` for the numbers, instead of duplicating them.
- Verified every relative link and `#anchor` across the doc set resolves.

## `TECHNICAL_DESIGN.md`
- Status line at the top now just says "Work in Progress — see 'Status' below" instead of restating context already covered by the README badge and the Status section itself.
- Added a Background subsection, "Working with data bigger than RAM," introducing external sorting + mmap/virtual memory/page cache at a light level (linking out to Wikipedia for background), since the design leans on this throughout `tables::` — cross-linked to the existing page-cache section and #711 for the empirical verification.
- Trimmed the "Pipeline steps" intro and a couple of other spots that had built up redundant hedging, and fixed a small grammar slip.

## Typography
- Straight `'`/`"` → curly `'`/`""` for consistency across `docs/` and both `README.md`s (most files already used curly quotes; a handful didn't).
- A few plain hyphens in numeric ranges → en dashes.
- `SECURITY.md` reflowed to match the rest of the doc set's line-wrapping style.
- `CODE_OF_CONDUCT.md` deliberately left untouched — it's verbatim Contributor Covenant boilerplate.

No spelling errors found; cross-linking and doc placement were otherwise already sound, so `TESTING.md`, `RELEASING.md`, `SUPPLY_CHAIN_SECURITY.md`, and `outputs/CONFLATED_PARQUET.md` are unchanged beyond what's noted above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)