### PR TITLE
feat: draw the ATP↔OSM connector line in conflated.pmtiles at high zoom (#775)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,13 @@ jobs:
       run: |
         protoc --version
         tippecanoe --version
+        # tile-join ships in the same apt package as tippecanoe (same
+        # upstream source tree); tests/integration_test.rs now
+        # actually invokes it via pipeline::tiles::join_tiles, so
+        # confirm its presence here too, not just tippecanoe's --
+        # tile-join has no --version flag of its own, so just resolve
+        # it on PATH.
+        which tile-join
     - name: Install Rust coverage tool
       uses: taiki-e/install-action@6cd13508893c0e7eab5f273c2575d3859bd7229a # v2.86.6
       with:

--- a/Containerfile
+++ b/Containerfile
@@ -51,6 +51,13 @@ RUN echo "@edge https://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/ap
 # ----------------------------------------------------------------------------
 #  Stage 1.2: Build statically linked tippecanoe binary
 # ----------------------------------------------------------------------------
+#
+# `make install` also installs tile-join -- a sibling binary from this
+# same source tree/commit, used by pipeline::tiles::join_tiles to merge
+# conflated.pmtiles' overview and detail passes (see
+# pipeline::conflated_tiles' module doc comment). Not a second
+# dependency to track: same repo, same commit, same static-link
+# treatment, same license.
 
 WORKDIR /build/tippecanoe
 
@@ -63,12 +70,14 @@ RUN make -j"$(nproc)" \
         PREFIX=/usr/local \
         LDFLAGS="-static -static-libgcc -static-libstdc++" && \
     make install PREFIX=/usr/local && \
-    strip --strip-all /usr/local/bin/tippecanoe
+    strip --strip-all /usr/local/bin/tippecanoe /usr/local/bin/tile-join
 
-# Sanity-check: confirm the binary is truly statically linked
-RUN readelf -d /usr/local/bin/tippecanoe 2>&1 | grep -q NEEDED \
-    && (echo "✗ dynamic deps detected" && exit 1) \
-    || echo "✓ no dynamic library dependencies"
+# Sanity-check: confirm both binaries are truly statically linked
+RUN for bin in tippecanoe tile-join; do \
+        readelf -d "/usr/local/bin/$bin" 2>&1 | grep -q NEEDED \
+        && (echo "✗ dynamic deps detected in $bin" && exit 1) \
+        || echo "✓ no dynamic library dependencies in $bin"; \
+    done
 
 
 # ----------------------------------------------------------------------------
@@ -107,6 +116,7 @@ ARG VCS_REF
 ARG VCS_URL
 
 COPY --from=builder /usr/local/bin/tippecanoe /usr/local/bin/tippecanoe
+COPY --from=builder /usr/local/bin/tile-join /usr/local/bin/tile-join
     
 COPY --from=builder --chown=1000:1000  \
     /usr/osm-diffs/target/release/osm-diffs  \

--- a/docs/TECHNICAL_DESIGN.md
+++ b/docs/TECHNICAL_DESIGN.md
@@ -188,15 +188,22 @@ graph TD
     OSM_INDEX --> CONFLATE
     CONFLATE --> CONFLATED[conflated.parquet]
     CONFLATED --> UPLOAD_CONFLATED(upload_conflated) --> S3A[(S3)]
+
     CONFLATED --> EXTRACT_CONFLATED_LAYERS(extract_conflated_layers) --> CONFLATED_LAYERS["matched.jsonl, unmatched.jsonl"]
-    CONFLATED_LAYERS --> RENDER_CONFLATED_TILES(render_conflated_tiles/tippecanoe) --> CONFLATED_PMTILES[conflated.pmtiles]
+    CONFLATED_LAYERS --> RENDER_CONFLATED_OVERVIEW("render_conflated_overview<br/>(tippecanoe, z0..12)") --> OVERVIEW_PMTILES[conflated-overview.pmtiles]
+    CONFLATED --> EXTRACT_DETAIL(extract_matched_detail_layer) --> DETAIL_LAYER[matched-detail.jsonl]
+    DETAIL_LAYER --> RENDER_CONFLATED_DETAIL("render_conflated_detail<br/>(tippecanoe, z13..16)") --> DETAIL_PMTILES[conflated-detail.pmtiles]
+    OVERVIEW_PMTILES --> JOIN_CONFLATED_TILES(join_conflated_tiles/tile-join)
+    DETAIL_PMTILES --> JOIN_CONFLATED_TILES
+    JOIN_CONFLATED_TILES --> CONFLATED_PMTILES[conflated.pmtiles]
     CONFLATED_PMTILES --> UPLOAD_CONFLATED_TILES(upload_conflated_tiles) --> S3C[(S3)]
+
     CONFLATED --> SUGGEST_EDITS(suggest_edits) --> LAYERS["*.jsonl (for visualization)"]
-    LAYERS --> RENDER_TILES(render_tiles/tippecanoe) --> PMTILES[diffed-places.pmtiles]
+    LAYERS --> RENDER_TILES("render_tiles<br/>(tippecanoe, auto zoom)") --> PMTILES[diffed-places.pmtiles]
     PMTILES --> UPLOAD_TILES(upload_tiles) --> S3B[(S3)]
 
     classDef process fill:#fce4ec,stroke:#ad1457,stroke-width:2px,color:#4a0e28,font-weight:bold;
-    class IMPORT_ATP,COLLECT_WIKI,IMPORT_OSM,CONFLATE,UPLOAD_CONFLATED,EXTRACT_CONFLATED_LAYERS,RENDER_CONFLATED_TILES,UPLOAD_CONFLATED_TILES,SUGGEST_EDITS,RENDER_TILES,UPLOAD_TILES process;
+    class IMPORT_ATP,COLLECT_WIKI,IMPORT_OSM,CONFLATE,UPLOAD_CONFLATED,EXTRACT_CONFLATED_LAYERS,RENDER_CONFLATED_OVERVIEW,EXTRACT_DETAIL,RENDER_CONFLATED_DETAIL,JOIN_CONFLATED_TILES,UPLOAD_CONFLATED_TILES,SUGGEST_EDITS,RENDER_TILES,UPLOAD_TILES process;
 ```
 
 (Pink boxes are processing steps; plain rectangles are the files they
@@ -296,20 +303,51 @@ fetch away.
   **~3.3s**, writing 730,512 matched / 1,013,503 unmatched rows, on a
   full-planet `conflated.parquet` (local run, Apple Silicon — not the
   cpx42 numbers elsewhere on this page).
-- **`render_conflated_tiles`**
+- **`render_conflated_overview`**
   ([`src/pipeline/tiles.rs`](../src/pipeline/tiles.rs)) — runs
-  [tippecanoe](https://github.com/felt/tippecanoe) over those layers to
-  build `conflated.pmtiles`. A pre-implementation spike (duckdb export +
-  tippecanoe on the CLI, outside the pipeline) against a real
-  full-planet `conflated.parquet` measured **3.64 GB peak RSS** /
-  **656 MB output** for the entire unfiltered dataset (1.74M rows) —
-  comfortably under the production container’s 12 GB `--mem-limit`.
-  Re-measured from an actual full-planet pipeline run afterwards (same
-  local machine as above, via `children_rss_peak_bytes`): **~1m48s**,
-  **1.87 GB peak RSS**, **768 MB output** — lower than the spike,
-  plausibly because splitting into two named layers (`matched`/
-  `unmatched`) rather than one combined layer changes tippecanoe’s own
-  memory profile.
+  [tippecanoe](https://github.com/felt/tippecanoe) over those layers,
+  bounded to z0–12 (`ZoomRange::Bounded`, not tippecanoe’s automatic
+  zoom selection — see `extract_matched_detail_layer` below for why),
+  to build `conflated-overview.pmtiles`. **~1m44s**, **1.87 GB peak
+  RSS**, **~750 MB output** on a full-planet `conflated.parquet` (same
+  local run as `extract_conflated_layers` above).
+- **`extract_matched_detail_layer`**
+  ([`src/pipeline/conflated_tiles.rs`](../src/pipeline/conflated_tiles.rs))
+  — a second, independent extraction, matched rows only: up to three
+  features per row (the ATP point, the OSM shape, and a connector line
+  between their centroids — each carrying only its own side’s tags, so
+  a tile inspector shows which is which), into `matched-detail.jsonl`.
+  Rows whose ATP↔OSM offset is below `MIN_CONNECTOR_LENGTH_METERS`
+  (a documented constant, currently 5m) omit the connector — it would
+  draw a visually meaningless near-zero-length line, and is exactly
+  the degenerate geometry that makes automatic zoom selection never
+  terminate, see the next step. **~3.4s**, producing 2,038,379 detail
+  features from 730,512 matched rows on the same run.
+- **`render_conflated_detail`**
+  ([`src/pipeline/tiles.rs`](../src/pipeline/tiles.rs)) — tippecanoe
+  again, bounded to z13–16 this time
+  (`conflated_tiles::DETAIL_MIN_ZOOM`/`DETAIL_MAX_ZOOM`, two more
+  documented constants), building `conflated-detail.pmtiles`.
+  Deliberately *not* `-zg`/`--extend-zooms-if-still-dropping`: that
+  combination keeps adding zoom levels until every crowded feature has
+  separated into its own tile, which never happens for a connector
+  line whose two ends are nearly coincident (a *good* match) — such a
+  line never spatially separates from its own endpoint no matter how
+  far you zoom in. An early, unbounded prototype of this feature
+  reached z19 chasing that impossible separation before an unrelated
+  internal limit stopped it; seeing the actual PMTiles header
+  (`min_zoom`/`max_zoom` bytes) is what caught this, not a guess.
+  **~2m02s**, **2.08 GB peak RSS**, **~1.0 GB output** on the same run.
+- **`join_conflated_tiles`**
+  ([`src/pipeline/tiles.rs`](../src/pipeline/tiles.rs)) — merges the
+  overview and detail archives into the final `conflated.pmtiles` with
+  [`tile-join`](https://github.com/felt/tippecanoe) (a sibling binary
+  from tippecanoe’s own build, see `Containerfile`), tippecanoe’s own
+  documented tool for exactly this coarse/detail split (`man
+  tippecanoe`’s “Show countries at low zoom levels but states at
+  higher zoom levels” example). **~2m42s**, **2.13 GB peak RSS**,
+  **~1.8 GB output** (z0–16) on the same run — total added cost over a
+  single-pass `conflated.pmtiles` build: **~4m43s**, **+~1.05 GB**.
 - **`suggest_edits`** ([`src/pipeline/edits.rs`](../src/pipeline/edits.rs))
   — scans `conflated.parquet` for matched rows and asks an
   [`edit_suggesters`](../src/edit_suggesters/) implementation what
@@ -326,8 +364,8 @@ fetch away.
   data output and both sets of tiles to S3-compatible storage. **~5.5s**
   / *(not yet measured)* / **~3s** respectively at full-planet scale
   (cpx42 run, except `upload_conflated_tiles`, which needs a real
-  S3-configured run to time — `conflated.pmtiles` is ~768 MB at
-  full-planet scale, several times `edits.pmtiles`’ size, so expect a
+  S3-configured run to time — `conflated.pmtiles` is ~1.8 GB at
+  full-planet scale, over 20x `edits.pmtiles`’ size, so expect a
   proportionally longer upload, not the same ~3s). `upload_logs` (same
   file, pushes the run’s own log) isn’t wrapped by the same per-step
   timing machinery as the others (see `run_pipeline` in
@@ -430,9 +468,6 @@ until the full pipeline was proven out:
   conflating municipal tree datasets against OSM by spatial distance
   and species looks particularly tractable). See
   [#708](https://github.com/alltheplaces/osm-diffs/issues/708).
-- `conflated.pmtiles`' matched features show only the OpenStreetMap
-  side, not a visual link back to where AllThePlaces placed it —
-  see [#775](https://github.com/alltheplaces/osm-diffs/issues/775).
 - There’s no per-row match-confidence or cartographic-importance
   signal yet, so both PMTiles archives rely entirely on tippecanoe’s
   own density-based dropping at low zoom — see

--- a/docs/notes/2026-08-27-connector-line-zoom-runaway.md
+++ b/docs/notes/2026-08-27-connector-line-zoom-runaway.md
@@ -1,0 +1,133 @@
+# Connector-line visualization: a zoom-runaway gotcha, and the fix
+
+Investigation note for [#775](https://github.com/alltheplaces/osm-diffs/issues/775)
+(visualize the ATP↔OSM offset in `conflated.pmtiles` with a connector
+line). A prototype, its measurements, and six real sample renders are
+published as an artifact:
+<https://claude.ai/code/artifact/0bd35079-99d3-4608-b2e8-a968cb53160c>.
+This note captures the same findings as plain text, for anyone without
+access to that link.
+
+## The idea
+
+For a matched row, draw the ATP point, the real OSM shape, and a line
+connecting their centroids — instead of just picking one geometry, the
+way `conflated.pmtiles` v1 (#709) does. Since a Mapbox Vector Tile
+feature can only be one geometry type, this means three separate
+features per matched row (`part: "atp" | "osm" | "link"`), not one.
+
+## First measurement: expensive, but why wasn't obvious
+
+An unrestricted build (`tippecanoe -zg --extend-zooms-if-still-dropping`,
+the same flags `render_conflated_tiles` already uses today) against a
+real full-planet `conflated.parquet` (1,744,015 rows, 730,512 matched):
+
+| | v1 (shipped) | Connector line, unrestricted |
+|---|---:|---:|
+| `render_conflated_tiles` wall time | 1m48s | 19m55s |
+| tippecanoe peak RSS | 1.87 GB | 2.86 GB |
+| `conflated.pmtiles` size | 768 MB | 5.4 GB |
+
+RAM only grew 1.5× — never the risk. Wall time and output size grew
+11× and 7×, wildly disproportionate to the 3× feature count.
+
+## Root cause: found by reading the PMTiles header, not by guessing
+
+The first hypothesis (low-zoom feature density triggering
+`--drop-densest-as-needed`'s retry loop) turned out to be wrong.
+Checking the actual PMTiles headers instead of speculating:
+
+```python
+with open("conflated.pmtiles", "rb") as f:
+    header = f.read(127)
+print(header[100], header[101])  # min_zoom, max_zoom
+```
+
+| Build | min_zoom | max_zoom |
+|---|---:|---:|
+| v1 (shipped) | 0 | 12 |
+| Connector line, unrestricted | 0 | **19** |
+
+`-zg --extend-zooms-if-still-dropping` keeps adding zoom levels until
+every crowded feature has separated into its own tile — which works
+when zooming in genuinely spreads features apart. It doesn't terminate
+when a connector line's two ends are nearly coincident (a *good*
+match!), because that line never spatially separates from its own
+endpoint no matter how far you zoom. Tippecanoe kept climbing, chasing
+a separation that can't happen, past z19 before an unrelated internal
+limit stopped it.
+
+Confirmed directly: killing an in-progress `-Z13`-only run (the `-Z`
+floor alone doesn't fix this — it only avoids the low-zoom cost, not
+the runaway) showed it had already reached **z20** before being
+terminated.
+
+## The fix: bounded zoom range, split build, `tile-join`
+
+Two independent fixes, both applied:
+
+1. **Never auto-detect zoom for the detail layer.** Replace
+   `-zg --extend-zooms-if-still-dropping` with an explicit, bounded
+   range (`-Z<min> -z<max>`) for any tippecanoe build that includes
+   connector-line features.
+2. **Skip near-zero-length connectors at the source** (not yet
+   measured standalone, but should reduce how often the pathological
+   case even arises): compute the haversine distance between the ATP
+   point and OSM centroid: below a small threshold, don't emit the
+   `link` feature at all — there's nothing useful to draw, and it's
+   exactly the degenerate geometry that caused the runaway.
+
+Building on that: `tippecanoe` also ships `tile-join`, its own
+documented tool for exactly the "coarse overview vs. high-zoom detail"
+split (see `man tippecanoe`'s "Show countries at low zoom levels but
+states at higher zoom levels" example, `-z3`/`-Z4` + `tile-join`).
+Applied here:
+
+- **Overview** = the already-shipped `conflated.pmtiles` (single
+  feature per row, z0–12) — reused unmodified, no rebuild needed.
+- **Detail** = the 3-feature dataset, *matched rows only* (unmatched
+  rows are already a single point at every zoom, so they don't belong
+  in the detail pass at all), built with a hard `-Z13 -z16` range.
+- Merged with `tile-join` (which warns about the differing max zoom
+  between inputs — expected, not an error).
+
+| Step | Wall time | Peak RSS | Output |
+|---|---:|---:|---:|
+| Detail pass (`-Z13 -z16`, matched only) | 2m11s | 2.87 GB | 1.1 GB |
+| `tile-join` merge | 3m09s | 2.37 GB | 1.8 GB (final) |
+| **Total added over shipped #709** | **5m20s** | ≤ 2.87 GB | **+1.1 GB** |
+
+vs. 19m55s / +4.6 GB for the unrestricted, runaway build. Every step
+individually stays well inside the production container's 12 GB
+`--mem-limit`.
+
+## Shipping this for real
+
+Decisions made when turning this into pipeline code (tracked in the
+PR that follows this note):
+
+- `atp` features carry only `atp:*` tags, `osm` features only `osm:*`
+  — today's prototype put both tag sets on every feature, which made
+  it hard to tell which end of a pair you were looking at in a tile
+  inspector. The `link` feature keeps both.
+- The z13/z16 zoom split and the minimum-connector-length threshold
+  each become a single, well-documented constant in
+  `src/pipeline/conflated_tiles.rs` — not scattered magic numbers.
+- `tile-join` is a sibling binary from the exact same
+  `felt/tippecanoe` build (`Containerfile`) already produces
+  `tippecanoe` from, at the same pinned commit — shipping it means one
+  more `COPY` line in the container stage, plus a small, mechanical
+  second component in `scripts/sbom/tippecanoe.jq` (same version/
+  supplier/license/musl-sqlite-zlib dependencies as the existing
+  `tippecanoe` entry), not new supply-chain investigation.
+
+## Open, not yet answered
+
+- Is z16 the right ceiling, or should it go deeper? Picked as a first
+  guess from what "individual buildings become legible" roughly
+  implies, not a measured optimum.
+- What connector-length threshold is right? Real observed offsets in
+  this run ranged from ~0.2 m (a coincident match) to the matcher's
+  own ~400 m search-radius cap; a few meters (comfortably above GPS/
+  geocoding noise, well below "meaningfully offset") is the working
+  assumption.

--- a/docs/outputs/CONFLATED_TILES.md
+++ b/docs/outputs/CONFLATED_TILES.md
@@ -21,38 +21,64 @@ notice. If you need something stable to build on, use
 
 ## Layers
 
-Two layers, split by whether `conflate()` found an OpenStreetMap match:
+Two layers, split by whether `conflate()` found an OpenStreetMap match
+— but `matched`'s own shape changes with zoom, see below.
 
-- **`matched`** — one feature per `conflated.parquet` row with an `osm`
-  side. Geometry is `osm_geometry`: the actual matched OpenStreetMap
-  shape (point, line, or polygon), since that's what a reviewer is
-  meant to look at.
-- **`unmatched`** — one feature per row with no OpenStreetMap match.
-  Geometry is `atp_geometry`: wherever AllThePlaces placed it.
+- **`matched`** — every `conflated.parquet` row with an `osm` side.
+- **`unmatched`** — every row with no OpenStreetMap match. One feature
+  per row at every zoom, geometry `atp_geometry` (wherever AllThePlaces
+  placed it).
 
 Every feature's coordinates are rounded to 1e-7 degrees (about 1 cm at
 the equator) before being written out — the same precision
 `edits.pmtiles`' features already use — so raw source-data precision
 noise doesn't inflate the file for no visual benefit.
 
+## `matched`'s two zoom ranges
+
+Built as two separate PMTiles archives, merged with `tile-join`, so a
+matched row looks different depending how far you're zoomed in:
+
+- **z0–12 (overview)**: one feature per row, geometry `osm_geometry` —
+  the actual matched OpenStreetMap shape (point, line, or polygon),
+  since that's what a reviewer is meant to look at.
+- **z13–16 (detail)**: up to three features per row —
+  - the AllThePlaces point (`part: "atp"`),
+  - the OpenStreetMap shape (`part: "osm"`),
+  - a connector line between their centroids (`part: "link"`) —
+    *unless* that offset is under 5 meters (too close to draw a
+    meaningful line; see `MIN_CONNECTOR_LENGTH_METERS` in
+    [`src/pipeline/conflated_tiles.rs`](../../src/pipeline/conflated_tiles.rs)
+    for the exact, documented threshold).
+
+  This split exists because a single Mapbox Vector Tile feature can
+  only be one geometry type — "ATP point ∪ OSM shape ∪ connector line"
+  can't be one feature — and because showing the connector at low zoom
+  turned out to be actively harmful: tippecanoe's automatic zoom
+  selection never terminates for a connector line whose ends are
+  nearly coincident (a *good* match), since such a line never
+  spatially separates from its own endpoint no matter how far you zoom
+  in. Bounding the detail pass to a fixed zoom range side-steps that
+  entirely — see
+  [`docs/notes/2026-08-27-connector-line-zoom-runaway.md`](../notes/2026-08-27-connector-line-zoom-runaway.md)
+  for the full investigation.
+
 ## Properties
 
 - `spider` — which AllThePlaces spider produced this feature (its
   `atp.fetched.spider` in `conflated.parquet`).
-- `atp:<tag>` — every tag from the row's `atp.tags` map, one property
-  per tag.
+- `atp:<tag>` — every tag from the row's `atp.tags` map, present on
+  `unmatched` features, the z0–12 `matched` overview feature, and the
+  z13–16 `atp`/`link` detail features.
 - `osm:type`, `osm:id`, and `osm:<tag>` for every tag in `osm.tags` —
-  present only on `matched` features.
+  present on the z0–12 `matched` overview feature and the z13–16
+  `osm`/`link` detail features.
+- `part` (`"atp"` | `"osm"` | `"link"`) — z13–16 detail features only,
+  identifying which of the three a given feature is.
 
-Tag properties are prefixed (`atp:name` vs. `osm:name`) rather than
-merged, since the two sides can and do disagree — that disagreement is
-often exactly what's worth reviewing.
-
-## What this isn't (yet)
-
-A matched feature shows only the OpenStreetMap side, not a visual link
-back to where AllThePlaces placed it — see
-[#775](https://github.com/alltheplaces/osm-diffs/issues/775) for that
-idea (a connector line between the two), left for later since a vector
-tile feature can only be one geometry type, so it needs its own design
-and its own memory/size measurement, not a quick addition here.
+At z0–12 and on the `link` feature, tag properties are prefixed
+(`atp:name` vs. `osm:name`) rather than merged, since the two sides can
+and do disagree — that disagreement is often exactly what's worth
+reviewing. The z13–16 `atp`/`osm` detail features carry only their own
+side's tags (no `osm:*` on the `atp` feature or vice versa), so a tile
+inspector shows unambiguously which end of a pair you're looking at.

--- a/scripts/sbom/README.md
+++ b/scripts/sbom/README.md
@@ -49,8 +49,11 @@ tools such as `apk`, `sed`, `awk` and `grep`. It then:
    `osm-testdata-grid`) that `cargo cyclonedx` has no way to see.
 3. Builds a CycloneDX fragment for the statically linked `tippecanoe`
    binary from scratch, with [`tippecanoe.jq`](tippecanoe.jq).
-4. Combines both fragments into the final, single SBOM for the container,
-   with [`merge.jq`](merge.jq).
+4. Builds a near-identical fragment for `tile-join`, a sibling binary
+   from that same `felt/tippecanoe` build (same commit, same static-link
+   treatment), with [`tile-join.jq`](tile-join.jq).
+5. Combines all three fragments into the final, single SBOM for the
+   container, with [`merge.jq`](merge.jq).
 
 None of the `.jq` files are invoked directly; `generate-sbom.sh` always
 passes the gathered facts to them as `--arg`/`--slurpfile` parameters, so

--- a/scripts/sbom/generate-sbom.sh
+++ b/scripts/sbom/generate-sbom.sh
@@ -4,9 +4,10 @@
 # SPDX-License-Identifier: MIT
 #
 # Generate the CycloneDX Software Bill of Materials (SBOM) for the
-# osm-diffs container image: one single file, describing both the
-# osm-diffs binary (with its Rust dependency graph) and the statically
-# linked tippecanoe binary that ships alongside it.
+# osm-diffs container image: one single file, describing the osm-diffs
+# binary (with its Rust dependency graph) and the two statically
+# linked tippecanoe-project binaries that ship alongside it, tippecanoe
+# and tile-join.
 #
 # Usage:
 #   ./scripts/sbom/generate-sbom.sh [OUTPUT]
@@ -176,6 +177,24 @@ jq -n \
   -f "${SCRIPT_DIR}/tippecanoe.jq" \
   > "${WORKDIR}/tippecanoe.cdx.json"
 
+# ── build the tile-join SBOM fragment ────────────────────────────────────────
+# Same arguments as tippecanoe's own fragment above: tile-join is a
+# sibling binary from that exact same build (see tile-join.jq's own
+# comment for why it reuses TIPPECANOE_VERSION rather than having a
+# version of its own).
+jq -n \
+  --arg ARCH               "${ARCH}" \
+  --arg TIPPECANOE_VERSION "${TIPPECANOE_VERSION}" \
+  --arg ALPINE_VERSION     "${ALPINE_VERSION}" \
+  --arg APK_VERSION        "${APK_VERSION}" \
+  --arg JQ_VERSION         "${JQ_VERSION}" \
+  --arg MUSL_VERSION       "${MUSL_VERSION}" \
+  --arg SQLITE_VERSION     "${SQLITE_VERSION}" \
+  --arg ZLIB_VERSION       "${ZLIB_VERSION}" \
+  --arg DEV_BUILD          "${DEV_BUILD}" \
+  -f "${SCRIPT_DIR}/tile-join.jq" \
+  > "${WORKDIR}/tile-join.cdx.json"
+
 # ── assemble the final, single SBOM ──────────────────────────────────────────
 mkdir -p "$(dirname "$OUTPUT")"
 jq -n \
@@ -184,6 +203,7 @@ jq -n \
   --arg timestamp  "$BUILD_TIMESTAMP" \
   --slurpfile pipeline   "${WORKDIR}/pipeline.cdx.json" \
   --slurpfile tippecanoe "${WORKDIR}/tippecanoe.cdx.json" \
+  --slurpfile tile_join  "${WORKDIR}/tile-join.cdx.json" \
   -f "${SCRIPT_DIR}/merge.jq" \
   > "$OUTPUT"
 

--- a/scripts/sbom/merge.jq
+++ b/scripts/sbom/merge.jq
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: MIT
 #
 # Assemble the final, single SBOM for the container image out of the
-# osm-diffs (pipeline) and tippecanoe component fragments.
+# osm-diffs (pipeline), tippecanoe, and tile-join component fragments.
 #
-# Invoked as `jq -n -f merge.jq` (no stdin input; both fragments are read
-# via --slurpfile).
+# Invoked as `jq -n -f merge.jq` (no stdin input; all three fragments
+# are read via --slurpfile).
 #
 # Note: at the point this script runs (inside `Containerfile`, during
 # `podman build`), the image digest is not known yet -- it only exists
@@ -24,20 +24,30 @@
 #               produced by pipeline.jq
 #   tippecanoe  (--slurpfile) the tippecanoe SBOM fragment, as produced
 #               by tippecanoe.jq
+#   tile_join   (--slurpfile) the tile-join SBOM fragment, as produced
+#               by tile-join.jq -- a sibling binary from tippecanoe's
+#               own build (see that script's own comment), modeled as
+#               its own top-level component here rather than folded
+#               into tippecanoe's, since it isn't a *dependency* of
+#               tippecanoe, just a co-built peer.
 
 ($pipeline[0].metadata.component)                              as $meta_pipeline        |
 ($tippecanoe[0].metadata.component)                            as $meta_tippecanoe      |
+($tile_join[0].metadata.component)                              as $meta_tile_join       |
 ($meta_pipeline   | (.["bom-ref"] // .name))                   as $ref_pipeline         |
 ($meta_tippecanoe | (.["bom-ref"] // .name))                   as $ref_tippecanoe       |
+($meta_tile_join  | (.["bom-ref"] // .name))                   as $ref_tile_join        |
 ($tippecanoe[0].components // [] | map(.["bom-ref"] // .name)) as $deps_of_tippecanoe   |
+($tile_join[0].components  // [] | map(.["bom-ref"] // .name)) as $deps_of_tile_join    |
 ($pipeline[0].components   // [] | map(.["bom-ref"] // .name)) as $deps_of_pipeline     |
 
 # Collect all known component bom-refs so we can filter out
 # dependency entries that reference undeclared components
 (
-  [$image, $ref_pipeline, $ref_tippecanoe] +
+  [$image, $ref_pipeline, $ref_tippecanoe, $ref_tile_join] +
   ($pipeline[0].components   // [] | map(.["bom-ref"] // .name)) +
-  ($tippecanoe[0].components // [] | map(.["bom-ref"] // .name))
+  ($tippecanoe[0].components // [] | map(.["bom-ref"] // .name)) +
+  ($tile_join[0].components  // [] | map(.["bom-ref"] // .name))
 ) as $known_refs |
 
 # Carry forward inner deps from each fragment:
@@ -46,6 +56,7 @@
 # - deduplicate by ref (keep first occurrence)
 (
   ($tippecanoe[0].dependencies // [] | map(select(.ref != $ref_tippecanoe))) +
+  ($tile_join[0].dependencies  // [] | map(select(.ref != $ref_tile_join))) +
   ($pipeline[0].dependencies   // [] | map(select(.ref != $ref_pipeline)))
   | map(select(.ref as $r | $known_refs | index($r) != null))
   | reduce .[] as $dep (
@@ -74,7 +85,11 @@
       # version (the image digest) is patched in by release.yml, see above.
     },
     properties: (
-      (($pipeline[0].metadata.properties // []) + ($tippecanoe[0].metadata.properties // []))
+      (
+        ($pipeline[0].metadata.properties // []) +
+        ($tippecanoe[0].metadata.properties // []) +
+        ($tile_join[0].metadata.properties // [])
+      )
       | unique
     )
   },
@@ -89,6 +104,11 @@
       "bom-ref":  $ref_tippecanoe,
       type:       "application",
       components: ($tippecanoe[0].components // [])
+    }),
+    ($meta_tile_join + {
+      "bom-ref":  $ref_tile_join,
+      type:       "application",
+      components: ($tile_join[0].components // [])
     })
   ],
 
@@ -96,11 +116,15 @@
     [
       {
         "ref":       $image,
-        "dependsOn": [$ref_tippecanoe, $ref_pipeline]
+        "dependsOn": [$ref_tippecanoe, $ref_tile_join, $ref_pipeline]
       },
       {
         "ref":       $ref_tippecanoe,
         "dependsOn": $deps_of_tippecanoe
+      },
+      {
+        "ref":       $ref_tile_join,
+        "dependsOn": $deps_of_tile_join
       },
       {
         "ref":       $ref_pipeline,
@@ -116,11 +140,19 @@
     },
     {
       "aggregate":  "complete",
+      "assemblies": [$ref_tile_join]
+    },
+    {
+      "aggregate":  "complete",
       "assemblies": [$ref_pipeline]
     }
   ],
 
-  formulation: (($pipeline[0].formulation // []) + ($tippecanoe[0].formulation // []) + [{
+  formulation: (
+    ($pipeline[0].formulation // []) +
+    ($tippecanoe[0].formulation // []) +
+    ($tile_join[0].formulation // []) +
+    [{
      workflows: [{
       "bom-ref": "assemble-container",
       uid: "assemble-container",
@@ -129,11 +161,13 @@
       resourceReferences: [
         { "ref": $image },
         { "ref": $ref_pipeline },
-        { "ref": $ref_tippecanoe }
+        { "ref": $ref_tippecanoe },
+        { "ref": $ref_tile_join }
       ],
       inputs: [
         { "resource": { "ref": $ref_pipeline } },
-        { "resource": { "ref": $ref_tippecanoe } }
+        { "resource": { "ref": $ref_tippecanoe } },
+        { "resource": { "ref": $ref_tile_join } }
       ],
       outputs: [
         { "type": "artifact", "resource": { "ref": $image } }

--- a/scripts/sbom/tile-join.jq
+++ b/scripts/sbom/tile-join.jq
@@ -1,0 +1,147 @@
+# SPDX-FileCopyrightText: 2026 Sascha Brawer <sascha@brawer.ch>
+# SPDX-License-Identifier: MIT
+#
+# Build a CycloneDX 1.7 SBOM fragment for the statically compiled
+# tile-join binary that we ship alongside osm-diffs and tippecanoe in
+# the OCI container image -- used by pipeline::tiles::join_tiles to
+# merge conflated.pmtiles' overview and detail passes (see
+# pipeline::conflated_tiles' module doc comment for why that split
+# exists).
+#
+# tile-join is a sibling binary built from the exact same
+# felt/tippecanoe source tree, at the exact same pinned commit, as
+# tippecanoe itself (see tippecanoe.jq and Containerfile) -- same
+# version, same license, same static-link treatment against
+# musl/sqlite/zlib. This fragment is deliberately near-identical to
+# tippecanoe.jq's; the one substantive difference is the purl's
+# `#tile-join` subpath, identifying which binary within that source
+# tree this component describes.
+#
+# Invoked as `jq -n -f tile-join.jq` (no stdin input; the whole
+# document is built from the arguments below).
+#
+# Arguments (all required, passed with --arg): see tippecanoe.jq --
+# identical argument list, describing the identical build environment
+# both binaries were compiled in.
+
+def alpine_supplier: {name: "Alpine Linux", url: ["https://alpinelinux.org"]};
+
+{
+  bomFormat: "CycloneDX",
+  specVersion: "1.7",
+  metadata: {
+    lifecycles: [{phase: "build"}],
+    authors: [{name: "Sascha Brawer", email: "sascha@brawer.ch"}],
+    supplier: {name: "All The Places", url: ["https://github.com/alltheplaces/"]},
+    component: {
+      type: "application",
+      name: "tile-join",
+      version: $TIPPECANOE_VERSION,
+      "bom-ref": ("tile-join-" + $TIPPECANOE_VERSION),
+      purl: ("pkg:github/felt/tippecanoe@" + $TIPPECANOE_VERSION + "#tile-join"),
+      supplier: {name: "Felt", url: ["https://github.com/felt/tippecanoe"]},
+      licenses: [{license: {id: "BSD-2-Clause"}}]
+    },
+    tools: {
+      components: [{
+        type: "operating-system",
+        name: "Alpine Linux",
+        version: $ALPINE_VERSION,
+        "bom-ref": ("alpine-" + $ALPINE_VERSION),
+        description: "Operating system on which this SBOM was built",
+        supplier: alpine_supplier
+      }, {
+        type: "application",
+        name: "apk",
+        version: $APK_VERSION,
+        "bom-ref": ("apk-" + $APK_VERSION),
+        description: "Package versions extracted via apk info",
+        supplier: alpine_supplier
+      }, {
+        type: "application",
+        name: "jq",
+        version: $JQ_VERSION,
+        "bom-ref": ("jq-" + $JQ_VERSION),
+        description: "Supplemental information injected with jq",
+        supplier: alpine_supplier
+      }]
+    },
+    properties: (if $DEV_BUILD == "true" then
+        [{name: "osm-diffs:sbom:devBuild", value: "true"}]
+      else
+        []
+      end)
+  },
+  components: [
+    {
+      type: "library",
+      name: "musl",
+      version: $MUSL_VERSION,
+      "bom-ref": ("musl-" + $MUSL_VERSION),
+      purl: ("pkg:apk/alpine/musl@" + $MUSL_VERSION + "?arch=" + $ARCH),
+      supplier: alpine_supplier,
+      licenses: [{license: {id: "MIT"}}],
+      evidence: {
+        identity: [{
+          field: "version",
+          confidence: 1,
+          concludedValue: $MUSL_VERSION,
+          methods: [{technique: "manifest-analysis", confidence: 1, value: "apk info musl"}],
+          tools: [("apk-" + $APK_VERSION)]
+        }]
+      }
+    },
+    {
+      type: "library",
+      name: "sqlite",
+      version: $SQLITE_VERSION,
+      "bom-ref": ("sqlite-" + $SQLITE_VERSION),
+      purl: ("pkg:apk/alpine/sqlite@" + $SQLITE_VERSION + "?arch=" + $ARCH),
+      supplier: alpine_supplier,
+      # See tippecanoe.jq's own comment on this field: SQLite isn't
+      # SPDX-licensed, so this uses the same "declared" Public Domain
+      # pattern, not a `license.id`.
+      licenses: [{
+        license: {
+          name: "Public Domain",
+          acknowledgement: "declared"
+        }
+      }],
+      evidence: {
+        identity: [{
+          field: "version",
+          confidence: 1,
+          concludedValue: $SQLITE_VERSION,
+          methods: [{technique: "manifest-analysis", confidence: 1, value: "apk info sqlite-static"}],
+          tools: [("apk-" + $APK_VERSION)]
+        }]
+      }
+    },
+    {
+      type: "library",
+      name: "zlib",
+      version: $ZLIB_VERSION,
+      "bom-ref": ("zlib-" + $ZLIB_VERSION),
+      purl: ("pkg:apk/alpine/zlib@" + $ZLIB_VERSION + "?arch=" + $ARCH),
+      supplier: alpine_supplier,
+      licenses: [{license: {id: "Zlib"}}],
+      evidence: {
+        identity: [{
+          field: "version",
+          confidence: 1,
+          concludedValue: $ZLIB_VERSION,
+          methods: [{technique: "manifest-analysis", confidence: 1, value: "apk info zlib-static"}],
+          tools: [("apk-" + $APK_VERSION)]
+        }]
+      }
+    }
+  ],
+  dependencies: [{
+    ref: ("tile-join-" + $TIPPECANOE_VERSION),
+    dependsOn: [
+      ("musl-" + $MUSL_VERSION),
+      ("sqlite-" + $SQLITE_VERSION),
+      ("zlib-" + $ZLIB_VERSION)
+    ]
+  }]
+}

--- a/scripts/test-on-hetzner/remote/extract-binaries.sh
+++ b/scripts/test-on-hetzner/remote/extract-binaries.sh
@@ -1,22 +1,24 @@
 #!/usr/bin/env bash
-# Extracts /app/osm-diffs and /usr/local/bin/tippecanoe out of the
-# locally tagged osm-diffs-test image into /usr/local/bin -- shared by
-# build.sh (after building from source) and pull.sh (after pulling an
-# already-built image), so bare-mode `start` works the same either way.
+# Extracts /app/osm-diffs, /usr/local/bin/tippecanoe, and
+# /usr/local/bin/tile-join out of the locally tagged osm-diffs-test
+# image into /usr/local/bin -- shared by build.sh (after building from
+# source) and pull.sh (after pulling an already-built image), so
+# bare-mode `start` works the same either way.
 set -euo pipefail
 
 # Remove any leftover "extract" container from a previous deploy first --
 # podman create fails with "name already in use" otherwise.
 podman rm -f extract >/dev/null 2>&1 || true
 podman create --name extract osm-diffs-test
-# Both go to /usr/local/bin, not somewhere repo-relative: osm-diffs
-# invokes tippecanoe via `Command::new("tippecanoe")`, a bare PATH
-# lookup with no hardcoded location (src/pipeline/tiles.rs), so
-# tippecanoe specifically must resolve on PATH for any branch that
-# reaches render_tiles.
+# All three go to /usr/local/bin, not somewhere repo-relative: osm-diffs
+# invokes tippecanoe and tile-join via `Command::new(...)`, a bare PATH
+# lookup with no hardcoded location (src/pipeline/tiles.rs), so both
+# specifically must resolve on PATH for any branch that reaches
+# render_tiles/join_tiles.
 podman cp extract:/app/osm-diffs /usr/local/bin/osm-diffs
 podman cp extract:/usr/local/bin/tippecanoe /usr/local/bin/tippecanoe
+podman cp extract:/usr/local/bin/tile-join /usr/local/bin/tile-join
 podman rm -f extract >/dev/null
 
-chmod +x /usr/local/bin/osm-diffs /usr/local/bin/tippecanoe
+chmod +x /usr/local/bin/osm-diffs /usr/local/bin/tippecanoe /usr/local/bin/tile-join
 /usr/local/bin/osm-diffs --version

--- a/src/pipeline/conflated_tiles.rs
+++ b/src/pipeline/conflated_tiles.rs
@@ -1,20 +1,30 @@
 //! Turns `conflated.parquet` (produced by `crate::pipeline::conflate`)
-//! into a PMTiles-ready pair of GeoJSON Lines tile layers, for
-//! visualizing the *matching* step itself -- every AllThePlaces
-//! feature, matched or not -- independent of whatever
-//! `crate::pipeline::edits` separately decides to propose as an edit
-//! (see [#709](https://github.com/alltheplaces/osm-diffs/issues/709)).
+//! into PMTiles-ready GeoJSON Lines tile layers, for visualizing the
+//! *matching* step itself -- every AllThePlaces feature, matched or
+//! not -- independent of whatever `crate::pipeline::edits` separately
+//! decides to propose as an edit (see
+//! [#709](https://github.com/alltheplaces/osm-diffs/issues/709)).
 //!
 //! Unlike `edits`, this doesn't need an external sort: it emits one
 //! output feature per input row, so there's nothing to deduplicate or
 //! merge across rows -- a straight sequential-batch, rayon-parallel-per-
 //! batch scan is enough.
+//!
+//! Two extraction paths feed `conflated.pmtiles`' two-pass build (see
+//! `pipeline::tiles::ZoomRange` and `pipeline::tiles::join_tiles`):
+//! [`extract_conflated_layers`] (single feature per row, both matched
+//! and unmatched) for the coarse overview pass, and
+//! [`extract_matched_detail_layer`] (matched rows only, up to three
+//! features per row) for the high-zoom detail pass -- see that
+//! function's own doc comment for why matched rows need more than one
+//! feature there, and [#775](https://github.com/alltheplaces/osm-diffs/issues/775)
+//! for the full design discussion.
 
 use crate::utils::parquet::{get_binary, get_string, get_struct, get_tags, get_u64};
 use crate::{TileLayer, make_progress_bar};
 use anyhow::{Context, Result};
 use arrow::array::{Array, RecordBatch};
-use geo::MapCoordsInPlace;
+use geo::{Centroid, Distance, Haversine, MapCoordsInPlace};
 use geo_traits::to_geo::ToGeoGeometry;
 use indicatif::{MultiProgress, ProgressBar};
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
@@ -25,6 +35,44 @@ use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 use wkb::reader::read_wkb;
+
+/// Zoom level at which `conflated.pmtiles`' detail pass (see
+/// [`extract_matched_detail_layer`]) takes over from the coarse
+/// overview pass ([`extract_conflated_layers`]). The overview pass is
+/// built up to `DETAIL_MIN_ZOOM - 1`; the detail pass starts at
+/// `DETAIL_MIN_ZOOM`. Keep both call sites (`pipeline::mod`'s
+/// `render_conflated_overview`/`render_conflated_detail` steps) in
+/// sync with this constant -- there must be neither a gap nor an
+/// overlap between the two ranges, or `tile-join` either leaves a hole
+/// or duplicates content at the boundary zoom.
+pub(crate) const DETAIL_MIN_ZOOM: u8 = 13;
+
+/// Highest zoom level the detail pass builds. Deliberately an explicit
+/// ceiling, not tippecanoe's `-zg`/`--extend-zooms-if-still-dropping`:
+/// that combination keeps adding zoom levels until every crowded
+/// feature has separated into its own tile, which never happens for a
+/// connector line whose two ends are nearly coincident (a *good*
+/// match!) -- such a line never spatially separates from its own
+/// endpoint no matter how far you zoom in. An early, unbounded
+/// prototype of this feature reached z19 chasing that impossible
+/// separation before an unrelated internal limit stopped it (see the
+/// investigation note linked from #775). `MIN_CONNECTOR_LENGTH_METERS`
+/// below heads off most such cases at the source, but this ceiling is
+/// the hard backstop regardless.
+pub(crate) const DETAIL_MAX_ZOOM: u8 = 16;
+
+/// Below this length, a connector line's endpoints are close enough
+/// that drawing a line between them adds no visual information to a
+/// reviewer -- and is exactly the degenerate geometry
+/// `DETAIL_MAX_ZOOM`'s doc comment describes. Comfortably above
+/// typical GPS/geocoding noise (a few meters) and well below "this
+/// match looks meaningfully offset" (tens of meters); real offsets
+/// measured against a full-planet run ranged from ~0.2m (a coincident
+/// match) up to the matcher's own ~400m search-radius cap. Tune if
+/// real-world review turns up either false positives (connectors
+/// shown for noise-level offsets) or missed ones (a genuine offset
+/// silently dropped).
+pub(crate) const MIN_CONNECTOR_LENGTH_METERS: f64 = 5.0;
 
 /// One decoded row of `conflated.parquet`, kept whether or not it has
 /// an OSM match -- unlike `edits::ConflatedRow`, which only exists for
@@ -47,40 +95,25 @@ struct OsmSide {
 }
 
 impl ConflatedTileRow {
+    /// The coarse overview layer's representation: one feature per
+    /// row. Geometry is the actual OSM shape when matched (what a
+    /// reviewer is meant to review -- point/line/polygon, all valid
+    /// within one GeoJSON/MVT layer), the raw ATP-provided shape
+    /// otherwise. See [`extract_matched_detail_layer`] for the richer,
+    /// matched-only, high-zoom-only representation.
+    ///
+    /// TODO(#713): once conflated.parquet carries a per-row rank/
+    /// importance signal, this is the natural place to also emit it
+    /// as a feature property (or otherwise feed it to tippecanoe),
+    /// so --drop-densest-as-needed can prefer important places over
+    /// low-priority ones at low zoom instead of today's
+    /// density-only heuristic.
     fn to_geojson_line(&self) -> Result<String> {
-        // Geometry: the actual OSM shape when matched (what a reviewer
-        // is meant to review -- point/line/polygon, all valid within
-        // one GeoJSON/MVT layer), the raw ATP-provided shape otherwise.
-        // Simplest useful choice for v1 -- see
-        // https://github.com/alltheplaces/osm-diffs/issues/775 for a
-        // richer "union of atp_geometry + osm_geometry + a connector
-        // line between their centroids" idea deliberately left for
-        // later: a Mapbox Vector Tile feature can only be one geometry
-        // type, so that idea needs three separate features per matched
-        // row, not one, and deserves its own memory/size measurement.
-        //
-        // TODO(#713): once conflated.parquet carries a per-row rank/
-        // importance signal, this is the natural place to also emit it
-        // as a feature property (or otherwise feed it to tippecanoe),
-        // so --drop-densest-as-needed can prefer important places over
-        // low-priority ones at low zoom instead of today's
-        // density-only heuristic.
         let geometry_wkb: &[u8] = match &self.osm {
             Some(osm) => &osm.osm_geometry_wkb,
             None => &self.atp_geometry_wkb,
         };
-        let mut geometry = read_wkb(geometry_wkb)
-            .context("failed to decode geometry")?
-            .to_geometry();
-        // Let's not emit coordinates with fake sub-millimeter
-        // precision, particularly for atp_geometry, which is whatever
-        // precision AllThePlaces' upstream source happened to provide
-        // -- same 1e-7-degree rounding SuggestedEdit::to_geojson
-        // already applies to its own point.
-        geometry.map_coords_in_place(|c| geo::Coord {
-            x: (c.x * 1e7).round() / 1e7,
-            y: (c.y * 1e7).round() / 1e7,
-        });
+        let geometry = decode_and_round(geometry_wkb)?;
 
         let mut properties: Map<String, Value> = Map::new();
         properties.insert("spider".to_string(), Value::String(self.spider.clone()));
@@ -94,18 +127,111 @@ impl ConflatedTileRow {
                 properties.insert(format!("osm:{k}"), Value::String(v.clone()));
             }
         }
-
-        let feature = geojson::Feature {
-            bbox: None,
-            geometry: Some(geojson::Geometry::from(&geometry)),
-            id: None,
-            properties: Some(properties),
-            foreign_members: None,
-        };
-        let mut line = feature.to_string();
-        line.push('\n');
-        Ok(line)
+        geometry_to_geojson_line(&geometry, properties)
     }
+
+    /// The detail layer's representation of a *matched* row -- never
+    /// called for an unmatched one, since the detail pass is
+    /// matched-only (an unmatched row is already a single point at
+    /// every zoom, so it never benefits from higher zoom's extra
+    /// detail; see `extract_matched_detail_layer`'s doc comment).
+    /// `osm` is passed explicitly, rather than read from
+    /// `self.osm`, so that precondition is enforced by the type
+    /// system instead of an internal `Option::unwrap`.
+    ///
+    /// Yields the ATP point and the OSM shape as two separate
+    /// features -- each carrying only its own side's tags (`atp:*` or
+    /// `osm:*`), so a tile inspector shows which end is which -- plus
+    /// a connector line between their centroids, unless that line
+    /// would be shorter than `MIN_CONNECTOR_LENGTH_METERS` (see that
+    /// constant's doc comment for why). Every feature also carries a
+    /// `part` property (`"atp"` | `"osm"` | `"link"`) identifying its
+    /// role, and the connector line -- the only feature that isn't
+    /// clearly one side or the other -- keeps both tag sets.
+    fn to_detail_geojson_lines(&self, osm: &OsmSide) -> Result<Vec<String>> {
+        let atp_geometry = decode_and_round(&self.atp_geometry_wkb)?;
+        let osm_geometry = decode_and_round(&osm.osm_geometry_wkb)?;
+
+        let mut atp_properties: Map<String, Value> = Map::new();
+        atp_properties.insert("spider".to_string(), Value::String(self.spider.clone()));
+        atp_properties.insert("part".to_string(), Value::String("atp".to_string()));
+        for (k, v) in &self.atp_tags {
+            atp_properties.insert(format!("atp:{k}"), Value::String(v.clone()));
+        }
+
+        let mut osm_properties: Map<String, Value> = Map::new();
+        osm_properties.insert("spider".to_string(), Value::String(self.spider.clone()));
+        osm_properties.insert("part".to_string(), Value::String("osm".to_string()));
+        osm_properties.insert("osm:type".to_string(), Value::String(osm.osm_type.clone()));
+        osm_properties.insert("osm:id".to_string(), Value::from(osm.osm_id));
+        for (k, v) in &osm.osm_tags {
+            osm_properties.insert(format!("osm:{k}"), Value::String(v.clone()));
+        }
+
+        let mut lines = vec![
+            geometry_to_geojson_line(&atp_geometry, atp_properties)?,
+            geometry_to_geojson_line(&osm_geometry, osm_properties)?,
+        ];
+
+        let atp_centroid = atp_geometry
+            .centroid()
+            .context("atp_geometry has no centroid")?;
+        let osm_centroid = osm_geometry
+            .centroid()
+            .context("osm_geometry has no centroid")?;
+        if Haversine.distance(atp_centroid, osm_centroid) >= MIN_CONNECTOR_LENGTH_METERS {
+            let connector = geo::Geometry::LineString(geo::LineString::new(vec![
+                atp_centroid.into(),
+                osm_centroid.into(),
+            ]));
+            let mut link_properties: Map<String, Value> = Map::new();
+            link_properties.insert("spider".to_string(), Value::String(self.spider.clone()));
+            link_properties.insert("part".to_string(), Value::String("link".to_string()));
+            for (k, v) in &self.atp_tags {
+                link_properties.insert(format!("atp:{k}"), Value::String(v.clone()));
+            }
+            link_properties.insert("osm:type".to_string(), Value::String(osm.osm_type.clone()));
+            link_properties.insert("osm:id".to_string(), Value::from(osm.osm_id));
+            for (k, v) in &osm.osm_tags {
+                link_properties.insert(format!("osm:{k}"), Value::String(v.clone()));
+            }
+            lines.push(geometry_to_geojson_line(&connector, link_properties)?);
+        }
+
+        Ok(lines)
+    }
+}
+
+/// Decodes WKB and rounds coordinates to 1e-7 degrees (about 1cm at
+/// the equator) -- same precision `SuggestedEdit::to_geojson` already
+/// applies to its own point, so we're not emitting fake sub-millimeter
+/// precision, particularly for `atp_geometry`, which is whatever
+/// precision AllThePlaces' upstream source happened to provide.
+fn decode_and_round(wkb: &[u8]) -> Result<geo::Geometry<f64>> {
+    let mut geometry = read_wkb(wkb)
+        .context("failed to decode geometry")?
+        .to_geometry();
+    geometry.map_coords_in_place(|c| geo::Coord {
+        x: (c.x * 1e7).round() / 1e7,
+        y: (c.y * 1e7).round() / 1e7,
+    });
+    Ok(geometry)
+}
+
+fn geometry_to_geojson_line(
+    geometry: &geo::Geometry<f64>,
+    properties: Map<String, Value>,
+) -> Result<String> {
+    let feature = geojson::Feature {
+        bbox: None,
+        geometry: Some(geojson::Geometry::from(geometry)),
+        id: None,
+        properties: Some(properties),
+        foreign_members: None,
+    };
+    let mut line = feature.to_string();
+    line.push('\n');
+    Ok(line)
 }
 
 pub fn extract_conflated_layers(
@@ -220,6 +346,99 @@ fn extract_rows(
     Ok((num_matched, num_unmatched))
 }
 
+/// The detail pass's own extraction: matched rows only (an unmatched
+/// row is already a single point at every zoom, so the detail pass has
+/// nothing to add for it -- see `DETAIL_MIN_ZOOM`'s doc comment for
+/// the overview/detail split this feeds into), each yielding up to
+/// three features via [`ConflatedTileRow::to_detail_geojson_lines`].
+/// The returned layer is deliberately named `"matched"` -- the same
+/// name [`extract_conflated_layers`]' overview layer uses -- so that
+/// once `tile-join` merges the overview (z0..DETAIL_MIN_ZOOM-1) and
+/// detail (DETAIL_MIN_ZOOM..DETAIL_MAX_ZOOM) passes, the result is one
+/// continuous `matched` layer spanning the whole zoom range, not two
+/// separately-toggleable layers in a tile inspector.
+pub fn extract_matched_detail_layer(
+    conflated: &Path,
+    progress: &MultiProgress,
+    workdir: &Path,
+) -> Result<TileLayer> {
+    assert!(workdir.exists());
+
+    let layer = TileLayer {
+        name: String::from("matched"),
+        path: workdir.join("matched-detail.jsonl"),
+    };
+    if layer.path.exists() {
+        return Ok(layer);
+    }
+
+    let num_rows = {
+        let file = File::open(conflated)?;
+        ParquetRecordBatchReaderBuilder::try_new(file)?
+            .metadata()
+            .file_metadata()
+            .num_rows() as u64
+    };
+    let progress_bar = make_progress_bar(progress, "confl-detail", num_rows, "conflated features");
+
+    let mut tmp_path = PathBuf::from(&layer.path);
+    tmp_path.add_extension("tmp");
+    let mut writer = BufWriter::with_capacity(32768, File::create(&tmp_path)?);
+
+    let num_features = extract_detail_rows(conflated, &progress_bar, &mut writer)?;
+    writer.flush()?;
+    rename(&tmp_path, &layer.path)?;
+
+    progress_bar.finish_with_message(format!(
+        "{} conflated features → {} detail features",
+        num_rows, num_features
+    ));
+
+    Ok(layer)
+}
+
+fn extract_detail_rows(
+    conflated: &Path,
+    progress_bar: &ProgressBar,
+    writer: &mut impl Write,
+) -> Result<u64> {
+    let start = Instant::now();
+    let mut num_features = 0u64;
+
+    let file = File::open(conflated)?;
+    let reader = ParquetRecordBatchReaderBuilder::try_new(file)?.build()?;
+    for batch in reader {
+        let batch = batch?;
+        let lines: Vec<Vec<String>> = (0..batch.num_rows())
+            .into_par_iter()
+            .map(|row| -> Result<Vec<String>> {
+                let Some(row) = extract_conflated_tile_row(&batch, row)? else {
+                    return Ok(Vec::new());
+                };
+                let Some(osm) = &row.osm else {
+                    return Ok(Vec::new());
+                };
+                row.to_detail_geojson_lines(osm)
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        for row_lines in lines {
+            progress_bar.inc(1);
+            for line in row_lines {
+                writer.write_all(line.as_bytes())?;
+                num_features += 1;
+            }
+        }
+    }
+
+    log::info!(
+        elapsed_seconds = start.elapsed().as_secs_f64(),
+        features = num_features;
+        "extract_matched_detail_layer: done"
+    );
+    Ok(num_features)
+}
+
 /// `None` means this row has no ATP side -- the schema allows it even
 /// though `conflate()` never actually produces such a row -- nothing to
 /// visualize, but still a real row the caller should count against its
@@ -269,6 +488,11 @@ mod tests {
         buf
     }
 
+    fn parse(line: &str) -> Value {
+        assert!(line.ends_with('\n'));
+        serde_json::from_str(line.trim_end()).expect("valid json")
+    }
+
     #[test]
     fn unmatched_row_uses_atp_geometry_and_only_atp_tags() {
         let row = ConflatedTileRow {
@@ -278,8 +502,7 @@ mod tests {
             osm: None,
         };
         let line = row.to_geojson_line().expect("to_geojson_line");
-        assert!(line.ends_with('\n'));
-        let value: Value = serde_json::from_str(line.trim_end()).expect("valid json");
+        let value = parse(&line);
 
         assert_eq!(value["type"], "Feature");
         assert_eq!(value["geometry"]["type"], "Point");
@@ -306,7 +529,7 @@ mod tests {
             }),
         };
         let line = row.to_geojson_line().expect("to_geojson_line");
-        let value: Value = serde_json::from_str(line.trim_end()).expect("valid json");
+        let value = parse(&line);
 
         // The OSM shape, not the ATP one -- that's the whole point of
         // preferring it once matched.
@@ -329,11 +552,91 @@ mod tests {
             osm: None,
         };
         let line = row.to_geojson_line().expect("to_geojson_line");
-        let value: Value = serde_json::from_str(line.trim_end()).expect("valid json");
+        let value = parse(&line);
 
         assert_eq!(
             value["geometry"]["coordinates"],
             Value::from(vec![8.1234568, 47.9876543])
         );
+    }
+
+    fn osm_side_far_from(atp_lon: f64, atp_lat: f64) -> OsmSide {
+        // Roughly 50m north -- comfortably above MIN_CONNECTOR_LENGTH_METERS.
+        OsmSide {
+            osm_type: "way".to_string(),
+            osm_id: 99,
+            osm_tags: vec![("shop".to_string(), "supermarket".to_string())],
+            osm_geometry_wkb: encode_point(atp_lon, atp_lat + 0.00045),
+        }
+    }
+
+    #[test]
+    fn detail_yields_atp_and_osm_features_with_only_their_own_tags() {
+        let row = ConflatedTileRow {
+            spider: "acme".to_string(),
+            atp_tags: vec![("name".to_string(), "Acme ATP".to_string())],
+            atp_geometry_wkb: encode_point(8.5, 47.2),
+            osm: None, // unused; osm side passed explicitly below
+        };
+        let osm = osm_side_far_from(8.5, 47.2);
+        let lines = row
+            .to_detail_geojson_lines(&osm)
+            .expect("to_detail_geojson_lines");
+        let features: Vec<Value> = lines.iter().map(|l| parse(l)).collect();
+
+        let atp = features
+            .iter()
+            .find(|f| f["properties"]["part"] == "atp")
+            .expect("expected an atp feature");
+        assert_eq!(atp["properties"]["atp:name"], "Acme ATP");
+        assert!(
+            atp["properties"].get("osm:type").is_none(),
+            "atp feature should carry no osm:* properties: {atp}"
+        );
+
+        let osm_feature = features
+            .iter()
+            .find(|f| f["properties"]["part"] == "osm")
+            .expect("expected an osm feature");
+        assert_eq!(osm_feature["properties"]["osm:shop"], "supermarket");
+        assert_eq!(osm_feature["properties"]["osm:id"], 99);
+        assert!(
+            osm_feature["properties"].get("atp:name").is_none(),
+            "osm feature should carry no atp:* properties: {osm_feature}"
+        );
+
+        let link = features
+            .iter()
+            .find(|f| f["properties"]["part"] == "link")
+            .expect("expected a link feature -- offset is well above the threshold");
+        assert_eq!(link["properties"]["atp:name"], "Acme ATP");
+        assert_eq!(link["properties"]["osm:shop"], "supermarket");
+    }
+
+    #[test]
+    fn detail_omits_the_connector_when_offset_is_below_threshold() {
+        let row = ConflatedTileRow {
+            spider: "acme".to_string(),
+            atp_tags: vec![],
+            atp_geometry_wkb: encode_point(8.5, 47.2),
+            osm: None,
+        };
+        // Same coordinates as the ATP point -- a coincident match.
+        let osm = OsmSide {
+            osm_type: "node".to_string(),
+            osm_id: 7,
+            osm_tags: vec![],
+            osm_geometry_wkb: encode_point(8.5, 47.2),
+        };
+        let lines = row
+            .to_detail_geojson_lines(&osm)
+            .expect("to_detail_geojson_lines");
+        assert_eq!(
+            lines.len(),
+            2,
+            "expected only atp+osm, no link, for a coincident match: {lines:?}"
+        );
+        let features: Vec<Value> = lines.iter().map(|l| parse(l)).collect();
+        assert!(features.iter().all(|f| f["properties"]["part"] != "link"));
     }
 }

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -148,11 +148,52 @@ fn run_pipeline_steps(
     // *matching* step itself, while `diffed-places.pmtiles` below
     // visualizes only what `suggest_edits` separately decided to
     // propose.
+    //
+    // conflated.pmtiles itself is built in two zoom-bounded passes,
+    // joined together, rather than one -zg/auto-zoom build: an
+    // overview pass (single feature per row, up to
+    // DETAIL_MIN_ZOOM - 1) and a detail pass (matched rows only, up
+    // to three features per row, DETAIL_MIN_ZOOM..DETAIL_MAX_ZOOM).
+    // See conflated_tiles::DETAIL_MAX_ZOOM's doc comment for why the
+    // detail pass can't use tippecanoe's automatic zoom selection the
+    // way the overview pass (and diffed-places.pmtiles, below) safely
+    // can.
     let conflated_layers = run_step("extract_conflated_layers", || {
         conflated_tiles::extract_conflated_layers(&conflated, progress, workdir)
     })?;
-    let conflated_tiles_out = run_step("render_conflated_tiles", || {
-        tiles::render_tiles(&conflated_layers, progress, workdir, "conflated.pmtiles")
+    let conflated_overview = run_step("render_conflated_overview", || {
+        tiles::render_tiles(
+            &conflated_layers,
+            progress,
+            workdir,
+            "conflated-overview.pmtiles",
+            tiles::ZoomRange::Bounded {
+                min: 0,
+                max: conflated_tiles::DETAIL_MIN_ZOOM - 1,
+            },
+        )
+    })?;
+    let detail_layer = run_step("extract_matched_detail_layer", || {
+        conflated_tiles::extract_matched_detail_layer(&conflated, progress, workdir)
+    })?;
+    let conflated_detail = run_step("render_conflated_detail", || {
+        tiles::render_tiles(
+            std::slice::from_ref(&detail_layer),
+            progress,
+            workdir,
+            "conflated-detail.pmtiles",
+            tiles::ZoomRange::Bounded {
+                min: conflated_tiles::DETAIL_MIN_ZOOM,
+                max: conflated_tiles::DETAIL_MAX_ZOOM,
+            },
+        )
+    })?;
+    let conflated_tiles_out = run_step("join_conflated_tiles", || {
+        tiles::join_tiles(
+            &[conflated_overview, conflated_detail],
+            workdir,
+            "conflated.pmtiles",
+        )
     })?;
     run_step("upload_conflated_tiles", || {
         upload::upload_conflated_tiles(&conflated_tiles_out, progress)
@@ -162,7 +203,13 @@ fn run_pipeline_steps(
         edits::suggest_edits(&conflated, progress, workdir)
     })?;
     let tiles = run_step("render_tiles", || {
-        tiles::render_tiles(&edits, progress, workdir, "diffed-places.pmtiles")
+        tiles::render_tiles(
+            &edits,
+            progress,
+            workdir,
+            "diffed-places.pmtiles",
+            tiles::ZoomRange::Auto,
+        )
     })?;
     run_step("upload_tiles", || upload::upload_tiles(&tiles, progress))?;
 

--- a/src/pipeline/tiles.rs
+++ b/src/pipeline/tiles.rs
@@ -6,11 +6,30 @@ use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
+/// How [`render_tiles`] should choose which zoom levels to build.
+pub enum ZoomRange {
+    /// `-zg --extend-zooms-if-still-dropping`: let tippecanoe pick a
+    /// maximum zoom automatically, extending further if features are
+    /// still being dropped once it gets there. Safe for ordinary
+    /// point/line/polygon data, where zooming in genuinely separates
+    /// crowded features from each other -- but see
+    /// `conflated_tiles::DETAIL_MAX_ZOOM`'s doc comment for a
+    /// real case where that assumption doesn't hold, and this never
+    /// terminates in practice.
+    Auto,
+    /// `-Z<min> -z<max>`: an explicit, non-negotiable zoom range, no
+    /// auto-detection or extension. Use this for any input that might
+    /// contain the kind of degenerate geometry `Auto`'s doc comment
+    /// warns about.
+    Bounded { min: u8, max: u8 },
+}
+
 pub fn render_tiles(
     layers: &[TileLayer],
     progress: &MultiProgress,
     workdir: &Path,
     out_filename: &str,
+    zoom_range: ZoomRange,
 ) -> Result<PathBuf> {
     let out_path = workdir.join(out_filename);
     if out_path.exists() {
@@ -26,7 +45,7 @@ pub fn render_tiles(
 
     let progress_bar = make_progress_bar(progress, "tiles.render", 100, "percent");
 
-    let mut cmd = make_tippecanoe_command(layers, workdir, &tmp_path)?;
+    let mut cmd = make_tippecanoe_command(layers, workdir, &tmp_path, zoom_range)?;
     let mut child = cmd.stderr(Stdio::piped()).spawn()?;
     let stderr = child.stderr.take().expect("Failed to capture stderr");
     let stderr_reader = BufReader::new(stderr);
@@ -52,6 +71,7 @@ fn make_tippecanoe_command(
     layers: &[TileLayer],
     workdir: &Path,
     out_path: &Path,
+    zoom_range: ZoomRange,
 ) -> Result<Command> {
     let mut cmd = Command::new("tippecanoe");
     // Clear all environment variables, so we don't leak secrets to an untrusted subprocess.
@@ -61,12 +81,16 @@ fn make_tippecanoe_command(
         .arg("--read-parallel")
         .arg("--force")
         .arg("--temporary-directory")
-        .arg(std::path::absolute(workdir)?)
-        .arg("-zg")
-        .arg("-r")
-        .arg("1.2")
-        .arg("--drop-densest-as-needed")
-        .arg("--extend-zooms-if-still-dropping");
+        .arg(std::path::absolute(workdir)?);
+    match zoom_range {
+        ZoomRange::Auto => {
+            cmd.arg("-zg").arg("--extend-zooms-if-still-dropping");
+        }
+        ZoomRange::Bounded { min, max } => {
+            cmd.arg(format!("-Z{min}")).arg(format!("-z{max}"));
+        }
+    }
+    cmd.arg("-r").arg("1.2").arg("--drop-densest-as-needed");
     for layer in layers.iter() {
         // Suppress empty layers; Tippecanoe fails if any input file is empty.
         let metadata = std::fs::metadata(&layer.path)?;
@@ -82,6 +106,52 @@ fn make_tippecanoe_command(
     }
     cmd.arg("--output").arg(out_path);
     Ok(cmd)
+}
+
+/// Merges PMTiles archives built at disjoint zoom ranges into one,
+/// via `tile-join` (a sibling binary tippecanoe's own build already
+/// produces -- see `Containerfile`). Used to combine
+/// `conflated.pmtiles`' coarse overview pass (built with
+/// `ZoomRange::Bounded { min: 0, max: DETAIL_MIN_ZOOM - 1 }`) and its
+/// high-zoom detail pass (`Bounded { min: DETAIL_MIN_ZOOM, max:
+/// DETAIL_MAX_ZOOM }`) into one file spanning the whole range -- see
+/// `pipeline::conflated_tiles`' module doc comment for why that split
+/// exists. `tile-join` itself warns (not an error) about the two
+/// inputs' differing max zoom; that's expected here, not a sign
+/// something went wrong.
+pub fn join_tiles(inputs: &[PathBuf], workdir: &Path, out_filename: &str) -> Result<PathBuf> {
+    let out_path = workdir.join(out_filename);
+    if out_path.exists() {
+        return Ok(out_path);
+    }
+
+    let mut tmp_path = PathBuf::from(&out_path);
+    tmp_path.add_extension("tmp.pmtiles");
+
+    let mut cmd = make_tile_join_command(inputs, &tmp_path);
+    let mut child = cmd.stderr(Stdio::piped()).spawn()?;
+    let stderr = child.stderr.take().expect("Failed to capture stderr");
+    for line in BufReader::new(stderr).lines() {
+        log::info!("tile-join: {}", line?);
+    }
+
+    if !child.wait()?.success() {
+        anyhow::bail!("tile-join failed");
+    }
+
+    std::fs::rename(&tmp_path, &out_path)?;
+    Ok(out_path)
+}
+
+fn make_tile_join_command(inputs: &[PathBuf], out_path: &Path) -> Command {
+    let mut cmd = Command::new("tile-join");
+    // Clear all environment variables, so we don't leak secrets to an untrusted subprocess.
+    cmd.env_clear().env("PATH", env!("PATH")).arg("--force");
+    for input in inputs {
+        cmd.arg(input);
+    }
+    cmd.arg("--output").arg(out_path);
+    cmd
 }
 
 /// Structure of the JSON record that tippecanoe writes to stderr
@@ -105,7 +175,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_make_tippecanoe_command() {
+    fn test_make_tippecanoe_command_auto_zoom() {
         let layers = [
             // Empty input file, expected to be suppressed from arguments.
             make_test_tile_layer("Empty", "empty.jsonl"),
@@ -113,7 +183,8 @@ mod tests {
         ];
         let workdir = PathBuf::from("test-workdir");
         let out = PathBuf::from("test-output.pmtiles");
-        let cmd = make_tippecanoe_command(&layers, &workdir, &out).expect("should not fail");
+        let cmd = make_tippecanoe_command(&layers, &workdir, &out, ZoomRange::Auto)
+            .expect("should not fail");
         assert_eq!(cmd.get_program(), "tippecanoe");
         let args: Vec<String> = cmd
             .get_args()
@@ -130,13 +201,70 @@ mod tests {
                 "--temporary-directory",
                 workdir_abs.to_str().expect("workdir.to_str"),
                 "-zg",
+                "--extend-zooms-if-still-dropping",
                 "-r",
                 "1.2",
                 "--drop-densest-as-needed",
-                "--extend-zooms-if-still-dropping",
                 &shop_layer_arg,
                 "--output",
                 "test-output.pmtiles"
+            ]
+        );
+    }
+
+    #[test]
+    fn test_make_tippecanoe_command_bounded_zoom() {
+        let layers = [make_test_tile_layer("Shops", "diffed-shops.jsonl")];
+        let workdir = PathBuf::from("test-workdir");
+        let out = PathBuf::from("test-output.pmtiles");
+        let cmd = make_tippecanoe_command(
+            &layers,
+            &workdir,
+            &out,
+            ZoomRange::Bounded { min: 13, max: 16 },
+        )
+        .expect("should not fail");
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|s| s.to_string_lossy().into_owned())
+            .collect();
+        assert!(
+            args.iter().any(|a| a == "-Z13"),
+            "expected -Z13 in {args:?}"
+        );
+        assert!(
+            args.iter().any(|a| a == "-z16"),
+            "expected -z16 in {args:?}"
+        );
+        assert!(
+            !args
+                .iter()
+                .any(|a| a == "-zg" || a == "--extend-zooms-if-still-dropping"),
+            "bounded zoom range should not also pass auto-zoom flags: {args:?}"
+        );
+    }
+
+    #[test]
+    fn test_make_tile_join_command() {
+        let inputs = [
+            PathBuf::from("overview.pmtiles"),
+            PathBuf::from("detail.pmtiles"),
+        ];
+        let out = PathBuf::from("out.tmp.pmtiles");
+        let cmd = make_tile_join_command(&inputs, &out);
+        assert_eq!(cmd.get_program(), "tile-join");
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|s| s.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(
+            args,
+            &[
+                "--force",
+                "overview.pmtiles",
+                "detail.pmtiles",
+                "--output",
+                "out.tmp.pmtiles"
             ]
         );
     }


### PR DESCRIPTION
Closes #775.

Investigation writeup: [`docs/notes/2026-08-27-connector-line-zoom-runaway.md`](https://github.com/alltheplaces/osm-diffs/blob/experiment/connector-line-775/docs/notes/2026-08-27-connector-line-zoom-runaway.md) (committed here) and the [visual report](https://claude.ai/code/artifact/0bd35079-99d3-4608-b2e8-a968cb53160c) it links (six real matched-feature examples, before/after measurements). Also discussed in [#775's own comments](https://github.com/alltheplaces/osm-diffs/issues/775#issuecomment-5442719123).

## What this does

For a matched row in `conflated.pmtiles`, shows the ATP point, the real OSM shape, *and* a connector line between them — not just one geometry, the way v1 (#709) does — so a reviewer can see the ATP↔OSM offset directly, not just infer it. Available at z13–16; z0–12 is unchanged from #709.

## Why it isn't a small tweak

A Mapbox Vector Tile feature can only be one geometry type, so a matched row needs up to three separate features, not one. An unrestricted build of that (naive `-zg`/`--extend-zooms-if-still-dropping`, same flags the shipped code already used) reached **max_zoom=19** — found by reading the actual PMTiles header, not guessing. `--extend-zooms-if-still-dropping` keeps adding zoom levels until crowded features separate; a connector line whose ends are nearly coincident (a *good* match!) never spatially separates from its own endpoint no matter how far you zoom, so it never terminates. Full story, including the wrong first diagnosis and how it got corrected, is in the note above.

## The fix, now shipped

- `conflated.pmtiles` is built as two zoom-bounded tippecanoe passes, joined with `tile-join` (tippecanoe's own tool for exactly this "overview vs. detail" split — `man tippecanoe`'s own documented example): an **overview** pass (today's single-feature-per-row, z0–12, unchanged) and a **detail** pass (matched rows only, z13–16, the new three-feature representation).
- `atp` features carry only `atp:*` tags, `osm` features only `osm:*` — the earlier prototype put both tag sets on everything, making it impossible to tell which end of a pair you were looking at in a tile inspector. The `link` feature keeps both.
- Rows whose ATP↔OSM offset is under `MIN_CONNECTOR_LENGTH_METERS` (a documented constant, 5m) skip the connector line — nothing useful to draw, and it's exactly the degenerate geometry that causes the zoom-runaway above.
- The zoom split (`DETAIL_MIN_ZOOM`/`DETAIL_MAX_ZOOM`) is two documented constants in `conflated_tiles.rs`, not scattered magic numbers.
- `render_tiles` takes a `ZoomRange` (`Auto` — today's `-zg`, unchanged for `diffed-places.pmtiles`; or `Bounded { min, max }`); new `join_tiles` wraps `tile-join`.
- `tile-join` ships alongside `tippecanoe` in `Containerfile` (same `felt/tippecanoe` build, same pinned commit — one more `COPY` line) and gets its own SBOM component (`tile-join.jq`, near-identical to `tippecanoe.jq`, same license/supplier/musl-sqlite-zlib deps, distinguished by a `#tile-join` purl subpath).

## Real measurements (full-planet local run, actual shipped code)

| Step | Time | Peak RSS | Output |
|---|---:|---:|---:|
| `render_conflated_overview` | 1m44s | 1.87 GB | ~750 MB |
| `extract_matched_detail_layer` | 3.4s | — | 2,038,379 features from 730,512 matched rows |
| `render_conflated_detail` | 2m02s | 2.08 GB | ~1.0 GB |
| `join_conflated_tiles` | 2m42s | 2.13 GB | ~1.8 GB (final) |
| **Total added over #709** | **~4m43s** | ≤2.13 GB | **+~1.05 GB** |

Every step comfortably inside the production container's 12 GB `--mem-limit`.

## Verification

- `cargo test`/`cargo clippy --all-targets`/`cargo fmt --check` all pass; new unit tests for the per-side tag split and the connector-length skip.
- Real `podman build` from this `Containerfile` (not just `generate-sbom.sh` standalone): produces a scratch image with both statically-linked, stripped binaries; runs the full test suite (including the now-real `tile-join` invocation in `tests/integration_test.rs`) inside the build; generated SBOM passes `cyclonedx validate --fail-on-errors`, the same check `test-container.yml` runs in CI.
- Ran the actual pipeline binary (release build) against this machine's local full-planet `conflated.parquet`: valid merged `conflated.pmtiles` (PMTiles v3, z0–16), sample features inspected by hand — see the artifact linked above for what it actually looks like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012a2RALc5Y8zDGwoDEWapF4
