### PR TITLE
docs: document temporary download location for current output

### DIFF
--- a/docs/outputs/CONFLATED_PARQUET.md
+++ b/docs/outputs/CONFLATED_PARQUET.md
@@ -1,5 +1,8 @@
 # `conflated.parquet`
 
+*Looking to download this file rather than read about its format? See
+[downloading the current output](README.md#downloading-the-current-output).*
+
 For every feature [AllThePlaces](https://alltheplaces.xyz/) scrapes
 that plausibly maps to something in
 [OpenStreetMap](https://www.openstreetmap.org/), this file has one row

--- a/docs/outputs/README.md
+++ b/docs/outputs/README.md
@@ -9,3 +9,18 @@ pipeline’s code, not for people using its output.)
 - [`CONFLATED_PARQUET.md`](CONFLATED_PARQUET.md) — `conflated.parquet`,
   pairing AllThePlaces features with their matching OpenStreetMap
   features.
+
+## Downloading the current output
+
+The pipeline isn’t running in production yet (see
+[`docs/TECHNICAL_DESIGN.md`](../TECHNICAL_DESIGN.md#status)), so
+there’s no fixed, permanent place to fetch its output from. For now,
+though, the latest `conflated.parquet` is publicly downloadable at
+<https://cdn.diffed-places.org/conflated.parquet>, and the matching
+PMTiles archive can be inspected visually, right in the browser, at
+<https://pmtiles.io/#url=https://cdn.diffed-places.org/edits.pmtiles&inspectFeatures=true>.
+
+**This URL is temporary.** Once the pipeline moves to production,
+output will be published at a different, hopefully permanent
+location, and this one will stop being updated. Don’t build anything
+that depends on `cdn.diffed-places.org` staying around.


### PR DESCRIPTION
Documents that the pipeline's current output is publicly downloadable while it's still not running in production:

- `conflated.parquet` at `cdn.diffed-places.org/conflated.parquet`
- `edits.pmtiles` inspectable via pmtiles.io

Makes clear this location is temporary and will move once the pipeline reaches production, so nothing should be built to depend on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012a2RALc5Y8zDGwoDEWapF4