### PR TITLE
Memory/refactor cleanups found while sizing #709

### DIFF
--- a/src/pipeline/edits.rs
+++ b/src/pipeline/edits.rs
@@ -13,11 +13,10 @@
 
 use crate::edit_suggesters::create_edit_suggester;
 use crate::pipeline::EXTERNAL_SORT_CHUNK_BYTES;
+use crate::utils::parquet::{get_binary, get_string, get_struct, get_tags, get_u32, get_u64};
 use crate::{TileLayer, make_progress_bar};
 use anyhow::{Context, Result};
-use arrow::array::{
-    Array, BinaryArray, MapArray, RecordBatch, StringArray, StructArray, UInt32Array, UInt64Array,
-};
+use arrow::array::{Array, RecordBatch};
 use deepsize::DeepSizeOf;
 use ext_sort::{ExternalSorter, ExternalSorterBuilder, buffer::mem::MemoryLimitedBufferBuilder};
 use geo::Centroid;
@@ -272,7 +271,7 @@ fn extract_conflated_row(batch: &RecordBatch, row: usize) -> Result<Option<Confl
     if osm.is_null(row) {
         return Ok(None);
     }
-    let modified = get_child_struct(osm, "modified")?;
+    let modified = get_struct(osm, "modified")?;
 
     Ok(Some(ConflatedRow {
         atp_tags: get_tags(atp, "tags", row)?,
@@ -283,98 +282,8 @@ fn extract_conflated_row(batch: &RecordBatch, row: usize) -> Result<Option<Confl
         // Top-level, not nested inside `osm` -- GeoParquet 2.0 requires
         // geometry columns to live at the schema root (see
         // `pipeline::conflate::writer::GEO_METADATA_KEY`'s doc comment).
-        osm_geometry_wkb: get_batch_binary(batch, "osm_geometry", row)?,
+        osm_geometry_wkb: get_binary(batch, "osm_geometry", row)?,
     }))
-}
-
-fn get_struct<'a>(batch: &'a RecordBatch, name: &str) -> Result<&'a StructArray> {
-    batch
-        .column_by_name(name)
-        .with_context(|| format!("missing column '{name}'"))?
-        .as_any()
-        .downcast_ref::<StructArray>()
-        .with_context(|| format!("column '{name}' is not a struct"))
-}
-
-fn get_child_struct<'a>(s: &'a StructArray, name: &str) -> Result<&'a StructArray> {
-    s.column_by_name(name)
-        .with_context(|| format!("missing field '{name}'"))?
-        .as_any()
-        .downcast_ref::<StructArray>()
-        .with_context(|| format!("field '{name}' is not a struct"))
-}
-
-fn get_string(s: &StructArray, name: &str, row: usize) -> Result<String> {
-    Ok(s.column_by_name(name)
-        .with_context(|| format!("missing field '{name}'"))?
-        .as_any()
-        .downcast_ref::<StringArray>()
-        .with_context(|| format!("field '{name}' is not a string"))?
-        .value(row)
-        .to_owned())
-}
-
-fn get_u64(s: &StructArray, name: &str, row: usize) -> Result<u64> {
-    Ok(s.column_by_name(name)
-        .with_context(|| format!("missing field '{name}'"))?
-        .as_any()
-        .downcast_ref::<UInt64Array>()
-        .with_context(|| format!("field '{name}' is not UInt64"))?
-        .value(row))
-}
-
-fn get_u32(s: &StructArray, name: &str, row: usize) -> Result<u32> {
-    Ok(s.column_by_name(name)
-        .with_context(|| format!("missing field '{name}'"))?
-        .as_any()
-        .downcast_ref::<UInt32Array>()
-        .with_context(|| format!("field '{name}' is not UInt32"))?
-        .value(row))
-}
-
-/// Reads a top-level `RecordBatch` column -- `osm_geometry`/`atp_geometry`
-/// live at the schema root, not nested inside the `osm`/`atp` structs
-/// (see `pipeline::conflate::writer::GEO_METADATA_KEY`'s doc comment),
-/// so this doesn't go through `StructArray` the way the `get_*` helpers
-/// above do.
-fn get_batch_binary(batch: &RecordBatch, name: &str, row: usize) -> Result<Vec<u8>> {
-    Ok(batch
-        .column_by_name(name)
-        .with_context(|| format!("missing column '{name}'"))?
-        .as_any()
-        .downcast_ref::<BinaryArray>()
-        .with_context(|| format!("column '{name}' is not binary"))?
-        .value(row)
-        .to_vec())
-}
-
-fn get_tags(s: &StructArray, name: &str, row: usize) -> Result<Vec<(String, String)>> {
-    let col = s
-        .column_by_name(name)
-        .with_context(|| format!("missing field '{name}'"))?
-        .as_any()
-        .downcast_ref::<MapArray>()
-        .with_context(|| format!("field '{name}' is not a map"))?;
-
-    let entry = col.value(row);
-    let keys = entry
-        .column_by_name("key")
-        .with_context(|| format!("map '{name}' has no 'key' field"))?
-        .as_any()
-        .downcast_ref::<StringArray>()
-        .with_context(|| format!("map '{name}' keys are not strings"))?;
-    let values = entry
-        .column_by_name("value")
-        .with_context(|| format!("map '{name}' has no 'value' field"))?
-        .as_any()
-        .downcast_ref::<StringArray>()
-        .with_context(|| format!("map '{name}' values are not strings"))?;
-
-    let mut tags = Vec::with_capacity(keys.len());
-    for i in 0..keys.len() {
-        tags.push((keys.value(i).to_owned(), values.value(i).to_owned()));
-    }
-    Ok(tags)
 }
 
 /// Every call site (see `suggest_edits` above) spawns exactly three of

--- a/src/pipeline/memstats.rs
+++ b/src/pipeline/memstats.rs
@@ -109,6 +109,19 @@ pub struct MemStats {
     /// bytes. Requires Linux 5.19+ (`memory.peak`); `None` on older
     /// kernels.
     pub cgroup_peak_bytes: Option<u64>,
+
+    /// Peak resident set size of this process's *terminated, reaped*
+    /// children, in bytes -- macOS only (`getrusage(RUSAGE_CHILDREN)`).
+    /// Exists because `rss_peak_bytes` above is `RUSAGE_SELF`, which
+    /// explicitly excludes child processes: without this, a step that
+    /// shells out (e.g. `pipeline::tiles`'s `tippecanoe` subprocess)
+    /// would show no memory usage at all in a local macOS run's
+    /// `pipeline.log`, even though `run_step` already waits for the
+    /// child to exit before taking its "end" snapshot. On Linux this is
+    /// deliberately left `None`: `cgroup_current_bytes`/`cgroup_peak_bytes`
+    /// already account for every process sharing the cgroup, children
+    /// included, so there's nothing this field would add there.
+    pub children_rss_peak_bytes: Option<u64>,
 }
 
 impl MemStats {
@@ -130,7 +143,7 @@ impl std::fmt::Display for MemStats {
     /// that are `None` -- meant to be interpolated straight into a
     /// `log::info!` message, e.g. `"step start: {name} {snapshot}"`.
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let fields: [(&str, Option<u64>); 8] = [
+        let fields: [(&str, Option<u64>); 9] = [
             ("rss_bytes", self.rss_bytes),
             ("rss_peak_bytes", self.rss_peak_bytes),
             ("rss_anon_bytes", self.rss_anon_bytes),
@@ -139,6 +152,7 @@ impl std::fmt::Display for MemStats {
             ("cgroup_current_bytes", self.cgroup_current_bytes),
             ("cgroup_max_bytes", self.cgroup_max_bytes),
             ("cgroup_peak_bytes", self.cgroup_peak_bytes),
+            ("children_rss_peak_bytes", self.children_rss_peak_bytes),
         ];
         let mut first = true;
         for (name, value) in fields {
@@ -302,22 +316,24 @@ mod macos {
 
     pub(super) fn snapshot() -> MemStats {
         MemStats {
-            rss_peak_bytes: peak_rss_bytes(),
+            rss_peak_bytes: peak_rss_bytes(libc::RUSAGE_SELF),
+            children_rss_peak_bytes: peak_rss_bytes(libc::RUSAGE_CHILDREN),
             ..MemStats::default()
         }
     }
 
-    /// Returns this process's peak resident set size since it started,
-    /// in bytes -- the same "maximum resident set size" figure
-    /// `/usr/bin/time -l` reports. Deliberately not `phys_footprint`;
-    /// see the module docs.
-    fn peak_rss_bytes() -> Option<u64> {
+    /// Returns the peak resident set size of either this process
+    /// (`who = RUSAGE_SELF`, the same "maximum resident set size"
+    /// figure `/usr/bin/time -l` reports) or its terminated, reaped
+    /// children (`who = RUSAGE_CHILDREN`), in bytes. Deliberately not
+    /// `phys_footprint`; see the module docs.
+    fn peak_rss_bytes(who: libc::c_int) -> Option<u64> {
         // SAFETY: `usage` is a plain-old-data struct that `getrusage`
         // fully overwrites on success (return value 0); we only read it
         // in that case.
         unsafe {
             let mut usage: libc::rusage = std::mem::zeroed();
-            if libc::getrusage(libc::RUSAGE_SELF, &mut usage) == 0 {
+            if libc::getrusage(who, &mut usage) == 0 {
                 // On Darwin, ru_maxrss is already in bytes (unlike
                 // Linux, where the same field is in kilobytes).
                 u64::try_from(usage.ru_maxrss).ok()
@@ -335,13 +351,24 @@ mod macos {
         fn test_peak_rss_bytes_is_nonzero() {
             // Every process has touched at least some resident memory
             // by the time it's running test code.
-            assert!(peak_rss_bytes().unwrap_or(0) > 0);
+            assert!(peak_rss_bytes(libc::RUSAGE_SELF).unwrap_or(0) > 0);
+        }
+
+        #[test]
+        fn test_peak_rss_bytes_children_succeeds() {
+            // Not necessarily nonzero -- other tests in this same
+            // process may or may not have spawned+reaped a child by
+            // now, and `cargo test`'s parallel execution makes that
+            // order unpredictable -- but getrusage(RUSAGE_CHILDREN)
+            // itself should always succeed.
+            assert!(peak_rss_bytes(libc::RUSAGE_CHILDREN).is_some());
         }
 
         #[test]
         fn test_snapshot_populates_rss_peak_bytes() {
             let stats = snapshot();
             assert!(stats.rss_peak_bytes.is_some());
+            assert!(stats.children_rss_peak_bytes.is_some());
             assert_eq!(stats.rss_bytes, None);
             assert_eq!(stats.cgroup_current_bytes, None);
         }

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -114,19 +114,29 @@ fn run_pipeline_steps(
     let _wikidata_ids = run_step("collect_wikidata_ids", || {
         atp::collect_wikidata_ids(&atp, workdir)
     })?;
-    let osm_features = run_step("import_osm", || {
-        osm::import_osm(http_client, progress, workdir)
-    })?;
-    let conflated = run_step("conflate", || {
-        conflate::conflate(
-            &atp,
-            &osm_features,
-            progress,
-            workdir,
-            pipeline_run_id,
-            pipeline_start_time,
-        )
-    })?;
+    // `osm_features` is scoped to just these two steps, not bound at
+    // this function's top level: it's an `OsmFeatureIndex`, holding the
+    // pipeline's largest mmap'd tables (coordinates, features, the
+    // inverted index -- tens of GB on a full-planet run). Nothing after
+    // `conflate()` needs it, so it should drop -- unmapping those tables
+    // -- right here, instead of pinning that address space for the rest
+    // of the pipeline's steps (`suggest_edits`, `render_tiles`, and
+    // beyond) for no reason.
+    let conflated = {
+        let osm_features = run_step("import_osm", || {
+            osm::import_osm(http_client, progress, workdir)
+        })?;
+        run_step("conflate", || {
+            conflate::conflate(
+                &atp,
+                &osm_features,
+                progress,
+                workdir,
+                pipeline_run_id,
+                pipeline_start_time,
+            )
+        })?
+    };
     run_step("upload_conflated", || {
         upload::upload_conflated(&conflated, progress)
     })?;

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -218,7 +218,8 @@ fn log_snapshot(name: &str, phase: &str, elapsed_seconds: Option<f64>) {
         rss_shmem_bytes = stats.rss_shmem_bytes,
         cgroup_current_bytes = stats.cgroup_current_bytes,
         cgroup_max_bytes = stats.cgroup_max_bytes,
-        cgroup_peak_bytes = stats.cgroup_peak_bytes;
+        cgroup_peak_bytes = stats.cgroup_peak_bytes,
+        children_rss_peak_bytes = stats.children_rss_peak_bytes;
         "{name}: {phase}"
     );
     if let Some(fraction) = stats.cgroup_usage_fraction()

--- a/src/places/reader.rs
+++ b/src/places/reader.rs
@@ -7,14 +7,19 @@
 //! hit for.
 
 use anyhow::{Context, Result};
-use arrow::array::{
-    Array, BinaryArray, Int64Array, MapArray, RecordBatch, StringArray, UInt16Array, UInt64Array,
-};
+use arrow::array::{Array, Int64Array, RecordBatch};
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use std::fs::File;
 use std::path::{Path, PathBuf};
 
-use crate::{matchers::MatchMask, places::Place, utils::UtcTimestamp};
+use crate::{
+    matchers::MatchMask,
+    places::Place,
+    utils::{
+        UtcTimestamp,
+        parquet::{get_binary, get_string, get_tags, get_u16, get_u64},
+    },
+};
 
 pub struct PlaceReader {
     file_path: PathBuf,
@@ -65,11 +70,11 @@ impl PlaceReader {
 
 fn extract_place(batch: &RecordBatch, row: usize) -> Result<Place> {
     Ok(Place {
-        s2_cell_id: get_u64_required(batch, "s2_cell_id", row)?,
-        spider: get_string_required(batch, "spider", row)?,
-        mask: MatchMask(get_u16_required(batch, "mask", row)?),
-        tags: get_tags(batch, row)?,
-        shape_wkb: get_binary_required(batch, "shape", row)?,
+        s2_cell_id: get_u64(batch, "s2_cell_id", row)?,
+        spider: get_string(batch, "spider", row)?,
+        mask: MatchMask(get_u16(batch, "mask", row)?),
+        tags: get_tags(batch, "tags", row)?,
+        shape_wkb: get_binary(batch, "shape", row)?,
         fetched: get_fetched(batch, row)?,
     })
 }
@@ -77,7 +82,7 @@ fn extract_place(batch: &RecordBatch, row: usize) -> Result<Place> {
 fn get_fetched(batch: &RecordBatch, row: usize) -> Result<UtcTimestamp> {
     let millis = batch
         .column_by_name("fetched")
-        .context("missing required column 'fetched'")?
+        .context("missing column 'fetched'")?
         .as_any()
         .downcast_ref::<Int64Array>()
         .context("column 'fetched' is not Int64")?
@@ -85,77 +90,6 @@ fn get_fetched(batch: &RecordBatch, row: usize) -> Result<UtcTimestamp> {
     let t = time::UtcDateTime::from_unix_timestamp_nanos(i128::from(millis) * 1_000_000)
         .with_context(|| format!("invalid 'fetched' timestamp: {millis} ms"))?;
     Ok(UtcTimestamp(t))
-}
-
-fn get_u64_required(batch: &RecordBatch, name: &str, row: usize) -> Result<u64> {
-    Ok(batch
-        .column_by_name(name)
-        .with_context(|| format!("missing required column '{name}'"))?
-        .as_any()
-        .downcast_ref::<UInt64Array>()
-        .with_context(|| format!("column '{name}' is not UInt64"))?
-        .value(row))
-}
-
-fn get_u16_required(batch: &RecordBatch, name: &str, row: usize) -> Result<u16> {
-    Ok(batch
-        .column_by_name(name)
-        .with_context(|| format!("missing required column '{name}'"))?
-        .as_any()
-        .downcast_ref::<UInt16Array>()
-        .with_context(|| format!("column '{name}' is not UInt16"))?
-        .value(row))
-}
-
-fn get_string_required(batch: &RecordBatch, name: &str, row: usize) -> Result<String> {
-    Ok(batch
-        .column_by_name(name)
-        .with_context(|| format!("missing required column '{name}'"))?
-        .as_any()
-        .downcast_ref::<StringArray>()
-        .with_context(|| format!("column '{name}' is not Utf8/String"))?
-        .value(row)
-        .to_owned())
-}
-
-fn get_binary_required(batch: &RecordBatch, name: &str, row: usize) -> Result<Vec<u8>> {
-    Ok(batch
-        .column_by_name(name)
-        .with_context(|| format!("missing required column '{name}'"))?
-        .as_any()
-        .downcast_ref::<BinaryArray>()
-        .with_context(|| format!("column '{name}' is not Binary"))?
-        .value(row)
-        .to_vec())
-}
-
-fn get_tags(batch: &RecordBatch, row: usize) -> Result<Vec<(String, String)>> {
-    let col = batch
-        .column_by_name("tags")
-        .context("missing required column 'tags'")?
-        .as_any()
-        .downcast_ref::<MapArray>()
-        .context("column 'tags' is not a MapArray")?;
-
-    let map_entry = col.value(row);
-    let keys = map_entry
-        .column_by_name("key")
-        .context("map 'tags' has no 'key' field")?
-        .as_any()
-        .downcast_ref::<StringArray>()
-        .context("map 'tags' keys are not strings")?;
-    let values = map_entry
-        .column_by_name("value")
-        .context("map 'tags' has no 'value' field")?
-        .as_any()
-        .downcast_ref::<StringArray>()
-        .context("map 'tags' values are not strings")?;
-
-    let mut tags = Vec::with_capacity(keys.len());
-    for i in 0..keys.len() {
-        tags.push((keys.value(i).to_owned(), values.value(i).to_owned()));
-    }
-    Ok(tags)
 }
 
 #[cfg(test)]

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -4,6 +4,8 @@
 //! home for other such helpers as they accumulate, as long as they're
 //! genuinely small and genuinely cross-cutting.
 
+pub(crate) mod parquet;
+
 /// Renders `bytes` as a lowercase hex string, e.g. for a digest.
 pub(crate) fn to_hex(bytes: &[u8]) -> String {
     use std::fmt::Write;

--- a/src/utils/parquet.rs
+++ b/src/utils/parquet.rs
@@ -1,0 +1,130 @@
+//! Generic helpers for decoding a single row's worth of leaf values out
+//! of an Arrow [`RecordBatch`]/[`StructArray`] read back from a Parquet
+//! file -- shared by every reader in this crate that walks a
+//! `ParquetRecordBatchReaderBuilder`-produced batch by hand:
+//! `places::reader` (flat columns, for `alltheplaces.parquet`) and
+//! `pipeline::edits`/`pipeline::conflated_tiles` (nested `atp`/`osm`
+//! struct columns, for `conflated.parquet`).
+//!
+//! [`RecordBatch::column_by_name`] and [`StructArray::column_by_name`]
+//! have the identical signature -- `Option<&ArrayRef>` -- so
+//! [`ColumnSource`] unifies "look up a named column, whether at the
+//! schema root or nested inside a struct" behind one trait, and every
+//! function below is generic over it instead of being written twice.
+
+use anyhow::{Context, Result};
+use arrow::array::{
+    Array, ArrayRef, BinaryArray, MapArray, RecordBatch, StringArray, StructArray, UInt16Array,
+    UInt32Array, UInt64Array,
+};
+
+/// Something a named column can be looked up in -- a [`RecordBatch`]
+/// (columns at the schema root) or a [`StructArray`] (fields of a
+/// nested struct column, e.g. `conflated.parquet`'s `atp`/`osm`).
+pub(crate) trait ColumnSource {
+    fn column_by_name(&self, name: &str) -> Option<&ArrayRef>;
+}
+
+impl ColumnSource for RecordBatch {
+    fn column_by_name(&self, name: &str) -> Option<&ArrayRef> {
+        RecordBatch::column_by_name(self, name)
+    }
+}
+
+impl ColumnSource for StructArray {
+    fn column_by_name(&self, name: &str) -> Option<&ArrayRef> {
+        StructArray::column_by_name(self, name)
+    }
+}
+
+fn column<'a>(src: &'a impl ColumnSource, name: &str) -> Result<&'a ArrayRef> {
+    src.column_by_name(name)
+        .with_context(|| format!("missing column '{name}'"))
+}
+
+/// Looks up `name` as a nested struct column -- e.g. `conflated.parquet`'s
+/// top-level `osm` column, or `osm`'s own nested `modified` field. Works
+/// for both a [`RecordBatch`] and a [`StructArray`] source, since a
+/// struct-typed column decodes to a [`StructArray`] either way.
+pub(crate) fn get_struct<'a>(src: &'a impl ColumnSource, name: &str) -> Result<&'a StructArray> {
+    column(src, name)?
+        .as_any()
+        .downcast_ref::<StructArray>()
+        .with_context(|| format!("column '{name}' is not a struct"))
+}
+
+pub(crate) fn get_string(src: &impl ColumnSource, name: &str, row: usize) -> Result<String> {
+    Ok(column(src, name)?
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .with_context(|| format!("column '{name}' is not a string"))?
+        .value(row)
+        .to_owned())
+}
+
+pub(crate) fn get_u64(src: &impl ColumnSource, name: &str, row: usize) -> Result<u64> {
+    Ok(column(src, name)?
+        .as_any()
+        .downcast_ref::<UInt64Array>()
+        .with_context(|| format!("column '{name}' is not UInt64"))?
+        .value(row))
+}
+
+pub(crate) fn get_u32(src: &impl ColumnSource, name: &str, row: usize) -> Result<u32> {
+    Ok(column(src, name)?
+        .as_any()
+        .downcast_ref::<UInt32Array>()
+        .with_context(|| format!("column '{name}' is not UInt32"))?
+        .value(row))
+}
+
+pub(crate) fn get_u16(src: &impl ColumnSource, name: &str, row: usize) -> Result<u16> {
+    Ok(column(src, name)?
+        .as_any()
+        .downcast_ref::<UInt16Array>()
+        .with_context(|| format!("column '{name}' is not UInt16"))?
+        .value(row))
+}
+
+pub(crate) fn get_binary(src: &impl ColumnSource, name: &str, row: usize) -> Result<Vec<u8>> {
+    Ok(column(src, name)?
+        .as_any()
+        .downcast_ref::<BinaryArray>()
+        .with_context(|| format!("column '{name}' is not Binary"))?
+        .value(row)
+        .to_vec())
+}
+
+/// Decodes a `MAP<UTF8, UTF8>` column (e.g. `conflated.parquet`'s
+/// `atp.tags`/`osm.tags`, or `alltheplaces.parquet`'s `tags`) at `row`
+/// into key/value pairs, in the map's own order.
+pub(crate) fn get_tags(
+    src: &impl ColumnSource,
+    name: &str,
+    row: usize,
+) -> Result<Vec<(String, String)>> {
+    let col = column(src, name)?
+        .as_any()
+        .downcast_ref::<MapArray>()
+        .with_context(|| format!("column '{name}' is not a MapArray"))?;
+
+    let entry = col.value(row);
+    let keys = entry
+        .column_by_name("key")
+        .with_context(|| format!("map '{name}' has no 'key' field"))?
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .with_context(|| format!("map '{name}' keys are not strings"))?;
+    let values = entry
+        .column_by_name("value")
+        .with_context(|| format!("map '{name}' has no 'value' field"))?
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .with_context(|| format!("map '{name}' values are not strings"))?;
+
+    let mut tags = Vec::with_capacity(keys.len());
+    for i in 0..keys.len() {
+        tags.push((keys.value(i).to_owned(), values.value(i).to_owned()));
+    }
+    Ok(tags)
+}


### PR DESCRIPTION
Three small, independent cleanups found while sizing memory headroom for #709 (rendering `conflated.parquet` into its own PMTiles archive) — none of them depend on that feature's code, so splitting them out here.

1. **`pipeline: surface subprocess memory in local macOS runs`** — `memstats::snapshot()` read `getrusage(RUSAGE_SELF)` only, which excludes child processes. A step that shells out (e.g. `tiles::render_tiles`'s `tippecanoe` subprocess) showed no memory usage at all in a local macOS run's `pipeline.log`, even though `run_step` already waits for the child to exit before its "end" snapshot. Adds `children_rss_peak_bytes` via `getrusage(RUSAGE_CHILDREN)`. Linux is unaffected — `cgroup_current_bytes`/`cgroup_peak_bytes` already account for every process sharing the cgroup, children included.

2. **`pipeline: drop OsmFeatureIndex right after conflate(), not at the end`** — `osm_features` was bound at `run_pipeline_steps`'s top level, so it stayed alive through every step after `conflate()` (`upload_conflated`, `suggest_edits`, `render_tiles`, `upload_tiles`), even though nothing past `conflate()` ever touches it again. `OsmFeatureIndex` holds this pipeline's largest mmap'd tables (coordinates, features, the inverted index — tens of GB on a full-planet run), so this pinned that whole address space for no reason for the rest of a run. Scoped it to a block covering just `import_osm`+`conflate`.

3. **`refactor: unify Arrow leaf-decoding helpers into utils::parquet`** — `places::reader` and `pipeline::edits` each had their own copy of the same string/u64/u32/u16/binary/tags-map extraction logic for decoding an Arrow `RecordBatch`/`StructArray` row by hand. `RecordBatch::column_by_name` and `StructArray::column_by_name` share the identical `Option<&ArrayRef>` signature, so a small `ColumnSource` trait unifies both behind one implementation, in a new `utils::parquet` (splitting `utils.rs` into `utils/mod.rs` + `utils/parquet.rs`). No behavior change — both modules' existing tests pass unchanged.

`cargo test`, `cargo clippy --all-targets`, and `cargo fmt --check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012a2RALc5Y8zDGwoDEWapF4
