### PR TITLE
docs: split documentation index by audience

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,11 @@ manually check each edit before applying it to OpenStreetMap — which
 edits go where is still being worked out, see
 [#696](https://github.com/alltheplaces/osm-diffs/issues/696).
 
-New here? See [`docs/TECHNICAL_DESIGN.md`](docs/TECHNICAL_DESIGN.md)
-for why this exists and how it’s built,
-[`docs/CONTRIBUTING.md`](docs/CONTRIBUTING.md) to get started
-contributing, and [`docs/`](docs/) generally for testing, cutting a
-release, and our security practices. Looking for what the pipeline
-actually produces instead? See [`docs/outputs/`](docs/outputs/).
+Just want the data this pipeline produces? See
+[`docs/outputs/`](docs/outputs/) for what’s in it and how to read it.
+
+Want to build or run the pipeline itself? See
+[`docs/CONTRIBUTING.md`](docs/CONTRIBUTING.md) to get started,
+[`docs/TECHNICAL_DESIGN.md`](docs/TECHNICAL_DESIGN.md) for why this
+exists and how it’s built, and [`docs/`](docs/) generally for testing,
+cutting a release, and our security practices.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,16 @@
 # Documentation
 
+## Using the outputs
+
+Just want the data this pipeline produces? Start here.
+
+- [`outputs/`](outputs/) — the pipeline’s output files: what’s in
+  them, and how to read them.
+
+## Building the pipeline
+
+Want to work on the pipeline itself, or run it somewhere? Start here.
+
 - [`CONTRIBUTING.md`](CONTRIBUTING.md) — start here if you’re new.
 - [`TECHNICAL_DESIGN.md`](TECHNICAL_DESIGN.md) — why this pipeline
   exists, the background it builds on, and how it’s put together.
@@ -8,8 +19,6 @@
   lands.
 - [`LOGGING.md`](LOGGING.md) — the JSON log format `osm-diffs run`
   writes, and where weekly-run logs end up archived in S3.
-- [`outputs/`](outputs/) — the pipeline’s output files: what’s in
-  them, and how to read them.
 - [`RELEASING.md`](RELEASING.md) — how to cut a release of `osm-diffs`.
 - [`PRODUCTION.md`](PRODUCTION.md) — operational knowledge for running
   a released container somewhere real: hardware sizing, required
@@ -18,6 +27,9 @@
   behind our release process: containers, multi-architecture images,
   SBOM/CBOM, CycloneDX, build provenance and attestations, and
   immutable releases.
+
+## For everyone
+
 - [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) — how we expect people to
   treat each other in this project.
 - [`SECURITY.md`](SECURITY.md) — how to report a security vulnerability.


### PR DESCRIPTION
Most people opening `docs/` just want the data (`conflated.parquet`, `edits.pmtiles`), not to work on the pipeline. Splits `docs/README.md` into two sections:

- **Using the outputs** — just `outputs/`, for data consumers
- **Building the pipeline** — everything about developing, testing, releasing, and running it

Deliberately named "Building the pipeline" rather than "Internals" — the latter reads as a keep-out sign, and contributions are very welcome. `CODE_OF_CONDUCT.md`/`SECURITY.md` apply to both audiences, so they stay in a small "For everyone" group at the end.

Mirrors the same split in the top-level `README.md`'s closing pointer paragraph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012a2RALc5Y8zDGwoDEWapF4