### PR TITLE
feat: render conflated.parquet into its own PMTiles archive (#709)

### DIFF
--- a/docs/TECHNICAL_DESIGN.md
+++ b/docs/TECHNICAL_DESIGN.md
@@ -293,6 +293,9 @@ fetch away.
   `matched`/`unmatched`, for visualizing the *matching* step in
   isolation. See
   [`docs/outputs/CONFLATED_TILES.md`](outputs/CONFLATED_TILES.md).
+  **~3.3s**, writing 730,512 matched / 1,013,503 unmatched rows, on a
+  full-planet `conflated.parquet` (local run, Apple Silicon — not the
+  cpx42 numbers elsewhere on this page).
 - **`render_conflated_tiles`**
   ([`src/pipeline/tiles.rs`](../src/pipeline/tiles.rs)) — runs
   [tippecanoe](https://github.com/felt/tippecanoe) over those layers to
@@ -300,8 +303,13 @@ fetch away.
   tippecanoe on the CLI, outside the pipeline) against a real
   full-planet `conflated.parquet` measured **3.64 GB peak RSS** /
   **656 MB output** for the entire unfiltered dataset (1.74M rows) —
-  comfortably under the production container’s 12 GB `--mem-limit`; not
-  yet re-measured from an actual full-planet pipeline run.
+  comfortably under the production container’s 12 GB `--mem-limit`.
+  Re-measured from an actual full-planet pipeline run afterwards (same
+  local machine as above, via `children_rss_peak_bytes`): **~1m48s**,
+  **1.87 GB peak RSS**, **768 MB output** — lower than the spike,
+  plausibly because splitting into two named layers (`matched`/
+  `unmatched`) rather than one combined layer changes tippecanoe’s own
+  memory profile.
 - **`suggest_edits`** ([`src/pipeline/edits.rs`](../src/pipeline/edits.rs))
   — scans `conflated.parquet` for matched rows and asks an
   [`edit_suggesters`](../src/edit_suggesters/) implementation what
@@ -317,7 +325,10 @@ fetch away.
   ([`src/pipeline/upload.rs`](../src/pipeline/upload.rs)) — push the
   data output and both sets of tiles to S3-compatible storage. **~5.5s**
   / *(not yet measured)* / **~3s** respectively at full-planet scale
-  (cpx42 run, except `upload_conflated_tiles`). `upload_logs` (same
+  (cpx42 run, except `upload_conflated_tiles`, which needs a real
+  S3-configured run to time — `conflated.pmtiles` is ~768 MB at
+  full-planet scale, several times `edits.pmtiles`’ size, so expect a
+  proportionally longer upload, not the same ~3s). `upload_logs` (same
   file, pushes the run’s own log) isn’t wrapped by the same per-step
   timing machinery as the others (see `run_pipeline` in
   [`src/pipeline/mod.rs`](../src/pipeline/mod.rs)), so it has no

--- a/docs/TECHNICAL_DESIGN.md
+++ b/docs/TECHNICAL_DESIGN.md
@@ -188,12 +188,15 @@ graph TD
     OSM_INDEX --> CONFLATE
     CONFLATE --> CONFLATED[conflated.parquet]
     CONFLATED --> UPLOAD_CONFLATED(upload_conflated) --> S3A[(S3)]
+    CONFLATED --> EXTRACT_CONFLATED_LAYERS(extract_conflated_layers) --> CONFLATED_LAYERS["matched.jsonl, unmatched.jsonl"]
+    CONFLATED_LAYERS --> RENDER_CONFLATED_TILES(render_conflated_tiles/tippecanoe) --> CONFLATED_PMTILES[conflated.pmtiles]
+    CONFLATED_PMTILES --> UPLOAD_CONFLATED_TILES(upload_conflated_tiles) --> S3C[(S3)]
     CONFLATED --> SUGGEST_EDITS(suggest_edits) --> LAYERS["*.jsonl (for visualization)"]
     LAYERS --> RENDER_TILES(render_tiles/tippecanoe) --> PMTILES[diffed-places.pmtiles]
     PMTILES --> UPLOAD_TILES(upload_tiles) --> S3B[(S3)]
 
     classDef process fill:#fce4ec,stroke:#ad1457,stroke-width:2px,color:#4a0e28,font-weight:bold;
-    class IMPORT_ATP,COLLECT_WIKI,IMPORT_OSM,CONFLATE,UPLOAD_CONFLATED,SUGGEST_EDITS,RENDER_TILES,UPLOAD_TILES process;
+    class IMPORT_ATP,COLLECT_WIKI,IMPORT_OSM,CONFLATE,UPLOAD_CONFLATED,EXTRACT_CONFLATED_LAYERS,RENDER_CONFLATED_TILES,UPLOAD_CONFLATED_TILES,SUGGEST_EDITS,RENDER_TILES,UPLOAD_TILES process;
 ```
 
 (Pink boxes are processing steps; plain rectangles are the files they
@@ -283,6 +286,22 @@ fetch away.
   writing) for 3.8M ATP features against the full OpenStreetMap
   planet, on the #665 bare-VM run. **10m37s** on the cpx42 run,
   writing 1,731,159 rows (719,507 matched).
+- **`extract_conflated_layers`**
+  ([`src/pipeline/conflated_tiles.rs`](../src/pipeline/conflated_tiles.rs))
+  — scans every row of `conflated.parquet` (matched or not, unlike
+  `suggest_edits` below) and splits it into two GeoJSON Lines layers,
+  `matched`/`unmatched`, for visualizing the *matching* step in
+  isolation. See
+  [`docs/outputs/CONFLATED_TILES.md`](outputs/CONFLATED_TILES.md).
+- **`render_conflated_tiles`**
+  ([`src/pipeline/tiles.rs`](../src/pipeline/tiles.rs)) — runs
+  [tippecanoe](https://github.com/felt/tippecanoe) over those layers to
+  build `conflated.pmtiles`. A pre-implementation spike (duckdb export +
+  tippecanoe on the CLI, outside the pipeline) against a real
+  full-planet `conflated.parquet` measured **3.64 GB peak RSS** /
+  **656 MB output** for the entire unfiltered dataset (1.74M rows) —
+  comfortably under the production container’s 12 GB `--mem-limit`; not
+  yet re-measured from an actual full-planet pipeline run.
 - **`suggest_edits`** ([`src/pipeline/edits.rs`](../src/pipeline/edits.rs))
   — scans `conflated.parquet` for matched rows and asks an
   [`edit_suggesters`](../src/edit_suggesters/) implementation what
@@ -290,15 +309,17 @@ fetch away.
   infrastructure, trees). **~20 seconds** at full-planet scale (cpx42
   run).
 - **`render_tiles`** ([`src/pipeline/tiles.rs`](../src/pipeline/tiles.rs))
-  — runs [tippecanoe](https://github.com/felt/tippecanoe) over those
-  layers to build one PMTiles archive for visual review. **~2m48s** at
-  full-planet scale (cpx42 run).
-- **`upload_conflated` / `upload_tiles`**
+  — runs tippecanoe over those layers to build `diffed-places.pmtiles`
+  for visual review. **~2m48s** at full-planet scale (cpx42 run). The
+  same function now builds both this and `conflated.pmtiles` above,
+  parameterized by output filename.
+- **`upload_conflated` / `upload_conflated_tiles` / `upload_tiles`**
   ([`src/pipeline/upload.rs`](../src/pipeline/upload.rs)) — push the
-  data output and the tiles to S3-compatible storage. **~5.5s** /
-  **~3s** respectively at full-planet scale (cpx42 run). `upload_logs`
-  (same file, pushes the run’s own log) isn’t wrapped by the same
-  per-step timing machinery as the others (see `run_pipeline` in
+  data output and both sets of tiles to S3-compatible storage. **~5.5s**
+  / *(not yet measured)* / **~3s** respectively at full-planet scale
+  (cpx42 run, except `upload_conflated_tiles`). `upload_logs` (same
+  file, pushes the run’s own log) isn’t wrapped by the same per-step
+  timing machinery as the others (see `run_pipeline` in
   [`src/pipeline/mod.rs`](../src/pipeline/mod.rs)), so it has no
   comparable number here — it’s a single small JSON file, not
   expected to be a meaningful cost either way.
@@ -379,7 +400,8 @@ Related documentation:
 
 We wanted to get the pipeline running end to end before polishing any
 single piece of it. As of this writing, it does: it produces
-`conflated.parquet` and a PMTiles archive for visual review, each
+`conflated.parquet` and two PMTiles archives for visual review — one of
+`conflated.parquet` itself, one of what `suggest_edits` proposes — each
 uploaded to S3 at the end of a run. What’s still ahead follows from
 that same choice — several pieces are deliberately simple placeholders
 until the full pipeline was proven out:
@@ -397,8 +419,10 @@ until the full pipeline was proven out:
   conflating municipal tree datasets against OSM by spatial distance
   and species looks particularly tractable). See
   [#708](https://github.com/alltheplaces/osm-diffs/issues/708).
-- `conflated.parquet` itself — every ATP feature, matched or not, not
-  just what `suggest_edits` decided to propose — has no visualization
-  of its own yet, which makes the matching step harder to review in
-  isolation. See
-  [#709](https://github.com/alltheplaces/osm-diffs/issues/709).
+- `conflated.pmtiles`' matched features show only the OpenStreetMap
+  side, not a visual link back to where AllThePlaces placed it —
+  see [#775](https://github.com/alltheplaces/osm-diffs/issues/775).
+- There’s no per-row match-confidence or cartographic-importance
+  signal yet, so both PMTiles archives rely entirely on tippecanoe’s
+  own density-based dropping at low zoom — see
+  [#713](https://github.com/alltheplaces/osm-diffs/issues/713).

--- a/docs/outputs/CONFLATED_TILES.md
+++ b/docs/outputs/CONFLATED_TILES.md
@@ -1,0 +1,56 @@
+# `conflated.pmtiles`
+
+*Looking to download this file rather than read about its format? See
+[downloading the current output](README.md#downloading-the-current-output).*
+
+Visualizes [`conflated.parquet`](CONFLATED_PARQUET.md) itself — every
+[AllThePlaces](https://alltheplaces.xyz/) feature, matched to
+[OpenStreetMap](https://www.openstreetmap.org/) or not — so the
+*matching* step can be reviewed on its own, independent of whatever
+[`edits.pmtiles`](../TECHNICAL_DESIGN.md) separately proposes changing.
+It's a [PMTiles](https://protomaps.com/docs/pmtiles) archive, built with
+[Tippecanoe](https://github.com/felt/tippecanoe) the same way
+`edits.pmtiles` is — see [`pmtiles.io`](https://pmtiles.io) for how to
+open one in a browser, no server required.
+
+## Layers
+
+Two layers, split by whether `conflate()` found an OpenStreetMap match:
+
+- **`matched`** — one feature per `conflated.parquet` row with an `osm`
+  side. Geometry is `osm_geometry`: the actual matched OpenStreetMap
+  shape (point, line, or polygon), since that's what a reviewer is
+  meant to look at.
+- **`unmatched`** — one feature per row with no OpenStreetMap match.
+  Geometry is `atp_geometry`: wherever AllThePlaces placed it.
+
+Every feature's coordinates are rounded to 1e-7 degrees (about 1 cm at
+the equator) before being written out — the same precision
+`edits.pmtiles`' features already use — so raw source-data precision
+noise doesn't inflate the file for no visual benefit.
+
+## Properties
+
+- `spider` — which AllThePlaces spider produced this feature (its
+  `atp.fetched.spider` in `conflated.parquet`).
+- `atp:<tag>` — every tag from the row's `atp.tags` map, one property
+  per tag.
+- `osm:type`, `osm:id`, and `osm:<tag>` for every tag in `osm.tags` —
+  present only on `matched` features.
+
+Tag properties are prefixed (`atp:name` vs. `osm:name`) rather than
+merged, since the two sides can and do disagree — that disagreement is
+often exactly what's worth reviewing.
+
+There's no match-confidence score yet — see
+[`CONFLATED_PARQUET.md`](CONFLATED_PARQUET.md) for why `conflate()`
+doesn't persist one today.
+
+## What this isn't (yet)
+
+A matched feature shows only the OpenStreetMap side, not a visual link
+back to where AllThePlaces placed it — see
+[#775](https://github.com/alltheplaces/osm-diffs/issues/775) for that
+idea (a connector line between the two), left for later since a vector
+tile feature can only be one geometry type, so it needs its own design
+and its own memory/size measurement, not a quick addition here.

--- a/docs/outputs/CONFLATED_TILES.md
+++ b/docs/outputs/CONFLATED_TILES.md
@@ -13,6 +13,12 @@ It's a [PMTiles](https://protomaps.com/docs/pmtiles) archive, built with
 `edits.pmtiles` is — see [`pmtiles.io`](https://pmtiles.io) for how to
 open one in a browser, no server required.
 
+⚠️ **This file is for visualization only** — a debugging aid for
+reviewing matching/conflation, not a data product. Its structure may
+change at any time, or we may stop producing it altogether, without
+notice. If you need something stable to build on, use
+[`conflated.parquet`](CONFLATED_PARQUET.md) instead.
+
 ## Layers
 
 Two layers, split by whether `conflate()` found an OpenStreetMap match:
@@ -41,10 +47,6 @@ noise doesn't inflate the file for no visual benefit.
 Tag properties are prefixed (`atp:name` vs. `osm:name`) rather than
 merged, since the two sides can and do disagree — that disagreement is
 often exactly what's worth reviewing.
-
-There's no match-confidence score yet — see
-[`CONFLATED_PARQUET.md`](CONFLATED_PARQUET.md) for why `conflate()`
-doesn't persist one today.
 
 ## What this isn't (yet)
 

--- a/docs/outputs/README.md
+++ b/docs/outputs/README.md
@@ -10,7 +10,8 @@ pipeline’s code, not for people using its output.)
   pairing AllThePlaces features with their matching OpenStreetMap
   features.
 - [`CONFLATED_TILES.md`](CONFLATED_TILES.md) — `conflated.pmtiles`,
-  visualizing `conflated.parquet` itself, matched or not.
+  visualizing `conflated.parquet`, matched or not, useful for
+  debugging.
 
 ## Downloading the current output
 

--- a/docs/outputs/README.md
+++ b/docs/outputs/README.md
@@ -9,6 +9,8 @@ pipeline’s code, not for people using its output.)
 - [`CONFLATED_PARQUET.md`](CONFLATED_PARQUET.md) — `conflated.parquet`,
   pairing AllThePlaces features with their matching OpenStreetMap
   features.
+- [`CONFLATED_TILES.md`](CONFLATED_TILES.md) — `conflated.pmtiles`,
+  visualizing `conflated.parquet` itself, matched or not.
 
 ## Downloading the current output
 
@@ -16,8 +18,11 @@ The pipeline isn’t running in production yet (see
 [`docs/TECHNICAL_DESIGN.md`](../TECHNICAL_DESIGN.md#status)), so
 there’s no fixed, permanent place to fetch its output from. For now,
 though, the latest `conflated.parquet` is publicly downloadable at
-<https://cdn.diffed-places.org/conflated.parquet>, and the matching
-PMTiles archive can be inspected visually, right in the browser, at
+<https://cdn.diffed-places.org/conflated.parquet>, and both PMTiles
+archives can be inspected visually, right in the browser:
+`conflated.pmtiles` (every AllThePlaces feature, matched or not) at
+<https://pmtiles.io/#url=https://cdn.diffed-places.org/conflated.pmtiles&inspectFeatures=true>,
+and `edits.pmtiles` (only what `suggest_edits` proposed) at
 <https://pmtiles.io/#url=https://cdn.diffed-places.org/edits.pmtiles&inspectFeatures=true>.
 
 **This URL is temporary.** Once the pipeline moves to production,

--- a/src/pipeline/conflated_tiles.rs
+++ b/src/pipeline/conflated_tiles.rs
@@ -256,3 +256,84 @@ fn extract_conflated_tile_row(batch: &RecordBatch, row: usize) -> Result<Option<
         osm,
     }))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wkb::writer::{WriteOptions, write_geometry};
+
+    fn encode_point(lon: f64, lat: f64) -> Vec<u8> {
+        let point = geo::point!(x: lon, y: lat);
+        let mut buf = Vec::new();
+        write_geometry(&mut buf, &point, &WriteOptions::default()).expect("encode point");
+        buf
+    }
+
+    #[test]
+    fn unmatched_row_uses_atp_geometry_and_only_atp_tags() {
+        let row = ConflatedTileRow {
+            spider: "acme".to_string(),
+            atp_tags: vec![("shop".to_string(), "bakery".to_string())],
+            atp_geometry_wkb: encode_point(8.5, 47.2),
+            osm: None,
+        };
+        let line = row.to_geojson_line().expect("to_geojson_line");
+        assert!(line.ends_with('\n'));
+        let value: Value = serde_json::from_str(line.trim_end()).expect("valid json");
+
+        assert_eq!(value["type"], "Feature");
+        assert_eq!(value["geometry"]["type"], "Point");
+        assert_eq!(
+            value["geometry"]["coordinates"],
+            Value::from(vec![8.5, 47.2])
+        );
+        assert_eq!(value["properties"]["spider"], "acme");
+        assert_eq!(value["properties"]["atp:shop"], "bakery");
+        assert!(value["properties"].get("osm:type").is_none());
+    }
+
+    #[test]
+    fn matched_row_uses_osm_geometry_and_both_tag_sets() {
+        let row = ConflatedTileRow {
+            spider: "acme".to_string(),
+            atp_tags: vec![("shop".to_string(), "bakery".to_string())],
+            atp_geometry_wkb: encode_point(8.5, 47.2),
+            osm: Some(OsmSide {
+                osm_type: "node".to_string(),
+                osm_id: 42,
+                osm_tags: vec![("shop".to_string(), "bakery".to_string())],
+                osm_geometry_wkb: encode_point(8.50001, 47.20001),
+            }),
+        };
+        let line = row.to_geojson_line().expect("to_geojson_line");
+        let value: Value = serde_json::from_str(line.trim_end()).expect("valid json");
+
+        // The OSM shape, not the ATP one -- that's the whole point of
+        // preferring it once matched.
+        assert_eq!(
+            value["geometry"]["coordinates"],
+            Value::from(vec![8.50001, 47.20001])
+        );
+        assert_eq!(value["properties"]["osm:id"], 42);
+        assert_eq!(value["properties"]["osm:type"], "node");
+        assert_eq!(value["properties"]["osm:shop"], "bakery");
+        assert_eq!(value["properties"]["atp:shop"], "bakery");
+    }
+
+    #[test]
+    fn geometry_coordinates_are_rounded_to_seven_decimal_places() {
+        let row = ConflatedTileRow {
+            spider: "acme".to_string(),
+            atp_tags: vec![],
+            atp_geometry_wkb: encode_point(8.123_456_789, 47.987_654_321),
+            osm: None,
+        };
+        let line = row.to_geojson_line().expect("to_geojson_line");
+        let value: Value = serde_json::from_str(line.trim_end()).expect("valid json");
+
+        assert_eq!(
+            value["geometry"]["coordinates"],
+            Value::from(vec![8.1234568, 47.9876543])
+        );
+    }
+}

--- a/src/pipeline/conflated_tiles.rs
+++ b/src/pipeline/conflated_tiles.rs
@@ -1,0 +1,258 @@
+//! Turns `conflated.parquet` (produced by `crate::pipeline::conflate`)
+//! into a PMTiles-ready pair of GeoJSON Lines tile layers, for
+//! visualizing the *matching* step itself -- every AllThePlaces
+//! feature, matched or not -- independent of whatever
+//! `crate::pipeline::edits` separately decides to propose as an edit
+//! (see [#709](https://github.com/alltheplaces/osm-diffs/issues/709)).
+//!
+//! Unlike `edits`, this doesn't need an external sort: it emits one
+//! output feature per input row, so there's nothing to deduplicate or
+//! merge across rows -- a straight sequential-batch, rayon-parallel-per-
+//! batch scan is enough.
+
+use crate::utils::parquet::{get_binary, get_string, get_struct, get_tags, get_u64};
+use crate::{TileLayer, make_progress_bar};
+use anyhow::{Context, Result};
+use arrow::array::{Array, RecordBatch};
+use geo::MapCoordsInPlace;
+use geo_traits::to_geo::ToGeoGeometry;
+use indicatif::{MultiProgress, ProgressBar};
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+use rayon::prelude::*;
+use serde_json::{Map, Value};
+use std::fs::{File, rename};
+use std::io::{BufWriter, Write};
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+use wkb::reader::read_wkb;
+
+/// One decoded row of `conflated.parquet`, kept whether or not it has
+/// an OSM match -- unlike `edits::ConflatedRow`, which only exists for
+/// matched rows (nothing to suggest an edit for otherwise). `None`
+/// means this row has no ATP side either -- the schema allows it even
+/// though `conflate()` never actually produces such a row -- and is
+/// skipped entirely, the same defensive handling `edits.rs` applies.
+struct ConflatedTileRow {
+    spider: String,
+    atp_tags: Vec<(String, String)>,
+    atp_geometry_wkb: Vec<u8>,
+    osm: Option<OsmSide>,
+}
+
+struct OsmSide {
+    osm_type: String,
+    osm_id: u64,
+    osm_tags: Vec<(String, String)>,
+    osm_geometry_wkb: Vec<u8>,
+}
+
+impl ConflatedTileRow {
+    fn to_geojson_line(&self) -> Result<String> {
+        // Geometry: the actual OSM shape when matched (what a reviewer
+        // is meant to review -- point/line/polygon, all valid within
+        // one GeoJSON/MVT layer), the raw ATP-provided shape otherwise.
+        // Simplest useful choice for v1 -- see
+        // https://github.com/alltheplaces/osm-diffs/issues/775 for a
+        // richer "union of atp_geometry + osm_geometry + a connector
+        // line between their centroids" idea deliberately left for
+        // later: a Mapbox Vector Tile feature can only be one geometry
+        // type, so that idea needs three separate features per matched
+        // row, not one, and deserves its own memory/size measurement.
+        //
+        // TODO(#713): once conflated.parquet carries a per-row rank/
+        // importance signal, this is the natural place to also emit it
+        // as a feature property (or otherwise feed it to tippecanoe),
+        // so --drop-densest-as-needed can prefer important places over
+        // low-priority ones at low zoom instead of today's
+        // density-only heuristic.
+        let geometry_wkb: &[u8] = match &self.osm {
+            Some(osm) => &osm.osm_geometry_wkb,
+            None => &self.atp_geometry_wkb,
+        };
+        let mut geometry = read_wkb(geometry_wkb)
+            .context("failed to decode geometry")?
+            .to_geometry();
+        // Let's not emit coordinates with fake sub-millimeter
+        // precision, particularly for atp_geometry, which is whatever
+        // precision AllThePlaces' upstream source happened to provide
+        // -- same 1e-7-degree rounding SuggestedEdit::to_geojson
+        // already applies to its own point.
+        geometry.map_coords_in_place(|c| geo::Coord {
+            x: (c.x * 1e7).round() / 1e7,
+            y: (c.y * 1e7).round() / 1e7,
+        });
+
+        let mut properties: Map<String, Value> = Map::new();
+        properties.insert("spider".to_string(), Value::String(self.spider.clone()));
+        for (k, v) in &self.atp_tags {
+            properties.insert(format!("atp:{k}"), Value::String(v.clone()));
+        }
+        if let Some(osm) = &self.osm {
+            properties.insert("osm:type".to_string(), Value::String(osm.osm_type.clone()));
+            properties.insert("osm:id".to_string(), Value::from(osm.osm_id));
+            for (k, v) in &osm.osm_tags {
+                properties.insert(format!("osm:{k}"), Value::String(v.clone()));
+            }
+        }
+
+        let feature = geojson::Feature {
+            bbox: None,
+            geometry: Some(geojson::Geometry::from(&geometry)),
+            id: None,
+            properties: Some(properties),
+            foreign_members: None,
+        };
+        let mut line = feature.to_string();
+        line.push('\n');
+        Ok(line)
+    }
+}
+
+pub fn extract_conflated_layers(
+    conflated: &Path,
+    progress: &MultiProgress,
+    workdir: &Path,
+) -> Result<Vec<TileLayer>> {
+    assert!(workdir.exists());
+
+    let layers = vec![
+        TileLayer {
+            name: String::from("matched"),
+            path: workdir.join("matched.jsonl"),
+        },
+        TileLayer {
+            name: String::from("unmatched"),
+            path: workdir.join("unmatched.jsonl"),
+        },
+    ];
+    if layers.iter().all(|layer| layer.path.exists()) {
+        return Ok(layers);
+    }
+
+    let num_rows = {
+        // Parquet row counts live in file metadata -- cheap, no row I/O.
+        let file = File::open(conflated)?;
+        ParquetRecordBatchReaderBuilder::try_new(file)?
+            .metadata()
+            .file_metadata()
+            .num_rows() as u64
+    };
+    let progress_bar = make_progress_bar(progress, "confl-tiles", num_rows, "conflated features");
+
+    let mut matched_tmp = PathBuf::from(&layers[0].path);
+    matched_tmp.add_extension("tmp");
+    let mut unmatched_tmp = PathBuf::from(&layers[1].path);
+    unmatched_tmp.add_extension("tmp");
+    let mut matched_writer = BufWriter::with_capacity(32768, File::create(&matched_tmp)?);
+    let mut unmatched_writer = BufWriter::with_capacity(32768, File::create(&unmatched_tmp)?);
+
+    let (num_matched, num_unmatched) = extract_rows(
+        conflated,
+        &progress_bar,
+        &mut matched_writer,
+        &mut unmatched_writer,
+    )?;
+    matched_writer.flush()?;
+    unmatched_writer.flush()?;
+    rename(&matched_tmp, &layers[0].path)?;
+    rename(&unmatched_tmp, &layers[1].path)?;
+
+    progress_bar.finish_with_message(format!(
+        "{} conflated features → {} matched, {} unmatched",
+        num_rows, num_matched, num_unmatched
+    ));
+
+    Ok(layers)
+}
+
+fn extract_rows(
+    conflated: &Path,
+    progress_bar: &ProgressBar,
+    matched_writer: &mut impl Write,
+    unmatched_writer: &mut impl Write,
+) -> Result<(u64, u64)> {
+    let start = Instant::now();
+    let mut num_matched = 0u64;
+    let mut num_unmatched = 0u64;
+
+    let file = File::open(conflated)?;
+    let reader = ParquetRecordBatchReaderBuilder::try_new(file)?.build()?;
+    for batch in reader {
+        let batch = batch?;
+        // Decoding + GeoJSON serialization is the CPU-heavy part of
+        // this loop; parallelize it per batch with Rayon, same as
+        // edits.rs's produce_edits, then write out sequentially --
+        // there's nothing to deduplicate or sort here, unlike edits.rs,
+        // so no channels/external sort are needed, just an ordered
+        // in-memory Vec per batch.
+        let lines: Vec<Option<(bool, String)>> = (0..batch.num_rows())
+            .into_par_iter()
+            .map(|row| -> Result<Option<(bool, String)>> {
+                let Some(row) = extract_conflated_tile_row(&batch, row)? else {
+                    return Ok(None);
+                };
+                let matched = row.osm.is_some();
+                Ok(Some((matched, row.to_geojson_line()?)))
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        for line in lines {
+            progress_bar.inc(1);
+            let Some((matched, line)) = line else {
+                continue;
+            };
+            if matched {
+                matched_writer.write_all(line.as_bytes())?;
+                num_matched += 1;
+            } else {
+                unmatched_writer.write_all(line.as_bytes())?;
+                num_unmatched += 1;
+            }
+        }
+    }
+
+    log::info!(
+        elapsed_seconds = start.elapsed().as_secs_f64(),
+        matched = num_matched,
+        unmatched = num_unmatched;
+        "extract_conflated_layers: done"
+    );
+    Ok((num_matched, num_unmatched))
+}
+
+/// `None` means this row has no ATP side -- the schema allows it even
+/// though `conflate()` never actually produces such a row -- nothing to
+/// visualize, but still a real row the caller should count against its
+/// progress bar. Unlike `edits::extract_conflated_row`, a `None` `osm`
+/// is kept, not skipped: an unmatched ATP feature is exactly what this
+/// module exists to show.
+fn extract_conflated_tile_row(batch: &RecordBatch, row: usize) -> Result<Option<ConflatedTileRow>> {
+    let atp = get_struct(batch, "atp")?;
+    if atp.is_null(row) {
+        return Ok(None);
+    }
+    let fetched = get_struct(atp, "fetched")?;
+
+    let osm = get_struct(batch, "osm")?;
+    let osm = if osm.is_null(row) {
+        None
+    } else {
+        Some(OsmSide {
+            osm_type: get_string(osm, "type", row)?,
+            osm_id: get_u64(osm, "id", row)?,
+            osm_tags: get_tags(osm, "tags", row)?,
+            // Top-level, not nested inside `osm` -- GeoParquet 2.0
+            // requires geometry columns to live at the schema root
+            // (see `pipeline::conflate::writer::GEO_METADATA_KEY`'s
+            // doc comment).
+            osm_geometry_wkb: get_binary(batch, "osm_geometry", row)?,
+        })
+    };
+
+    Ok(Some(ConflatedTileRow {
+        spider: get_string(fetched, "spider", row)?,
+        atp_tags: get_tags(atp, "tags", row)?,
+        atp_geometry_wkb: get_binary(batch, "atp_geometry", row)?,
+        osm,
+    }))
+}

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -31,6 +31,7 @@ pub(crate) const EXTERNAL_SORT_CHUNK_BYTES: usize = 512 * 1024 * 1024;
 
 mod atp;
 mod conflate;
+mod conflated_tiles;
 mod edits;
 mod logging;
 mod memstats;
@@ -140,11 +141,28 @@ fn run_pipeline_steps(
     run_step("upload_conflated", || {
         upload::upload_conflated(&conflated, progress)
     })?;
+
+    // Two independent branches off `conflated`, neither depending on
+    // the other: `conflated.pmtiles` (every ATP feature, matched or
+    // not -- see conflated_tiles's own doc comment) visualizes the
+    // *matching* step itself, while `diffed-places.pmtiles` below
+    // visualizes only what `suggest_edits` separately decided to
+    // propose.
+    let conflated_layers = run_step("extract_conflated_layers", || {
+        conflated_tiles::extract_conflated_layers(&conflated, progress, workdir)
+    })?;
+    let conflated_tiles_out = run_step("render_conflated_tiles", || {
+        tiles::render_tiles(&conflated_layers, progress, workdir, "conflated.pmtiles")
+    })?;
+    run_step("upload_conflated_tiles", || {
+        upload::upload_conflated_tiles(&conflated_tiles_out, progress)
+    })?;
+
     let edits = run_step("suggest_edits", || {
         edits::suggest_edits(&conflated, progress, workdir)
     })?;
     let tiles = run_step("render_tiles", || {
-        tiles::render_tiles(&edits, progress, workdir)
+        tiles::render_tiles(&edits, progress, workdir, "diffed-places.pmtiles")
     })?;
     run_step("upload_tiles", || upload::upload_tiles(&tiles, progress))?;
 

--- a/src/pipeline/tiles.rs
+++ b/src/pipeline/tiles.rs
@@ -10,8 +10,9 @@ pub fn render_tiles(
     layers: &[TileLayer],
     progress: &MultiProgress,
     workdir: &Path,
+    out_filename: &str,
 ) -> Result<PathBuf> {
-    let out_path = workdir.join("diffed-places.pmtiles");
+    let out_path = workdir.join(out_filename);
     if out_path.exists() {
         return Ok(out_path);
     }

--- a/src/pipeline/upload.rs
+++ b/src/pipeline/upload.rs
@@ -298,6 +298,16 @@ pub fn upload_conflated(conflated: &Path, progress: &MultiProgress) -> Result<()
     )
 }
 
+pub fn upload_conflated_tiles(tiles: &Path, progress: &MultiProgress) -> Result<()> {
+    upload_file(
+        tiles,
+        "conflated.pmtiles",
+        "application/vnd.pmtiles",
+        "upload.conflated-tiles",
+        progress,
+    )
+}
+
 /// Uploads `workdir`'s `pipeline.log` to `logs/<run-id>.log`, where
 /// `<run-id>` is `pipeline_start_time` -- the same timestamp already
 /// embedded into `conflated.parquet`'s provenance BOM as

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -45,6 +45,14 @@ fn test_pipeline() -> Result<()> {
 
     assert_conflated_parquet(&workdir.path().join("conflated.parquet"))?;
     assert_shops_jsonl(&workdir.path().join("shops.jsonl"))?;
+    assert_conflated_tile_layers(
+        &workdir.path().join("matched.jsonl"),
+        &workdir.path().join("unmatched.jsonl"),
+    )?;
+    assert!(
+        workdir.path().join("conflated.pmtiles").exists(),
+        "conflated.pmtiles was not produced"
+    );
 
     Ok(())
 }
@@ -353,6 +361,68 @@ fn assert_shops_jsonl(path: &Path) -> Result<()> {
         2,
         "unexpected extra tags in suggested edit: {edit}"
     );
+
+    Ok(())
+}
+
+/// Checks `extract_conflated_layers`'s output against the same fixture
+/// data `assert_conflated_parquet` checks: 3 matched + 3 unmatched ATP
+/// features (see `assert_conflated_parquet`'s own "expected 6 conflated
+/// rows" / "expected 3 ATP features matched" assertions above).
+fn assert_conflated_tile_layers(matched_path: &Path, unmatched_path: &Path) -> Result<()> {
+    let read_features = |path: &Path| -> Result<Vec<serde_json::Value>> {
+        let content =
+            std::fs::read_to_string(path).with_context(|| format!("could not read {path:?}"))?;
+        content
+            .lines()
+            .map(|line| Ok(serde_json::from_str(line)?))
+            .collect()
+    };
+
+    let matched = read_features(matched_path)?;
+    let unmatched = read_features(unmatched_path)?;
+    assert_eq!(
+        matched.len(),
+        3,
+        "expected 3 matched features in {matched_path:?}, got:\n{matched:#?}"
+    );
+    assert_eq!(
+        unmatched.len(),
+        3,
+        "expected 3 unmatched features in {unmatched_path:?}, got:\n{unmatched:#?}"
+    );
+
+    for feature in matched.iter().chain(&unmatched) {
+        assert_eq!(feature["type"], "Feature");
+        assert!(
+            feature["properties"]["spider"].is_string(),
+            "feature has no spider: {feature}"
+        );
+        assert!(
+            feature["properties"]
+                .as_object()
+                .expect("properties should be an object")
+                .keys()
+                .any(|k| k.starts_with("atp:")),
+            "feature has no atp:* properties: {feature}"
+        );
+    }
+    for feature in &unmatched {
+        assert!(
+            feature["properties"].get("osm:type").is_none(),
+            "unmatched feature should carry no osm:* properties: {feature}"
+        );
+    }
+
+    // Same known match `assert_shops_jsonl` checks above: MediaMarkt,
+    // matched to OSM way/737021556, a polygon.
+    let media_markt = matched
+        .iter()
+        .find(|f| f["properties"]["osm:id"] == 737021556)
+        .expect("expected a matched feature for OSM feature 737021556");
+    assert_eq!(media_markt["properties"]["osm:type"], "way");
+    assert_eq!(media_markt["geometry"]["type"], "Polygon");
+    assert_eq!(media_markt["properties"]["atp:shop"], "electronics");
 
     Ok(())
 }


### PR DESCRIPTION
Closes #709.

Adds `conflated.pmtiles`, visualizing `conflated.parquet` itself — every AllThePlaces feature, matched or not, plus whichever OSM feature it matched to — independent of whatever `suggest_edits`/`edit_suggesters` (a separate, still-evolving piece, #708) decides to propose as an edit.

Plan discussed in [#709's comments](https://github.com/alltheplaces/osm-diffs/issues/709#issuecomment-5439477041) before implementing, including a de-risking spike (duckdb export + tippecanoe on the CLI) against a real full-planet `conflated.parquet`: **3.64 GB peak RSS / 656 MB output** for the entire unfiltered dataset — comfortably under the production container's 12 GB `--mem-limit`.

## What's here

- `pipeline::conflated_tiles::extract_conflated_layers()` — scans `conflated.parquet` once, writes `matched.jsonl`/`unmatched.jsonl`. No external sort needed (unlike `edits.rs`): the input is already one row per ATP feature, so decoding is a straight rayon-parallel-per-batch scan.
- Per-row geometry: `osm_geometry` when matched (the real OSM shape), `atp_geometry` otherwise. Properties: `spider`, `atp:<tag>` per ATP tag, and when matched also `osm:type`/`osm:id`/`osm:<tag>` per OSM tag.
- `tiles::render_tiles` now takes an `out_filename` parameter instead of hardcoding `diffed-places.pmtiles`, so it builds both PMTiles archives.
- New `upload::upload_conflated_tiles`, mirroring `upload_tiles`, to S3 key `conflated.pmtiles`.
- Wired as three new pipeline steps — `extract_conflated_layers` → `render_conflated_tiles` → `upload_conflated_tiles` — a third branch off `conflated`, independent of the existing `suggest_edits`/`render_tiles`/`upload_tiles` branch.
- Docs: new `docs/outputs/CONFLATED_TILES.md`, `docs/outputs/README.md`'s list/download URLs, `docs/TECHNICAL_DESIGN.md`'s diagram/step timings/status section.

## Deliberately deferred

- **No match score.** `conflate()` computes one via `Matcher::score_osm_candidate` but discards it (`// TODO: Signals for ranking.`) — persisting it would touch the `Matcher` trait, the Arrow schema, and public docs, out of scope here.
- **No ATP↔OSM connector-line visualization.** A Mapbox Vector Tile feature can only be one geometry type, so that idea needs three separate features per matched row, not one — a distinct memory/size profile deserving its own measurement. Tracked as #775, with a `TODO` at the geometry line in `conflated_tiles.rs`.
- A `TODO(#713)` at the same spot for a future per-row rank/importance signal, so `--drop-densest-as-needed` can eventually prefer important places over low-priority ones at low zoom.

## Verification

- `cargo test`/`cargo clippy --all-targets`/`cargo fmt --check` all pass.
- Unit tests for `ConflatedTileRow::to_geojson_line`'s geometry-choice/rounding/property-prefixing logic.
- `tests/integration_test.rs` extended to assert `matched.jsonl`/`unmatched.jsonl` (3+3, matching the fixture's known counts) and `conflated.pmtiles`, checking the same known MediaMarkt match `assert_shops_jsonl` already checks.
- Ran the full pipeline manually against `tests/test_data`'s fixtures: `conflated.pmtiles` decodes with a valid PMTiles v3 header, `matched.jsonl`/`unmatched.jsonl` contents inspected by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012a2RALc5Y8zDGwoDEWapF4

